### PR TITLE
Fixed download selected certs with 1 selected (fixes #92)

### DIFF
--- a/trustpoint/pki/templates/pki/certificates/certificates.html
+++ b/trustpoint/pki/templates/pki/certificates/certificates.html
@@ -16,7 +16,7 @@
         {% render_table table %}
     </div>
     <div class="card-footer tp-table-footer-btn-group d-flex justify-content-between align-items-center tp-sticky-footer">
-        <button type="button" class="btn btn-primary tp-table-select-btn" data-tp-url="download/multiple">
+        <button type="button" class="btn btn-primary tp-table-select-btn" data-tp-url="download">
             {% trans "Download selected" %}
         </button>
     </div>

--- a/trustpoint/pki/templates/pki/truststores/truststores.html
+++ b/trustpoint/pki/templates/pki/truststores/truststores.html
@@ -13,7 +13,7 @@
     </div>
     <div class="card-footer d-flex justify-content-between align-items-center tp-sticky-footer">
         <div>
-            <button type="button" class="btn btn-primary tp-table-select-btn" data-tp-url="download/multiple">{% trans "Download selected" %}</button>
+            <button type="button" class="btn btn-primary tp-table-select-btn" data-tp-url="download">{% trans "Download selected" %}</button>
             <button type="button" class="btn btn-secondary tp-table-select-btn" data-tp-url="delete">{% trans "Delete selected" %}</button>
         </div>
         <a class="btn btn-primary" href="{% url 'pki:truststores-add' %}">{% trans "Add New Trust Store" %}</a>

--- a/trustpoint/pki/urls/pki.py
+++ b/trustpoint/pki/urls/pki.py
@@ -17,7 +17,7 @@ urlpatterns = [
         certificates.IssuedCertificatesTableView.as_view(),
         name='issued_certificates'),
     re_path(
-        r'^certificates/download/multiple/(?P<pks>([0-9]+/)+[0-9]+)/?$',
+        r'^certificates/download/(?P<pks>([0-9]+/)+[0-9]+)/?$',
         certificates.CertificateMultipleDownloadView.as_view(),
         name='certificates-download'
     ),
@@ -95,7 +95,7 @@ urlpatterns = [
         name='truststores-add'
     ),
     re_path(
-        r'^truststores/download/multiple/(?P<pks>([0-9]+/)+[0-9]+)/?$',
+        r'^truststores/download/(?P<pks>([0-9]+/)+[0-9]+)/?$',
         trust_stores.TrustStoresMultipleDownloadView.as_view(),
         name='truststores-download'
     ),


### PR DESCRIPTION
<!-- related issue number, remove if n/a -->
Related to #92

**Description of changes**
Fixes download of Trust Stores and Certificates using "Download selected" if only one has been selected.

Removes `/multiple` from `MultipleDownloadView` view regex. Due to the order, this regex still only matches if multiple certs/trust stores are requested.  Single selections will instead be matched by the following regex which will use the regular single download view.

**Notes** <!-- optional -->
Please test a few downloads to see if the correct certificates are downloaded using the correct file types.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.