### PR TITLE
Serializers - Ruff compliance

### DIFF
--- a/trustpoint/pki/serializer/__init__.py
+++ b/trustpoint/pki/serializer/__init__.py
@@ -50,10 +50,10 @@ API Documentation
 """
 
 
-from .base import Serializer, PublicKey, PrivateKey
-from .key import PublicKeySerializer, PrivateKeySerializer
-from .certificate import CertificateSerializer, CertificateCollectionSerializer
+from .base import PrivateKey, PublicKey, Serializer
+from .certificate import CertificateCollectionSerializer, CertificateSerializer
 from .credential import CredentialSerializer
+from .key import PrivateKeySerializer, PublicKeySerializer
 
 __all__ = [
     'PublicKey',
@@ -63,5 +63,5 @@ __all__ = [
     'CertificateCollectionSerializer',
     'PublicKeySerializer',
     'PrivateKeySerializer',
-    'CredentialSerializer'
+    'CredentialSerializer',
 ]

--- a/trustpoint/pki/serializer/base.py
+++ b/trustpoint/pki/serializer/base.py
@@ -2,8 +2,8 @@
 
 import abc
 from typing import Union
-from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519, rsa
 
+from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519, rsa
 
 PublicKey = Union[rsa.RSAPublicKey, ec.EllipticCurvePublicKey, ed448.Ed448PublicKey, ed25519.Ed25519PublicKey]
 PrivateKey = Union[rsa.RSAPrivateKey, ec.EllipticCurvePrivateKey, ed448.Ed448PrivateKey, ed25519.Ed25519PrivateKey]
@@ -16,4 +16,7 @@ class Serializer(abc.ABC):
         Serializer classes do not include any type of validation.
         They are merely converting between formats.
     """
-    pass
+
+    @abc.abstractmethod
+    def serialize(self) -> bytes:
+        """The default serialization method."""

--- a/trustpoint/pki/serializer/credential.py
+++ b/trustpoint/pki/serializer/credential.py
@@ -138,7 +138,15 @@ class CredentialSerializer(Serializer):
             err_msg = 'Failed to load credential. May be an incorrect password or malformed data.'
             raise ValueError(err_msg) from exception
 
-    def as_pkcs12(self, password: None | bytes, friendly_name: bytes = b'') -> bytes:
+    def serialize(self, password: None | bytes = None, friendly_name: bytes = b'') -> bytes:
+        """Default serialization method that returns the credential as PKCS#12 bytes.
+
+        Returns:
+            bytes: Bytes that contains the credential in PKCS#12 format.
+        """
+        return self.as_pkcs12(password, friendly_name)
+
+    def as_pkcs12(self, password: None | bytes = None, friendly_name: bytes = b'') -> bytes:
         """Gets the credential as bytes in PKCS#12 format.
 
         Args:


### PR DESCRIPTION
**Description of changes**
Serializer package now complies to ruff

**Notes** <!-- optional -->
Two slight changes to the ZIP and TAR.GZ methods of the CredentialSerializer.
Use the internal enum class PrivateKeyFormat to specify the format on call.
The default is the more secure PKCS#8 format, if not give.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.