### PR TITLE
Serializers Ruff Check fixes, slight change in ZIP, TAR.GZ method calls

### DIFF
--- a/trustpoint/pki/serializer/__init__.py
+++ b/trustpoint/pki/serializer/__init__.py
@@ -50,10 +50,10 @@ API Documentation
 """
 
 
-from .base import Serializer, PublicKey, PrivateKey
-from .key import PublicKeySerializer, PrivateKeySerializer
-from .certificate import CertificateSerializer, CertificateCollectionSerializer
+from .base import PrivateKey, PublicKey, Serializer
+from .certificate import CertificateCollectionSerializer, CertificateSerializer
 from .credential import CredentialSerializer
+from .key import PrivateKeySerializer, PublicKeySerializer
 
 __all__ = [
     'PublicKey',
@@ -63,5 +63,5 @@ __all__ = [
     'CertificateCollectionSerializer',
     'PublicKeySerializer',
     'PrivateKeySerializer',
-    'CredentialSerializer'
+    'CredentialSerializer',
 ]

--- a/trustpoint/pki/serializer/base.py
+++ b/trustpoint/pki/serializer/base.py
@@ -2,8 +2,8 @@
 
 import abc
 from typing import Union
-from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519, rsa
 
+from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519, rsa
 
 PublicKey = Union[rsa.RSAPublicKey, ec.EllipticCurvePublicKey, ed448.Ed448PublicKey, ed25519.Ed25519PublicKey]
 PrivateKey = Union[rsa.RSAPrivateKey, ec.EllipticCurvePrivateKey, ed448.Ed448PrivateKey, ed25519.Ed25519PrivateKey]
@@ -16,4 +16,7 @@ class Serializer(abc.ABC):
         Serializer classes do not include any type of validation.
         They are merely converting between formats.
     """
-    pass
+
+    @abc.abstractmethod
+    def serialize(self) -> bytes:
+        """The default serialization method."""


### PR DESCRIPTION
**Description of changes**
Fixes so the serializer package passes the ruff checks.

Small change in the call of the ZIP and TAR.GZ methods on the CredentialSerializer.
Use internal enum class to specify type. The default type is the more secure one (PKCS#8).

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.