### PR TITLE
Add PEM download to manual onboarding

### DIFF
--- a/trustpoint/onboarding/templates/onboarding/manual/browser-download.html
+++ b/trustpoint/onboarding/templates/onboarding/manual/browser-download.html
@@ -22,17 +22,17 @@
             </div>
             <h2>{% trans "Download PKCS12 key and certificate" %}</h2>
             <div class="text-center">
-                <a href="{% url 'onboarding:api-p12-download' device_id %}?token={{ download_token }}" download="{{ device.device_name }}.p12" class="btn btn-primary mt-2 w-50">{% trans "Download PKCS12" %}</a>
+                <a href="{% url 'onboarding:api-p12-download' device_id %}?token={{ download_token }}" download="{{ device.device_name }}.p12" class="btn btn-primary mt-2 min-width-15">{% trans "Download PKCS12" %}</a>
             </div>
             <hr>
-            <h2>{% trans "Keypair in PEM format" %}</h2>
+            <h2>{% trans "Certificate and keypair in PEM format" %}</h2>
             <div class="text-center">
-                <a href="{% url 'onboarding:pem-download' device_id %}?token={{ download_token }}" download="{{ device.device_name }}.pem" class="btn btn-secondary mt-2 w-50">{% trans "Download PEM" %}</a>
+                <a href="{% url 'onboarding:pem-download' device_id %}?token={{ download_token }}" download="{{ device.device_name }}.pem" class="btn btn-secondary mt-2 min-width-15">{% trans "Download PEM" %}</a>
             </div>
             <hr>
             <h2>{% trans "Java KeyStore" %}</h2>
             <div class="text-center">
-                <a href="{% url 'onboarding:keystore-download' device_id %}" download="{{ device.device_name }}.jks" class="btn btn-secondary mt-2 w-50">{% trans "Download Java KeyStore" %}</a>
+                <a href="{% url 'onboarding:keystore-download' device_id %}" download="{{ device.device_name }}.jks" class="btn btn-secondary mt-2 min-width-15 disabled">{% trans "Download Java KeyStore" %}</a>
             </div>
         </div>
         <div class="card-footer text-body-secondary">

--- a/trustpoint/onboarding/templates/onboarding/manual/download.html
+++ b/trustpoint/onboarding/templates/onboarding/manual/download.html
@@ -20,13 +20,14 @@
             </div>
             <h2>{% trans "Download PKCS12 key and certificate" %}</h2>
             <div class="text-center">
-              <a href="{% url 'onboarding:api-p12-download' device_id %}?token={{ download_token }}" download="{{ device_name }}.p12" class="btn btn-primary mt-2 w-50">{% trans "Download PKCS12" %}</a>
+              <a href="{% url 'onboarding:api-p12-download' device_id %}?token={{ download_token }}" download="{{ device_name }}.p12" class="btn btn-primary mt-2 min-width-15">{% trans "Download PKCS12" %}</a>
             </div>
             <hr>
-            <h2>{% trans "Keypair in PEM format" %}</h2>
+            <h2>{% trans "Certificate and keypair in PEM format" %}</h2>
+            <div class="text-center">
+                <a href="{% url 'onboarding:pem-download' device_id %}?token={{ download_token }}" download="{{ device.device_name }}.pem" class="btn btn-primary mt-2 min-width-15">{% trans "Download PEM" %}</a>
+            </div>
             <hr>
-            <h2>{% trans "LDevID certificate" %}</h2>
-            
         </div>
         <div class="card-footer text-body-secondary">
             <a href="{% url 'devices:devices' %}" class="btn btn-secondary">{% trans "Back" %}</a>


### PR DESCRIPTION
PEM button was not yet added for manual onboarding, thus only PKCS12 download was possible despite the API already supporting manual PEM download.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.