### PR TITLE
Pki request pkcs12 serializer

### DIFF
--- a/trustpoint/devices/tables.py
+++ b/trustpoint/devices/tables.py
@@ -183,7 +183,8 @@ class DeviceTable(tables.Table):
         if is_brski or is_fido:
             return self._render_zero_touch_onboarding_action(record)
 
-        raise UnknownOnboardingProtocolError(record.onboarding_protocol)
+        #raise UnknownOnboardingProtocolError(record.onboarding_protocol)
+        return format_html('<span class="text-danger">' + _('Unknown onboarding protocol!') + '</span>')
 
     @staticmethod
     def render_details(record: Device) -> SafeString:

--- a/trustpoint/pki/initializer/issuing_ca/file_import.py
+++ b/trustpoint/pki/initializer/issuing_ca/file_import.py
@@ -175,7 +175,7 @@ class FileImportLocalIssuingCaInitializer(IssuingCaInitializer, abc.ABC):
             issuing_ca_model = self._issuing_ca_model_class(
                 unique_name=self._unique_name,
                 auto_crl=self._auto_crl,
-                private_key_pem=self._credential_serializer.credential_private_key.as_pkcs1_pem(None)
+                private_key_pem=self._credential_serializer.credential_private_key.as_pkcs1_pem(None).decode("utf-8")
             )
 
             issuing_ca_model.issuing_ca_certificate = saved_certs[0]


### PR DESCRIPTION
**Description of changes**
- PKCS12 PKI request uses serializer (reducing duplication)
- Fix CA from file initialization byte-to-string conversion
- do not fail hard on table rendering for unknown onboarding protocol

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.