### PR TITLE
Credential serializer, added zip and tar.gz serialization

### DIFF
--- a/trustpoint/pki/initializer/issuing_ca/file_import.py
+++ b/trustpoint/pki/initializer/issuing_ca/file_import.py
@@ -213,6 +213,11 @@ class UnprotectedFileImportLocalIssuingCaFromPkcs12Initializer(FileImportLocalIs
         self._private_key_serializer = credential_serializer.credential_private_key
         self._certificate_collection_serializer = credential_serializer.all_certificates
 
+        with open('/home/alex/Dev/trustpoint/cred.zip', 'wb') as f:
+            f.write(credential_serializer.as_pem_zip())
+
+        with open('/home/alex/Dev/trustpoint/cred.tar.gz', 'wb') as f:
+            f.write(credential_serializer.as_pem_tar_gz())
 
 class UnprotectedFileImportLocalIssuingCaFromSeparateFilesInitializer(FileImportLocalIssuingCaInitializer):
     """Responsible for initializing an Issuing CA from separate files."""

--- a/trustpoint/pki/initializer/issuing_ca/file_import.py
+++ b/trustpoint/pki/initializer/issuing_ca/file_import.py
@@ -213,12 +213,6 @@ class UnprotectedFileImportLocalIssuingCaFromPkcs12Initializer(FileImportLocalIs
         self._private_key_serializer = credential_serializer.credential_private_key
         self._certificate_collection_serializer = credential_serializer.all_certificates
 
-        with open('/home/alex/Dev/trustpoint/cred.zip', 'wb') as f:
-            f.write(credential_serializer.as_pem_zip())
-
-        with open('/home/alex/Dev/trustpoint/cred.tar.gz', 'wb') as f:
-            f.write(credential_serializer.as_pem_tar_gz())
-
 class UnprotectedFileImportLocalIssuingCaFromSeparateFilesInitializer(FileImportLocalIssuingCaInitializer):
     """Responsible for initializing an Issuing CA from separate files."""
 

--- a/trustpoint/pki/serializer/certificate.py
+++ b/trustpoint/pki/serializer/certificate.py
@@ -159,11 +159,11 @@ class CertificateCollectionSerializer(Serializer):
             self._certificate_collection = self._from_string(certificate_collection)
         elif isinstance(certificate_collection, list):
             certificate_serializers = []
-            for certificate in certificate_collection:
+            for certificate in certificate_collection.copy():
                     certificate_serializers.append(CertificateSerializer(certificate))
             self._certificate_collection = certificate_serializers
         elif isinstance(certificate_collection, CertificateCollectionSerializer):
-            self._certificate_collection = certificate_collection.as_certificate_serializer_list()
+            self._certificate_collection = certificate_collection.as_certificate_serializer_list().copy()
         else:
             raise TypeError(
                 'Expected one of the types: '

--- a/trustpoint/pki/serializer/key.py
+++ b/trustpoint/pki/serializer/key.py
@@ -179,7 +179,7 @@ class PrivateKeySerializer(Serializer):
             encryption_algorithm=self._get_encryption_algorithm(password),
         )
 
-    def as_pkcs1_pem(self, password: None | bytes) -> bytes:
+    def as_pkcs1_pem(self, password: None | bytes = None) -> bytes:
         """Gets the associated private key as bytes in PKCS#1 PEM format.
 
         Args:
@@ -194,7 +194,7 @@ class PrivateKeySerializer(Serializer):
             encryption_algorithm=self._get_encryption_algorithm(password),
         )
 
-    def as_pkcs8_der(self, password: None | bytes) -> bytes:
+    def as_pkcs8_der(self, password: None | bytes = None) -> bytes:
         """Gets the associated private key as bytes in PKCS#8 DER format.
 
         Args:
@@ -209,7 +209,7 @@ class PrivateKeySerializer(Serializer):
             encryption_algorithm=self._get_encryption_algorithm(password),
         )
 
-    def as_pkcs8_pem(self, password: None | bytes) -> bytes:
+    def as_pkcs8_pem(self, password: None | bytes = None) -> bytes:
         """Gets the associated private key as bytes in PKCS#8 DER format.
 
         Args:
@@ -224,7 +224,7 @@ class PrivateKeySerializer(Serializer):
             encryption_algorithm=self._get_encryption_algorithm(password),
         )
 
-    def as_pkcs12(self, password: None | bytes, friendly_name: bytes = b'') -> bytes:
+    def as_pkcs12(self, password: None | bytes = None, friendly_name: bytes = b'') -> bytes:
         """Gets the associated private key as bytes in PKCS#12 format.
 
         Args:


### PR DESCRIPTION
Credential serializer, added zip and tar.gz serialization

**Description of changes**
Methods added to CredentialSerializer class to support zip and tar.gz files containing PEM files.
The private key can either be stored as PKCS#1 or PKCS#8 (default).

Methods added:
get_as_separate_pem_files(self, password: None | bytes = None, pkcs1: bool = False) -> tuple[bytes, bytes, bytes]
as_pem_zip(self, password: None | bytes = None, pkcs1: bool = False) -> bytes
as_pem_tar_gz(self, password: None | bytes = None, pkcs1: bool = False) -> bytes

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.