### PR TITLE
Auto-Generated PKI

### DIFF
--- a/trustpoint/devices/signals.py
+++ b/trustpoint/devices/signals.py
@@ -1,5 +1,5 @@
 from devices.models import Device
-from pki.models import ReasonCode
+from pki import ReasonCode
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 

--- a/trustpoint/devices/templates/devices/confirm_delete.html
+++ b/trustpoint/devices/templates/devices/confirm_delete.html
@@ -16,8 +16,8 @@
                     {% include 'devices/sub_details.html' with device=object %}
                 {% endfor %}
 
-                <div class="alert alert-info d-flex align-items-center mt-3" role="alert">  
-                    <svg class="bi flex-shrink-0 me-2" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-info"/></svg>
+                <div class="alert alert-info d-flex mt-3" role="alert">  
+                    <svg class="bi flex-shrink-0 tp-msg-icon-margin" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-info"/></svg>
                     <div>{% trans "Deletion will revoke any certificates issued to devices with reason code 'Cessation of Operation'" %}</div>
                 </div>
 

--- a/trustpoint/onboarding/api.py
+++ b/trustpoint/onboarding/api.py
@@ -33,7 +33,7 @@ from onboarding.schema import (
     AokiFinalizationMessageSchema,
     AokiFinalizationResponseSchema
 )
-from pki.models import CertificateModel, TrustStoreModel, DomainModel
+from pki.models import CertificateModel, TrustStoreModel, DomainModel, ReasonCode
 
 log = logging.getLogger('tp.onboarding')
 
@@ -364,6 +364,8 @@ def revoke(request: HttpRequest, device_id: int) -> tuple[int, dict] | HttpRespo
     if not device:
         return 404, {'error': 'Device not found.'}
 
-    if device.revoke_ldevid():
-        return 200, {'success': True}
+    if device.ldevid:
+        if device.revoke_ldevid(ReasonCode.CESSATION):
+            return 200, {'success': True}
+        return 422, {'error': 'Error during certificate revocation.'}
     return 422, {'error': 'Device has no LDevID certificate to revoke.'}

--- a/trustpoint/onboarding/templates/onboarding/manual/browser-download.html
+++ b/trustpoint/onboarding/templates/onboarding/manual/browser-download.html
@@ -16,8 +16,8 @@
             <h1>{% blocktranslate %}Download certificate for device {{ device.device_name }}{% endblocktranslate %}</h1>
         </div>
         <div class="card-body tp-main-centered pt-3 pb-4">
-            <div id="onboarding-state-dl" class="alert alert-info d-flex align-items-center mt-3 breathing-anim dl" role="alert">  
-                <svg class="bi flex-shrink-0 me-2" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-clock"/></svg>
+            <div id="onboarding-state-dl" class="alert alert-info d-flex mt-3 breathing-anim dl" role="alert">  
+                <svg class="bi flex-shrink-0 tp-msg-icon-margin" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-clock"/></svg>
                 <div>{% trans "Fetching state from server..." %}</div>                
             </div>
             <h2>{% trans "Download PKCS12 key and certificate" %}</h2>

--- a/trustpoint/onboarding/templates/onboarding/manual/browser-login.html
+++ b/trustpoint/onboarding/templates/onboarding/manual/browser-login.html
@@ -16,7 +16,7 @@
                         {% endif %}
                     {% endif %} d-flex align-items-center" role="alert">
 
-                    <svg class="bi flex-shrink-0 me-2" width="20" height="20" fill="currentColor" role="img" aria-label="{{ message.tags }}:">
+                    <svg class="bi flex-shrink-0 tp-msg-icon-margin" width="20" height="20" fill="currentColor" role="img" aria-label="{{ message.tags }}:">
                         <use xlink:href="{% static 'img/icons.svg' %}#icon-{{ message.tags }}"/></svg>
                     <div>
                         {{ message }}

--- a/trustpoint/onboarding/templates/onboarding/manual/browser.html
+++ b/trustpoint/onboarding/templates/onboarding/manual/browser.html
@@ -14,8 +14,8 @@
             <h1>{% blocktranslate %}Save details for {{ device_name }}{% endblocktranslate %}</h1>
         </div>
         <div class="card-body tp-main-centered pt-3 pb-4">
-            <div id="onboarding-state-bo" class="alert alert-info d-flex align-items-center mt-3 breathing-anim dl" role="alert">  
-                <svg class="bi flex-shrink-0 me-2" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-clock"/></svg>
+            <div id="onboarding-state-bo" class="alert alert-info d-flex mt-3 breathing-anim dl" role="alert">  
+                <svg class="bi flex-shrink-0 tp-msg-icon-margin" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-clock"/></svg>
                 <div>{% trans "Fetching state from server..." %}</div>                
             </div>
             <h2>Device ID</h2>

--- a/trustpoint/onboarding/templates/onboarding/manual/cli.html
+++ b/trustpoint/onboarding/templates/onboarding/manual/cli.html
@@ -15,8 +15,8 @@
         </div>
         <div class="card-body tp-main-centered pt-3 pb-4">
             <h2>{% trans "Overall onboarding progress" %}</h2>
-            <div id="onboarding-state" class="alert alert-info d-flex align-items-center mt-3 breathing-anim" role="alert">  
-                <svg class="bi flex-shrink-0 me-2" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-clock"/></svg>
+            <div id="onboarding-state" class="alert alert-info d-flex mt-3 breathing-anim" role="alert">  
+                <svg class="bi flex-shrink-0 tp-msg-icon-margin" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-clock"/></svg>
                 <div>{% trans "Fetching state from server..." %}</div>                
             </div>
             <hr>
@@ -30,8 +30,8 @@
                     </div><br>
                 </div>
                 {% endfor %}
-            <div id="onboarding-state-1" class="alert alert-secondary d-flex align-items-center mt-3" role="alert">  
-              <svg class="bi flex-shrink-0 me-2" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-clock"/></svg>
+            <div id="onboarding-state-1" class="alert alert-secondary d-flex mt-3" role="alert">  
+              <svg class="bi flex-shrink-0 tp-msg-icon-margin" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-clock"/></svg>
               <div>Trust store not requested yet.</div>                
             </div>
             <hr>
@@ -44,8 +44,8 @@
                     </div><br>
                 </div>
                 {% endfor %}
-            <div id="onboarding-state-2" class="alert alert-secondary d-flex align-items-center mt-3" role="alert">  
-              <svg class="bi flex-shrink-0 me-2" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-clock"/></svg>
+            <div id="onboarding-state-2" class="alert alert-secondary d-flex mt-3" role="alert">  
+              <svg class="bi flex-shrink-0 tp-msg-icon-margin" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-clock"/></svg>
               <div>LDevID not requested yet.</div>                
             </div>
             <hr>
@@ -58,8 +58,8 @@
                     </div><br>
                 </div>
                 {% endfor %}
-            <div id="onboarding-state-3" class="alert alert-secondary d-flex align-items-center mt-3" role="alert">  
-              <svg class="bi flex-shrink-0 me-2" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-clock"/></svg>
+            <div id="onboarding-state-3" class="alert alert-secondary d-flex mt-3" role="alert">  
+              <svg class="bi flex-shrink-0 tp-msg-icon-margin" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-clock"/></svg>
               <div>Request LDevID first.</div>                
             </div>
         </div>

--- a/trustpoint/onboarding/templates/onboarding/manual/client.html
+++ b/trustpoint/onboarding/templates/onboarding/manual/client.html
@@ -21,8 +21,8 @@
             <div class="text-end"><button class="btn btn-primary" onclick="copyToClipboard(this,'#code-provisioning-0')">{% trans "Copy to clipboard" %}</button></div>
             <hr>
             <h2>{% trans "Onboarding progress" %}</h2>
-            <div id="onboarding-state" class="alert alert-info d-flex align-items-center mt-3 breathing-anim" role="alert">  
-                <svg class="bi flex-shrink-0 me-2" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-clock"/></svg>
+            <div id="onboarding-state" class="alert alert-info d-flex mt-3 breathing-anim" role="alert">  
+                <svg class="bi flex-shrink-0 tp-msg-icon-margin" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-clock"/></svg>
                 <div>{% trans "Fetching state from server..." %}</div>                
             </div>
         </div>

--- a/trustpoint/onboarding/templates/onboarding/manual/download.html
+++ b/trustpoint/onboarding/templates/onboarding/manual/download.html
@@ -14,8 +14,8 @@
             <h1>{% blocktranslate %}Download certificate for device {{ device_name }}{% endblocktranslate %}</h1>
         </div>
         <div class="card-body tp-main-centered pt-3 pb-4">
-            <div id="onboarding-state-dl" class="alert alert-info d-flex align-items-center mt-3 breathing-anim dl" role="alert">  
-                <svg class="bi flex-shrink-0 me-2" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-clock"/></svg>
+            <div id="onboarding-state-dl" class="alert alert-info d-flex mt-3 breathing-anim dl" role="alert">  
+                <svg class="bi flex-shrink-0 tp-msg-icon-margin" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-clock"/></svg>
                 <div>{% trans "Fetching state from server..." %}</div>                
             </div>
             <h2>{% trans "Download PKCS12 key and certificate" %}</h2>

--- a/trustpoint/onboarding/views.py
+++ b/trustpoint/onboarding/views.py
@@ -422,8 +422,14 @@ class OnboardingRevocationView(TpLoginRequiredMixin, Detail404RedirectionMessage
         form = RevokeCertificateForm(request.POST)
         if form.is_valid():
             revocation_reason = form.cleaned_data['revocation_reason']
-            if device.revoke_ldevid(revocation_reason):
-                messages.success(request, _('LDevID certificate for device %s revoked.') % device.device_name)
+            
+            if device.ldevid:
+                if device.revoke_ldevid(revocation_reason):
+                    messages.success(request, _('LDevID certificate for device %s revoked.') % device.device_name)
+                else:
+                    messages.error(request,
+                        _('Failed to revoke LDevID certificate for device %s. This may be due to a deleted CA.')
+                         % device.device_name)
             else:
                 messages.warning(request, _('Device %s has no LDevID certificate to revoke.') % device.device_name)
             return redirect(self.redirection_view)

--- a/trustpoint/pki/__init__.py
+++ b/trustpoint/pki/__init__.py
@@ -1,0 +1,22 @@
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+class ReasonCode(models.TextChoices):
+    """Revocation reasons per RFC 5280"""
+    UNSPECIFIED = 'unspecified', _('Unspecified')
+    KEY_COMPROMISE = 'keyCompromise', _('Key Compromise')
+    CA_COMPROMISE = 'cACompromise', _('CA Compromise')
+    AFFILIATION_CHANGED = 'affiliationChanged', _('Affiliation Changed')
+    SUPERSEDED = 'superseded', _('Superseded')
+    CESSATION = 'cessationOfOperation', _('Cessation of Operation')
+    CERTIFICATE_HOLD = 'certificateHold', _('Certificate Hold')
+    PRIVILEGE_WITHDRAWN = 'privilegeWithdrawn', _('Privilege Withdrawn')
+    AA_COMPROMISE = 'aACompromise', _('AA Compromise')
+    REMOVE_FROM_CRL = 'removeFromCRL', _('Remove from CRL')
+
+class CertificateStatus(models.TextChoices):
+    """CertificateModel status"""
+    OK = 'O', _('OK')
+    REVOKED = 'R', _('Revoked')
+    # EXPIRED = 'E', _('Expired')
+    # NOT_YET_VALID = 'N', _('Not Yet Valid')

--- a/trustpoint/pki/auto_gen_pki.py
+++ b/trustpoint/pki/auto_gen_pki.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger('tp.pki')
+
+class AutoGenPki:
+    """Manages the auto-generated local CAs."""
+
+    @staticmethod
+    def enable_auto_gen_pki() -> None:
+        """Enables the auto-generated PKI."""
+        log.warning('! Enabling auto-generated PKI !')
+        pass
+    
+    @staticmethod
+    def disable_auto_gen_pki() -> None:
+        """Disables the auto-generated PKI."""
+        log.warning('! Disabling auto-generated PKI !')
+        pass

--- a/trustpoint/pki/auto_gen_pki.py
+++ b/trustpoint/pki/auto_gen_pki.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from pki.models import IssuingCaModel
+from pki.models import IssuingCaModel, RootCaModel, ReasonCode
 from pki.initializer.issuing_ca.key_gen import UnprotectedKeyGenLocalRootCaInitializer, UnprotectedKeyGenLocalIssuingCaInitializer
 from pki.util.keys import KeyAlgorithm
 
@@ -24,36 +24,44 @@ class AutoGenPki:
 
         # check if local root CA exists
         try:
-            root_ca = IssuingCaModel.objects.get(unique_name='local_auto_gen_pki_root_ca')
+            root_ca = RootCaModel.objects.get(unique_name='Local_Auto_Gen_PKI_Root_CA')
             log.info('Using existing local auto-generated PKI Root CA')
-        except IssuingCaModel.DoesNotExist:
+        except RootCaModel.DoesNotExist:
             log.info('Creating local auto-generated PKI Root CA')
             root_ca_initializer = UnprotectedKeyGenLocalRootCaInitializer('local_auto_gen_pki_root_ca', key_algorithm, auto_crl=True)
             root_ca_initializer.initialize()
             root_ca_initializer.save()
 
         try:
-            root_ca = IssuingCaModel.objects.get(unique_name='local_auto_gen_pki_root_ca')
-            log.info('Using existing local auto-generated PKI Root CA')
-        except IssuingCaModel.DoesNotExist:
+            root_ca = RootCaModel.objects.get(unique_name='Local_Auto_Gen_PKI_Root_CA')
+        except RootCaModel.DoesNotExist:
             log.error('Local auto-generated PKI Root CA is not in database - illegal state')
             raise
             
 
         # check if local issuing CA exists (it shouldn't as it is deleted on auto-gen PKI disable)
         try:
-            issuing_ca = IssuingCaModel.objects.get(unique_name='local_auto_gen_pki_issuing_ca')
+            issuing_ca = IssuingCaModel.objects.get(unique_name='Local_Auto_Gen_PKI_Issuing_CA')
             log.error('Local auto-generated PKI Issuing CA already exists - illegal re-enable of auto-gen PKI?')
         except IssuingCaModel.DoesNotExist:
             log.info('Creating local auto-generated PKI Issuing CA')
             root_ca_instance = root_ca.get_issuing_ca()
-            issuing_ca_initializer = UnprotectedKeyGenLocalIssuingCaInitializer('local_auto_gen_pki_issuing_ca', key_algorithm, root_ca = root_ca_instance, auto_crl=True)
+            issuing_ca_initializer = UnprotectedKeyGenLocalIssuingCaInitializer('Local_Auto_Gen_PKI_Issuing_CA', key_algorithm, root_ca = root_ca_instance, auto_crl=True)
             issuing_ca_initializer.initialize()
             issuing_ca_initializer.save()
-        pass
+        log.warning('Auto-generated PKI enabled.')
     
     @staticmethod
     def disable_auto_gen_pki() -> None:
         """Disables the auto-generated PKI."""
         log.warning('! Disabling auto-generated PKI !')
-        pass
+        try:
+            issuing_ca = IssuingCaModel.objects.get(unique_name='local_auto_gen_pki_issuing_ca')
+        except IssuingCaModel.DoesNotExist:
+            log.error('Issuing CA for auto-generated PKI does not exist - auto-generated PKI possibly not fully disabled')
+            raise
+        
+        issuing_ca_instance = issuing_ca.get_issuing_ca()
+        issuing_ca_instance.get_issuing_ca_certificate().revoke(revocation_reason=ReasonCode.CESSATION)
+        issuing_ca.delete()
+        log.warning('Auto-generated PKI disabled.')

--- a/trustpoint/pki/auto_gen_pki.py
+++ b/trustpoint/pki/auto_gen_pki.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 
 from pki.models import IssuingCaModel
+from pki.initializer.issuing_ca.key_gen import UnprotectedKeyGenLocalRootCaInitializer, UnprotectedKeyGenLocalIssuingCaInitializer
+from pki.util.keys import KeyAlgorithm
 
 from sysconf.security import SecurityFeatures
 from sysconf.security.decorators import security_level
@@ -18,16 +20,36 @@ class AutoGenPki:
         """Enables the auto-generated PKI."""
         log.warning('! Enabling auto-generated PKI !')
 
+        key_algorithm = KeyAlgorithm.RSA4096
+
         # check if local root CA exists
         try:
             root_ca = IssuingCaModel.objects.get(unique_name='local_auto_gen_pki_root_ca')
             log.info('Using existing local auto-generated PKI Root CA')
         except IssuingCaModel.DoesNotExist:
             log.info('Creating local auto-generated PKI Root CA')
-            root_ca = IssuingCaModel()
-            root_ca.unique_name = 'local_auto_gen_pki_root_ca'
-            root_ca.save()
+            root_ca_initializer = UnprotectedKeyGenLocalRootCaInitializer('local_auto_gen_pki_root_ca', key_algorithm, auto_crl=True)
+            root_ca_initializer.initialize()
+            root_ca_initializer.save()
 
+        try:
+            root_ca = IssuingCaModel.objects.get(unique_name='local_auto_gen_pki_root_ca')
+            log.info('Using existing local auto-generated PKI Root CA')
+        except IssuingCaModel.DoesNotExist:
+            log.error('Local auto-generated PKI Root CA is not in database - illegal state')
+            raise
+            
+
+        # check if local issuing CA exists (it shouldn't as it is deleted on auto-gen PKI disable)
+        try:
+            issuing_ca = IssuingCaModel.objects.get(unique_name='local_auto_gen_pki_issuing_ca')
+            log.error('Local auto-generated PKI Issuing CA already exists - illegal re-enable of auto-gen PKI?')
+        except IssuingCaModel.DoesNotExist:
+            log.info('Creating local auto-generated PKI Issuing CA')
+            root_ca_instance = root_ca.get_issuing_ca()
+            issuing_ca_initializer = UnprotectedKeyGenLocalIssuingCaInitializer('local_auto_gen_pki_issuing_ca', key_algorithm, root_ca = root_ca_instance, auto_crl=True)
+            issuing_ca_initializer.initialize()
+            issuing_ca_initializer.save()
         pass
     
     @staticmethod

--- a/trustpoint/pki/auto_gen_pki.py
+++ b/trustpoint/pki/auto_gen_pki.py
@@ -2,15 +2,32 @@ from __future__ import annotations
 
 import logging
 
+from pki.models import IssuingCaModel
+
+from sysconf.security import SecurityFeatures
+from sysconf.security.decorators import security_level
+
 log = logging.getLogger('tp.pki')
 
 class AutoGenPki:
     """Manages the auto-generated local CAs."""
 
     @staticmethod
+    @security_level(SecurityFeatures.AUTO_GEN_PKI)
     def enable_auto_gen_pki() -> None:
         """Enables the auto-generated PKI."""
         log.warning('! Enabling auto-generated PKI !')
+
+        # check if local root CA exists
+        try:
+            root_ca = IssuingCaModel.objects.get(unique_name='local_auto_gen_pki_root_ca')
+            log.info('Using existing local auto-generated PKI Root CA')
+        except IssuingCaModel.DoesNotExist:
+            log.info('Creating local auto-generated PKI Root CA')
+            root_ca = IssuingCaModel()
+            root_ca.unique_name = 'local_auto_gen_pki_root_ca'
+            root_ca.save()
+
         pass
     
     @staticmethod

--- a/trustpoint/pki/auto_gen_pki.py
+++ b/trustpoint/pki/auto_gen_pki.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import logging
+import threading
 
-from pki.models import IssuingCaModel, RootCaModel, ReasonCode
+from pki.models import DomainModel, IssuingCaModel, RootCaModel, ReasonCode
 from pki.initializer.issuing_ca.key_gen import UnprotectedKeyGenLocalRootCaInitializer, UnprotectedKeyGenLocalIssuingCaInitializer
 from pki.util.keys import KeyAlgorithm
 
@@ -13,50 +14,81 @@ log = logging.getLogger('tp.pki')
 
 class AutoGenPki:
     """Manages the auto-generated local CAs."""
+    _lock : threading.Lock = threading.Lock() # prevent concurrent enable/disable
 
     @staticmethod
     @security_level(SecurityFeatures.AUTO_GEN_PKI)
     def enable_auto_gen_pki() -> None:
+        """Starts a thread that enables the auto-generated PKI."""
+        thread = threading.Thread(target=AutoGenPki._enable_auto_gen_pki)
+        thread.start()
+
+    @staticmethod
+    def disable_auto_gen_pki() -> None:
+        """Starts a thread that disables the auto-generated PKI."""
+        thread = threading.Thread(target=AutoGenPki._disable_auto_gen_pki)
+        thread.start()
+
+    @staticmethod
+    @security_level(SecurityFeatures.AUTO_GEN_PKI)
+    def _enable_auto_gen_pki() -> None:
         """Enables the auto-generated PKI."""
+        AutoGenPki._lock.acquire()
         log.warning('! Enabling auto-generated PKI !')
 
         key_algorithm = KeyAlgorithm.RSA4096
 
         # check if local root CA exists
         try:
-            root_ca = RootCaModel.objects.get(unique_name='Local_Auto_Gen_PKI_Root_CA')
+            _ = RootCaModel.objects.get(unique_name='AutoGenPKI_Root_CA')
             log.info('Using existing local auto-generated PKI Root CA')
         except RootCaModel.DoesNotExist:
             log.info('Creating local auto-generated PKI Root CA')
-            root_ca_initializer = UnprotectedKeyGenLocalRootCaInitializer('local_auto_gen_pki_root_ca', key_algorithm, auto_crl=True)
+            root_ca_initializer = UnprotectedKeyGenLocalRootCaInitializer('AutoGenPKI_Root_CA', key_algorithm, auto_crl=True)
             root_ca_initializer.initialize()
             root_ca_initializer.save()
 
         try:
-            root_ca = RootCaModel.objects.get(unique_name='Local_Auto_Gen_PKI_Root_CA')
+            root_ca = RootCaModel.objects.get(unique_name='AutoGenPKI_Root_CA')
         except RootCaModel.DoesNotExist:
             log.error('Local auto-generated PKI Root CA is not in database - illegal state')
-            raise
-            
+            raise        
 
         # check if local issuing CA exists (it shouldn't as it is deleted on auto-gen PKI disable)
         try:
-            issuing_ca = IssuingCaModel.objects.get(unique_name='Local_Auto_Gen_PKI_Issuing_CA')
+            _ = IssuingCaModel.objects.get(unique_name='AutoGenPKI_Issuing_CA')
             log.error('Local auto-generated PKI Issuing CA already exists - illegal re-enable of auto-gen PKI?')
         except IssuingCaModel.DoesNotExist:
             log.info('Creating local auto-generated PKI Issuing CA')
             root_ca_instance = root_ca.get_issuing_ca()
-            issuing_ca_initializer = UnprotectedKeyGenLocalIssuingCaInitializer('Local_Auto_Gen_PKI_Issuing_CA', key_algorithm, root_ca = root_ca_instance, auto_crl=True)
+            issuing_ca_initializer = UnprotectedKeyGenLocalIssuingCaInitializer('AutoGenPKI_Issuing_CA', key_algorithm, root_ca = root_ca_instance, auto_crl=True)
             issuing_ca_initializer.initialize()
             issuing_ca_initializer.save()
+
+        try:
+            issuing_ca = IssuingCaModel.objects.get(unique_name='AutoGenPKI_Issuing_CA')
+        except IssuingCaModel.DoesNotExist:
+            log.error('Local auto-generated PKI Issuing CA is not in database - illegal state')
+            raise
+
+        # for convenience, also generate a domain
+        try:
+            _ = DomainModel.objects.get(unique_name='AutoGenPKI')
+        except DomainModel.DoesNotExist:
+            domain = DomainModel(unique_name='AutoGenPKI')
+            domain.issuing_ca = issuing_ca
+            domain.save()
+
         log.warning('Auto-generated PKI enabled.')
+        AutoGenPki._lock.release()
     
     @staticmethod
-    def disable_auto_gen_pki() -> None:
+    def _disable_auto_gen_pki() -> None:
         """Disables the auto-generated PKI."""
+        AutoGenPki._lock.acquire()
         log.warning('! Disabling auto-generated PKI !')
         try:
-            issuing_ca = IssuingCaModel.objects.get(unique_name='local_auto_gen_pki_issuing_ca')
+            issuing_ca = IssuingCaModel.objects.get(unique_name='AutoGenPKI_Issuing_CA')
         except IssuingCaModel.DoesNotExist:
             log.error('Issuing CA for auto-generated PKI does not exist - auto-generated PKI possibly not fully disabled')
             raise
@@ -65,3 +97,4 @@ class AutoGenPki:
         issuing_ca_instance.get_issuing_ca_certificate().revoke(revocation_reason=ReasonCode.CESSATION)
         issuing_ca.delete()
         log.warning('Auto-generated PKI disabled.')
+        AutoGenPki._lock.release()

--- a/trustpoint/pki/auto_gen_pki.py
+++ b/trustpoint/pki/auto_gen_pki.py
@@ -94,6 +94,7 @@ class AutoGenPki:
             raise
         
         issuing_ca_instance = issuing_ca.get_issuing_ca()
+        issuing_ca_instance.revoke_all_certificates()
         issuing_ca_instance.get_issuing_ca_certificate().revoke(revocation_reason=ReasonCode.CESSATION)
         issuing_ca.delete()
         log.warning('Auto-generated PKI disabled.')

--- a/trustpoint/pki/initializer/issuing_ca/base.py
+++ b/trustpoint/pki/initializer/issuing_ca/base.py
@@ -6,7 +6,8 @@ from . import InitializerError
 
 
 class IssuingCaInitializer(Initializer, abc.ABC):
-    pass
+    _unique_name: str
+    _is_initialized: bool = False
 
 class IssuingCaInitializerError(InitializerError):
     pass

--- a/trustpoint/pki/initializer/issuing_ca/file_import.py
+++ b/trustpoint/pki/initializer/issuing_ca/file_import.py
@@ -7,8 +7,6 @@ from django.db import transaction
 from django.utils.translation import gettext_lazy as _
 from django.core.exceptions import ValidationError
 
-from pki.models import CertificateModel, IssuingCaModel, CertificateChainOrderModel
-
 from pki.serializer import (
     PrivateKeySerializer,
     CertificateCollectionSerializer,

--- a/trustpoint/pki/initializer/issuing_ca/key_gen.py
+++ b/trustpoint/pki/initializer/issuing_ca/key_gen.py
@@ -9,6 +9,7 @@ from . import IssuingCaInitializerError
 from .local import LocalIssuingCaInitializer
 
 from pki.issuing_ca import UnprotectedLocalIssuingCa
+from pki.models import RootCaModel
 from pki.util.keys import KeyAlgorithm, KeyGenerator
 from pki.util.ca import CaGenerator
 
@@ -32,6 +33,7 @@ class UnprotectedKeyGenLocalCaInitializer(KeyGenLocalIssuingCaInitializer):
 
 class UnprotectedKeyGenLocalRootCaInitializer(UnprotectedKeyGenLocalCaInitializer):
     """Responsible for initializing the local root CA."""
+    _issuing_ca_model_class : type[RootCaModel] = RootCaModel # overriding IssuingCaModel
 
     def initialize(self) -> None:
         """Initializes the local root CA."""

--- a/trustpoint/pki/initializer/issuing_ca/key_gen.py
+++ b/trustpoint/pki/initializer/issuing_ca/key_gen.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import abc
+import logging
+
+from . import IssuingCaInitializer
+from . import IssuingCaInitializerError
+
+from pki.util.keys import KeyAlgorithm, KeyGenerator
+
+class KeyGenLocalIssuingCaInitializer(IssuingCaInitializer, abc.ABC):
+    """Abstract base class for the key generation local issuing CA initializer."""
+    _unique_name: str
+    _auto_crl: bool
+
+    _is_initialized: bool = False
+
+class UnprotectedKeyGenLocalIssuingCaInitializer(KeyGenLocalIssuingCaInitializer):
+    
+    def __init__(self, unique_name: str, key_algorithm: KeyAlgorithm, auto_crl: bool = True) -> None:
+        self._unique_name = unique_name
+        self._auto_crl = auto_crl
+        self._is_initialized = False
+
+    def initialize(self) -> None:
+        """Initializes the key generation local issuing CA."""
+
+        self._private_key = KeyGenerator(self._key_algorithm).generate_key()
+
+        self._is_initialized = True

--- a/trustpoint/pki/initializer/issuing_ca/key_gen.py
+++ b/trustpoint/pki/initializer/issuing_ca/key_gen.py
@@ -40,7 +40,7 @@ class UnprotectedKeyGenLocalRootCaInitializer(UnprotectedKeyGenLocalCaInitialize
 
         self._private_key = KeyGenerator(self._key_algorithm).generate_key()
 
-        subject_ = CaGenerator.generate_subject('trustpoint.auto_gen_pki.root')
+        subject_ = CaGenerator.generate_subject('trustpoint.auto_gen_pki.%s.root' %  self._key_algorithm.value.lower())
 
         not_valid_before = datetime.datetime.today() - ONE_DAY
         not_valid_after = datetime.datetime.today() + ONE_DAY * 365 * 10

--- a/trustpoint/pki/initializer/issuing_ca/key_gen.py
+++ b/trustpoint/pki/initializer/issuing_ca/key_gen.py
@@ -1,30 +1,96 @@
 from __future__ import annotations
 
 import abc
+import datetime
 import logging
 
 from . import IssuingCaInitializer
 from . import IssuingCaInitializerError
+from .local import LocalIssuingCaInitializer
 
+from pki.issuing_ca import UnprotectedLocalIssuingCa
 from pki.util.keys import KeyAlgorithm, KeyGenerator
+from pki.util.ca import CaGenerator
 
-class KeyGenLocalIssuingCaInitializer(IssuingCaInitializer, abc.ABC):
+from pki.serializer import CertificateCollectionSerializer
+
+
+ONE_DAY = datetime.timedelta(1, 0, 0)
+
+class KeyGenLocalIssuingCaInitializer(LocalIssuingCaInitializer, abc.ABC):
     """Abstract base class for the key generation local issuing CA initializer."""
-    _unique_name: str
-    _auto_crl: bool
 
-    _is_initialized: bool = False
-
-class UnprotectedKeyGenLocalIssuingCaInitializer(KeyGenLocalIssuingCaInitializer):
+class UnprotectedKeyGenLocalCaInitializer(KeyGenLocalIssuingCaInitializer):
+    """Base class for unprotected local CA initializers."""
+    _key_algorithm: KeyAlgorithm
     
     def __init__(self, unique_name: str, key_algorithm: KeyAlgorithm, auto_crl: bool = True) -> None:
         self._unique_name = unique_name
         self._auto_crl = auto_crl
+        self._key_algorithm = key_algorithm
         self._is_initialized = False
 
+class UnprotectedKeyGenLocalRootCaInitializer(UnprotectedKeyGenLocalCaInitializer):
+    """Responsible for initializing the local root CA."""
+
     def initialize(self) -> None:
-        """Initializes the key generation local issuing CA."""
+        """Initializes the local root CA."""
 
         self._private_key = KeyGenerator(self._key_algorithm).generate_key()
+
+        subject_ = CaGenerator.generate_subject('trustpoint.auto_gen_pki.root')
+
+        not_valid_before = datetime.datetime.today() - ONE_DAY
+        not_valid_after = datetime.datetime.today() + ONE_DAY * 365 * 10
+
+        certificate = CaGenerator.generate_ca_certificate(subject_=subject_,
+                                                          issuer_=subject_,
+                                                          subject_key=self._private_key.public_key(),
+                                                          signing_key=self._private_key,
+                                                          not_valid_before=not_valid_before,
+                                                          not_valid_after=not_valid_after)
+
+        self._credential_serializer = self._credential_serializer_class(
+            (self._private_key,certificate) # self._certificate_collection_serializer([]))
+        )
+
+        self._is_initialized = True
+
+class UnprotectedKeyGenLocalIssuingCaInitializer(UnprotectedKeyGenLocalCaInitializer):
+    """Responsible for initializing the local issuing (subordinate) CA."""
+    _root_ca: UnprotectedLocalIssuingCa
+    
+    def __init__(self, unique_name: str, key_algorithm: KeyAlgorithm, root_ca: UnprotectedLocalIssuingCa, auto_crl: bool = True) -> None:
+        self._unique_name = unique_name
+        self._auto_crl = auto_crl
+        self._key_algorithm = key_algorithm
+        self._is_initialized = False
+        self._root_ca = root_ca
+
+    def initialize(self) -> None:
+        """Initializes the local issuing CA."""
+
+        self._private_key = KeyGenerator(self._key_algorithm).generate_key()
+
+        subject_ = CaGenerator.generate_subject('trustpoint.auto_gen_pki.issuing')
+
+        not_valid_before = datetime.datetime.today() - ONE_DAY
+        not_valid_after = datetime.datetime.today() + ONE_DAY * 365 * 10
+
+        root_subject = self._root_ca.subject_name
+        root_private_key = self._root_ca.private_key
+        root_certificate = self._root_ca.get_issuing_ca_certificate().get_certificate_serializer()
+
+        certificate = CaGenerator.generate_ca_certificate(subject_=subject_,
+                                                          issuer_=root_subject,
+                                                          subject_key=self._private_key.public_key(),
+                                                          signing_key=root_private_key,
+                                                          not_valid_before=not_valid_before,
+                                                          not_valid_after=not_valid_after)
+
+        # self._credential_serializer = self._credential_serializer_class(
+        self._credential_serializer = self._credential_serializer_class(
+            (self._private_key,certificate, CertificateCollectionSerializer([root_certificate]))
+        )
 
         self._is_initialized = True

--- a/trustpoint/pki/initializer/issuing_ca/local.py
+++ b/trustpoint/pki/initializer/issuing_ca/local.py
@@ -1,0 +1,123 @@
+"""Code common to all local CAs."""
+
+from __future__ import annotations
+
+import abc
+import logging
+
+from django.db import transaction
+from django.utils.translation import gettext_lazy as _
+from django.core.exceptions import ValidationError
+
+from pki.models import CertificateModel, IssuingCaModel, CertificateChainOrderModel
+
+from pki.serializer import (
+    PrivateKeySerializer,
+    CertificateCollectionSerializer,
+    CredentialSerializer
+)
+
+from . import IssuingCaInitializer
+from . import IssuingCaInitializerError
+
+from pki.util import Sha256Fingerprint, CredentialExtractor
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Union
+    from cryptography.hazmat.primitives.asymmetric import rsa, ec, ed448, ed25519
+    PrivateKey = Union[rsa.RSAPrivateKey, ec.EllipticCurvePrivateKey, ed448.Ed448PrivateKey, ed25519.Ed25519PrivateKey]
+
+log = logging.getLogger('tp.pki.initializer')
+
+
+class LocalIssuingCaInitializerError(IssuingCaInitializerError):
+    pass
+
+
+class InternalServerError(LocalIssuingCaInitializerError):
+    """Raised if an unexpected error occurred.
+
+     E.g. is raised, if .initialize() is not called before .save()
+     """
+
+    def __init__(self, message: None | str = None) -> None:
+        if message:
+            super().__init__(message=message)
+        else:
+            super().__init__(message=_(
+                f'An unexpected internal server error occurred during CA initialization.'
+                f'Please contact the Trustpoint support.'))
+            
+
+class IssuingCaAlreadyExistsError(LocalIssuingCaInitializerError):
+    """Raised if an Issuing CA already exists for a corresponding Issuing CA certificate."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(message=_(f'Issuing CA already exists with unique name: {name}.'))
+
+
+class LocalIssuingCaInitializer(IssuingCaInitializer, abc.ABC):
+    """Abstract base class for the local issuing CA initializer."""
+
+    _auto_crl: bool
+
+    _credential_serializer: CredentialSerializer
+    _private_key_serializer: PrivateKeySerializer
+    _certificate_collection_serializer: CertificateCollectionSerializer
+
+    _credential_serializer_class: type[CredentialSerializer] = CredentialSerializer
+
+    _cert_model_class: type[CertificateModel] = CertificateModel
+    _issuing_ca_model_class: type[IssuingCaModel] = IssuingCaModel
+    _cert_chain_order_model_class: type[CertificateChainOrderModel] = CertificateChainOrderModel
+
+    @transaction.atomic
+    def save(self):
+        """Saves the initialized Issuing CA in the database.
+
+        Raises:
+            InternalServerError: If the Issuing CA was not yet initialized or some other unexpected error occurred.
+        """
+
+        if not self._is_initialized:
+            raise InternalServerError
+
+        try:
+            issuing_ca_certificate = self._credential_serializer.credential_certificate.as_crypto()
+
+            try:
+                saved_certs = [self._cert_model_class.save_certificate(issuing_ca_certificate)]
+            except ValueError:
+
+                cert_model = self._cert_model_class.objects.get(
+                    sha256_fingerprint=Sha256Fingerprint.get_fingerprint_hex_str(issuing_ca_certificate))
+
+                if hasattr(cert_model, 'issuing_ca_model'):
+                    raise IssuingCaAlreadyExistsError(name=cert_model.issuing_ca_model.unique_name)
+
+                saved_certs = [cert_model]
+
+            for certificate in self._credential_serializer.additional_certificates.crypto_iterator():
+                saved_certs.append(self._cert_model_class.save_certificate(certificate, exist_ok=True))
+
+            issuing_ca_model = self._issuing_ca_model_class(
+                unique_name=self._unique_name,
+                auto_crl=self._auto_crl,
+                private_key_pem=self._credential_serializer.credential_private_key.as_pkcs1_pem(None).decode("utf-8")
+            )
+
+            issuing_ca_model.issuing_ca_certificate = saved_certs[0]
+            issuing_ca_model.root_ca_certificate = saved_certs[-1]
+            issuing_ca_model.save()
+
+            for number, certificate in enumerate(saved_certs[1:-1]):
+                cert_chain_order_model = self._cert_chain_order_model_class()
+                cert_chain_order_model.order = number
+                cert_chain_order_model.certificate = certificate
+                cert_chain_order_model.issuing_ca = issuing_ca_model
+                cert_chain_order_model.save()
+        except Exception as exception:
+            log.error(exception)
+            raise InternalServerError(exception)

--- a/trustpoint/pki/initializer/issuing_ca/local.py
+++ b/trustpoint/pki/initializer/issuing_ca/local.py
@@ -99,8 +99,9 @@ class LocalIssuingCaInitializer(IssuingCaInitializer, abc.ABC):
 
                 saved_certs = [cert_model]
 
-            for certificate in self._credential_serializer.additional_certificates.crypto_iterator():
-                saved_certs.append(self._cert_model_class.save_certificate(certificate, exist_ok=True))
+            if (self._credential_serializer.additional_certificates):
+                for certificate in self._credential_serializer.additional_certificates.crypto_iterator():
+                    saved_certs.append(self._cert_model_class.save_certificate(certificate, exist_ok=True))
 
             issuing_ca_model = self._issuing_ca_model_class(
                 unique_name=self._unique_name,

--- a/trustpoint/pki/issuing_ca.py
+++ b/trustpoint/pki/issuing_ca.py
@@ -9,6 +9,7 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from django.db import transaction
 
+from . import ReasonCode, CertificateStatus
 from .serializer import CertificateCollectionSerializer, PrivateKeySerializer
 
 if TYPE_CHECKING:
@@ -186,6 +187,28 @@ class UnprotectedLocalIssuingCa(IssuingCa):
         """
         from .models import CRLStorage
         return CRLStorage.get_crl_object(ca=self._issuing_ca_model)
+    
+    def revoke_all_certificates(self) -> None:
+        """Revokes all certificates issued by the CA."""
+        log.info('Revoking all certificates issued by the CA %s.', self._issuing_ca_model.unique_name)
+        # Disable auto CRL generation so we don't generate a CRL for each revocation
+        auto_crl_state = self._issuing_ca_model.auto_crl
+        self._issuing_ca_model.auto_crl = False
+        self._issuing_ca_model.save()
+        # Get all non-revoked certificates issued by the CA
+        issued_certs = self.get_issuing_ca_certificate().issued_certificate_references.exclude(
+                            certificate_status=CertificateStatus.REVOKED)
+        # Check if any certificates are device LDevIDs, in that case revoke via device
+        for cert in issued_certs:
+            if cert.device_set.exists():
+                for device in cert.device_set.all():
+                    device.revoke_ldevid(revocation_reason=ReasonCode.CESSATION)
+            else:  # Revoke the certificate directly
+                cert.revoke(revocation_reason=ReasonCode.CESSATION)
+
+        self.generate_crl()
+        self._issuing_ca_model.auto_crl = auto_crl_state
+        self._issuing_ca_model.save()
 
     def get_ca_name(self) -> str:
         """Retrieves the unique name of the issuing CA.

--- a/trustpoint/pki/issuing_ca.py
+++ b/trustpoint/pki/issuing_ca.py
@@ -14,7 +14,7 @@ from .serializer import CertificateCollectionSerializer, PrivateKeySerializer
 if TYPE_CHECKING:
     from typing import Union
     from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519, rsa
-    from .models import CertificateModel, IssuingCaModel, RevokedCertificate, CRLStorage
+    from .models import CertificateModel, BaseCaModel, RevokedCertificate, CRLStorage
     PublicKey = Union[rsa.RSAPublicKey, ec.EllipticCurvePublicKey, ed448.Ed448PublicKey, ed25519.Ed25519PublicKey]
     PrivateKey = Union[rsa.RSAPrivateKey, ec.EllipticCurvePrivateKey, ed448.Ed448PrivateKey, ed25519.Ed25519PrivateKey]
     from serializer import CertificateSerializer, PublicKeySerializer
@@ -24,7 +24,7 @@ log = logging.getLogger('tp.pki')
 
 
 class IssuingCa(ABC):
-    _issuing_ca_model: IssuingCaModel
+    _issuing_ca_model: BaseCaModel
 
     def get_issuing_ca_certificate(self) -> CertificateModel:
         return self._issuing_ca_model.get_issuing_ca_certificate()
@@ -42,7 +42,7 @@ class IssuingCa(ABC):
         return self._issuing_ca_model.get_issuing_ca_certificate_chain_serializer()
 
     @property
-    def issuing_ca_model(self) -> IssuingCaModel:
+    def issuing_ca_model(self) -> BaseCaModel:
         return self._issuing_ca_model
 
 
@@ -51,11 +51,11 @@ class UnprotectedLocalIssuingCa(IssuingCa):
     _private_key: None | PrivateKey = None
     _builder: x509.CertificateRevocationListBuilder
 
-    def __init__(self, issuing_ca_model: IssuingCaModel, *args, **kwargs) -> None:
+    def __init__(self, issuing_ca_model: BaseCaModel, *args, **kwargs) -> None:
         """Initializes an UnprotectedLocalIssuingCa instance.
 
         Args:
-            issuing_ca_model (IssuingCaModel): The issuing CA model instance
+            issuing_ca_model (BaseCaModel): The issuing CA model instance
             representing the CA for which the CRL is being managed.
         """
         super().__init__(*args, **kwargs)

--- a/trustpoint/pki/management/commands/__init__.py
+++ b/trustpoint/pki/management/commands/__init__.py
@@ -1,11 +1,1 @@
 """Django management commands for the PKI application."""
-
-
-from enum import Enum
-
-
-class Algorithm(Enum):
-    RSA2048 = 'rsa2048'
-    RSA4096 = 'rsa4096'
-    SECP256 = 'secp256'
-    SECP521 = 'secp521'

--- a/trustpoint/pki/signals.py
+++ b/trustpoint/pki/signals.py
@@ -6,24 +6,24 @@ from django.dispatch import receiver
 
 from pki.pki.request.message import Protocols
 
-from .models import DomainModel, IssuingCaModel, CMPModel, ESTModel
+from .models import DomainModel, BaseCaModel, CMPModel, ESTModel
 from .tasks import add_crl_to_schedule, remove_crl_from_schedule
 
 logger = logging.getLogger('tp.pki')
 
 
-@receiver(post_save, sender=IssuingCaModel)
+@receiver(post_save, sender=BaseCaModel)
 def handle_post_save(sender, instance, created, **kwargs) -> None:
     if created:
         add_crl_to_schedule(instance)
 
 
-@receiver(post_delete, sender=IssuingCaModel)
+@receiver(post_delete, sender=BaseCaModel)
 def handle_post_delete(sender, instance, **kwargs) -> None:
     remove_crl_from_schedule(instance)
 
 
-@receiver(pre_delete, sender=IssuingCaModel)
+@receiver(pre_delete, sender=BaseCaModel)
 def handle_pre_delete(sender, instance, **kwargs) -> None:
     print(sender)
     instance.issuing_ca_certificate.remove_private_key()

--- a/trustpoint/pki/util/ca.py
+++ b/trustpoint/pki/util/ca.py
@@ -1,0 +1,59 @@
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric.types import CertificatePublicKeyTypes, PrivateKeyTypes
+
+
+class CaGenerator():
+    @staticmethod
+    def generate_subject(common_name: str) -> x509.Name:
+
+        subject_ = x509.Name(
+            [
+                #               x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country_name),
+                #               x509.NameAttribute(x509.NameOID.STATE_OR_PROVINCE_NAME, state_name),
+                #               x509.NameAttribute(x509.NameOID.LOCALITY_NAME, city_name),
+                #               x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, ORGANIZATION_NAME),
+                #               x509.NameAttribute(x509.NameOID.ORGANIZATIONAL_UNIT_NAME, ORGANIZATIONAL_UNIT),
+                x509.NameAttribute(x509.NameOID.COMMON_NAME, common_name),
+            ]
+        )
+
+        return subject_
+
+    @staticmethod
+    def generate_ca_certificate(subject_ : x509.Name, issuer_ : x509.Name,
+                                signing_key : PrivateKeyTypes, subject_key : CertificatePublicKeyTypes,
+                                not_valid_before, not_valid_after) -> x509.Certificate:
+
+        # Determine path length based on whether the CA is root or subordinate
+        path_length = 1 if subject_ == issuer_ else 0
+
+        certificate = x509.CertificateBuilder().subject_name(
+            subject_
+        ).issuer_name(
+            issuer_
+        ).public_key(
+            subject_key
+        ).serial_number(
+            x509.random_serial_number()
+        ).not_valid_before(
+            not_valid_before
+        ).not_valid_after(
+            not_valid_after
+        ).add_extension(
+            x509.BasicConstraints(ca=True, path_length=path_length), critical=True
+        ).add_extension(
+            x509.KeyUsage(digital_signature=False, key_encipherment=False,
+                          key_cert_sign=True, key_agreement=False,
+                          content_commitment=False, data_encipherment=False,
+                          crl_sign=True, encipher_only=False, decipher_only=False), critical=True
+        ).add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(subject_key), critical=False
+        ).add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(signing_key.public_key()), critical=False
+        ).sign(
+            signing_key, hashes.SHA256(), default_backend()
+        )
+
+        return certificate

--- a/trustpoint/pki/util/keys.py
+++ b/trustpoint/pki/util/keys.py
@@ -3,12 +3,23 @@ from enum import Enum
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.hazmat.backends import default_backend
 
+from django.db import models
+
 class KeyAlgorithm(Enum):
     RSA2048 = 'RSA2048'
     RSA4096 = 'RSA4096'
-    SECP256 = 'SECP256R1'
-    SECP384 = 'SECP384R1'
-    SECP521 = 'SECP521R1'
+    SECP256R1 = 'SECP256R1'
+    SECP384R1 = 'SECP384R1'
+    SECP521R1 = 'SECP521R1'
+
+class AutoGenPkiKeyAlgorithm(models.TextChoices):
+    RSA2048 = 'RSA2048', 'RSA2048'
+    RSA4096 = 'RSA4096', 'RSA4096'
+    SECP256R1 = 'SECP256R1', 'SECP256R1'
+    # omitting the rest of the choices as an example that Auto Gen PKI doesn't have to support all key algorithms
+
+    def to_key_algorithm(self) -> KeyAlgorithm:
+        return KeyAlgorithm[self]
 
 class KeyGenerator():
     def __init__(self, algorithm: KeyAlgorithm):
@@ -17,11 +28,11 @@ class KeyGenerator():
     def generate_key(self):
         """Generates a private key."""
         match self._algorithm:
-            case KeyAlgorithm.SECP256:
+            case KeyAlgorithm.SECP256R1:
                 key = ec.generate_private_key(ec.SECP256R1(), backend=default_backend())
-            case KeyAlgorithm.SECP384:
+            case KeyAlgorithm.SECP384R1:
                 key = ec.generate_private_key(ec.SECP384R1(), backend=default_backend())
-            case KeyAlgorithm.SECP521:
+            case KeyAlgorithm.SECP521R1:
                 key = ec.generate_private_key(ec.SECP521R1(), backend=default_backend())
             case KeyAlgorithm.RSA2048:
                 key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())

--- a/trustpoint/pki/util/keys.py
+++ b/trustpoint/pki/util/keys.py
@@ -1,0 +1,33 @@
+from enum import Enum
+
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.backends import default_backend
+
+class KeyAlgorithm(Enum):
+    RSA2048 = 'RSA2048'
+    RSA4096 = 'RSA4096'
+    SECP256 = 'SECP256R1'
+    SECP384 = 'SECP384R1'
+    SECP521 = 'SECP521R1'
+
+class KeyGenerator():
+    def __init__(self, algorithm: KeyAlgorithm):
+        self._algorithm = algorithm
+
+    def generate_key(self):
+        """Generates a private key."""
+        match self._algorithm:
+            case KeyAlgorithm.SECP256:
+                key = ec.generate_private_key(ec.SECP256R1(), backend=default_backend())
+            case KeyAlgorithm.SECP384:
+                key = ec.generate_private_key(ec.SECP384R1(), backend=default_backend())
+            case KeyAlgorithm.SECP521:
+                key = ec.generate_private_key(ec.SECP521R1(), backend=default_backend())
+            case KeyAlgorithm.RSA2048:
+                key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+            case KeyAlgorithm.RSA4096:
+                key = rsa.generate_private_key(public_exponent=65537, key_size=4096, backend=default_backend())
+            case _:  # Invalid algorithm
+                raise ValueError("Unsupported key algorithm type")
+
+        return key

--- a/trustpoint/pki/views/crls.py
+++ b/trustpoint/pki/views/crls.py
@@ -6,7 +6,7 @@ from django.shortcuts import redirect
 from django.utils.translation import gettext as _
 from django.views import View
 
-from pki.models import IssuingCaModel
+from pki.models import BaseCaModel
 
 
 class CRLDownloadView(View):
@@ -15,8 +15,8 @@ class CRLDownloadView(View):
     @staticmethod
     def download_ca_crl(self: CRLDownloadView, ca_id):
         try:
-            issuing_ca = IssuingCaModel.objects.get(pk=ca_id).get_issuing_ca()
-        except IssuingCaModel.DoesNotExist:
+            issuing_ca = BaseCaModel.objects.get(pk=ca_id).get_issuing_ca()
+        except BaseCaModel.DoesNotExist:
             messages.error(self, _('Issuing CA not found.'))
             return redirect('pki:issuing_cas')
 
@@ -31,8 +31,8 @@ class CRLDownloadView(View):
     @staticmethod
     def generate_ca_crl(self: CRLDownloadView, ca_id):
         try:
-            issuing_ca = IssuingCaModel.objects.get(pk=ca_id).get_issuing_ca()
-        except IssuingCaModel.DoesNotExist:
+            issuing_ca = BaseCaModel.objects.get(pk=ca_id).get_issuing_ca()
+        except BaseCaModel.DoesNotExist:
             messages.error(self, _('Issuing CA not found.'))
             return redirect('pki:issuing_cas')
 

--- a/trustpoint/static/css/trustpoint.css
+++ b/trustpoint/static/css/trustpoint.css
@@ -462,6 +462,11 @@ table .tp-onboarding-btn {
     grid-template-columns: 1fr;
 }
 
+.tp-msg-icon-margin {
+    margin-top: 0.1rem;
+    margin-right: 0.5rem;
+}
+
 /* ----- Theme ----- */
 
 html[data-bs-theme="light"] {

--- a/trustpoint/static/js/onboarding.js
+++ b/trustpoint/static/js/onboarding.js
@@ -31,10 +31,10 @@ function getOnboardingState(urlExt, iconUrl) {
 }
 
 function setOnboardingStateUIElement(el, iconUrl, type, message, icon, extraClasses='') {
-  el.className = `alert alert-${type} d-flex align-items-center mt-3 ${extraClasses}`;
+  el.className = `alert alert-${type} d-flex mt-3 ${extraClasses}`;
 
   el.innerHTML =
-    `<svg class="bi flex-shrink-0 me-2" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="${iconUrl}#icon-${icon}"/></svg>
+    `<svg class="bi flex-shrink-0 tp-msg-icon-margin" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="${iconUrl}#icon-${icon}"/></svg>
     <div>${message}</div>`;
 }
 

--- a/trustpoint/static/js/sysconf.js
+++ b/trustpoint/static/js/sysconf.js
@@ -52,7 +52,7 @@ function prevalidateSecuritySettings() {
     // 0 = dev, 1 = basic, 2 = medium, 3 = high, 4 = highest
     if (sl < 0 || sl > 4) return; // invalid security level
     document.querySelector('#hidden_input_note').style.display = 'none';
-    for (el of document.querySelectorAll('#security_configuration input')) {
+    for (el of document.querySelectorAll('#security_configuration input, select')) {
         // hide settings that are not available for the selected security level
         if (el.dataset?.hideAtSl) {
             arr = JSON.parse(el.dataset.hideAtSl);

--- a/trustpoint/static/js/sysconf.js
+++ b/trustpoint/static/js/sysconf.js
@@ -46,8 +46,8 @@ function detectSettingsMismatch() {
     // tests if the set advanced security settings are lower than the defaults of the set security level
     if (!document.querySelector('#security_configuration')) return; // not in security settings
     let sl = document.querySelector('input[name="security_mode"]:checked').value;
-    sl -= 1; // 0-based index, 0 = basic, 1 = medium, 2 = high
-    if (sl < 0 || sl > 2) return; // invalid security level
+    sl -= 1; // 0-based index, 0 = dev, 1 = basic, 2 = medium, 3 = high, 4 = highest
+    if (sl < 0 || sl > 4) return; // invalid security level
     for (el of document.querySelectorAll('#security_configuration input')) {
         if (!el.dataset?.slDefaults) continue;
         arr = JSON.parse(el.dataset.slDefaults);

--- a/trustpoint/static/js/sysconf.js
+++ b/trustpoint/static/js/sysconf.js
@@ -73,9 +73,9 @@ function prevalidateSecuritySettings() {
 }
 
 function renderAutoGenPkiDisableWarning() {
-    var willDisable = (document.querySelector('#id_enable_auto_gen_pki').checked === false || 
-                        document.querySelector('#id_enable_auto_gen_pki').classList.contains('mismatch'));
-    var showWarning = (willDisable && initialValues['enable_auto_gen_pki'] === true)
+    var willDisable = (document.querySelector('#id_auto_gen_pki').checked === false || 
+                        document.querySelector('#id_auto_gen_pki').classList.contains('mismatch'));
+    var showWarning = (willDisable && initialValues['auto_gen_pki'] === true)
     document.querySelector('#auto_gen_pki_disable_warning').style.display = showWarning ? 'flex': 'none';
 }
 

--- a/trustpoint/static/js/sysconf.js
+++ b/trustpoint/static/js/sysconf.js
@@ -42,11 +42,13 @@ function dhcpState() {
 
 // ----- Security settings -----
 
-function detectSettingsMismatch() {
+var initialValues = {};
+
+function prevalidateSecuritySettings() {
     // tests if the set advanced security settings are lower than the defaults of the set security level
-    if (!document.querySelector('#security_configuration')) return; // not in security settings
+    if (!document.querySelector('#security_configuration')) return; // only in security settings
     let sl = document.querySelector('input[name="security_mode"]:checked').value;
-    sl -= 1; // 0-based index, 0 = dev, 1 = basic, 2 = medium, 3 = high, 4 = highest
+    // 0 = dev, 1 = basic, 2 = medium, 3 = high, 4 = highest
     if (sl < 0 || sl > 4) return; // invalid security level
     for (el of document.querySelectorAll('#security_configuration input')) {
         if (!el.dataset?.slDefaults) continue;
@@ -60,10 +62,21 @@ function detectSettingsMismatch() {
             value < slDefault && el.dataset.moreSecure === 'true') {
             el.classList.add('mismatch');
             el.dataset.target = slDefault;
-        } else
+            el.parentElement.style.display = 'none'; // TODO: consider separate dataset for visibility of disallowed settings
+        } else {
             el.classList.remove('mismatch');
+            el.parentElement.style.display = 'block'; // TODO: consider separate dataset for visibility of disallowed settings
+        }
     }
     renderMismatchWarning();
+    renderAutoGenPkiDisableWarning();
+}
+
+function renderAutoGenPkiDisableWarning() {
+    var willDisable = (document.querySelector('#id_enable_auto_gen_pki').checked === false || 
+                        document.querySelector('#id_enable_auto_gen_pki').classList.contains('mismatch'));
+    var showWarning = (willDisable && initialValues['enable_auto_gen_pki'] === true)
+    document.querySelector('#auto_gen_pki_disable_warning').style.display = showWarning ? 'flex': 'none';
 }
 
 function renderMismatchWarning() {
@@ -72,8 +85,8 @@ function renderMismatchWarning() {
     if (mismatches.length > 0) {
         warning.style.display = 'flex';
         text = ngettext(
-            'An advanced security setting is less secure than the selected security level.',
-            'Some advanced security settings are less secure than the selected security level.', mismatches.length);
+            'An advanced security setting is less secure than the selected security level permits.',
+            'Some advanced security settings are less secure than the selected security level permits.', mismatches.length);
         text += '<ul>'
         for (el of mismatches) {
             labeltext = document.querySelector('label[for="' + el.id + '"]')?.innerText;
@@ -85,38 +98,47 @@ function renderMismatchWarning() {
                 target = el.dataset.target == 1 ? gettext('enabled') : gettext('disabled');
                 value = el.checked ? gettext('enabled') : gettext('disabled');
             }
-            format = gettext("is %(is)s, but should be %(leastormost)s%(target)s");
+            format = gettext("is %(is)s, but must be %(leastormost)s%(target)s");
             guide = interpolate(format, {is: value, leastormost: more, target: target}, true);
             text += '<li>' + labeltext + ' (' + guide + ')</li>';
         }
         text += '</ul>'	
-        text += ngettext(
-            'It is recommended to change this setting to meet the desired security level.',
-            'It is recommended to change these settings to meet the desired security level.', mismatches.length);
-        text += '<br><button class="btn btn-primary float-end" type="button" onclick="changeMismatchedSettings()">'
-        text += ngettext('Change', 'Change all', mismatches.length);
-        text += '</button>';
+        format = ngettext(
+            'This setting will be changed on save to meet the desired security level %(lvl)s.',
+            'These settings will be changed on save to meet the desired security level %(lvl)s.', mismatches.length);
+        text += interpolate(format, {lvl: document.querySelector('input[name="security_mode"]:checked').labels[0].innerText}, true)
+        // text += '<br><button class="btn btn-primary float-end" type="button" onclick="changeMismatchedSettings()">'
+        // text += ngettext('Change', 'Change all', mismatches.length);
+        // text += '</button>';
         document.querySelector('#mismatch_warning_text').innerHTML = text;
     } else {
         warning.style.display = 'none';
     }
 }
 
-// Add event listeners security settings form inputs
+// Add event listeners security settings form inputs and store initial values
 for (el of document.querySelectorAll('#security_configuration input')) {
-    el.addEventListener('change', detectSettingsMismatch);
-}
-
-function changeMismatchedSettings() {
-    let mismatches = document.querySelectorAll('#security_configuration .mismatch');
-    for (el of mismatches) {
-        if (el.type === 'checkbox') {
-            el.checked = el.dataset.target == 1;
-        } else {
-            el.value = el.dataset.target
-        }
+    el.addEventListener('change', prevalidateSecuritySettings);
+    if (el.type === 'checkbox') {
+        initialValues[el.name] = el.checked;
+    } else if (el.type === 'radio') {
+        if (el.checked) initialValues[el.name] = el.value;
+    } else {
+        initialValues[el.name] = el.value;
     }
-    detectSettingsMismatch();
 }
+//console.log(initialValues)
 
-detectSettingsMismatch();
+// function changeMismatchedSettings() {
+//     let mismatches = document.querySelectorAll('#security_configuration .mismatch');
+//     for (el of mismatches) {
+//         if (el.type === 'checkbox') {
+//             el.checked = el.dataset.target == 1;
+//         } else {
+//             el.value = el.dataset.target
+//         }
+//     }
+//     prevalidateSecuritySettings();
+// }
+
+prevalidateSecuritySettings();

--- a/trustpoint/static/js/sysconf.js
+++ b/trustpoint/static/js/sysconf.js
@@ -44,13 +44,24 @@ function dhcpState() {
 
 var initialValues = {};
 
+
 function prevalidateSecuritySettings() {
     // tests if the set advanced security settings are lower than the defaults of the set security level
     if (!document.querySelector('#security_configuration')) return; // only in security settings
     let sl = document.querySelector('input[name="security_mode"]:checked').value;
     // 0 = dev, 1 = basic, 2 = medium, 3 = high, 4 = highest
     if (sl < 0 || sl > 4) return; // invalid security level
+    document.querySelector('#hidden_input_note').style.display = 'none';
     for (el of document.querySelectorAll('#security_configuration input')) {
+        // hide settings that are not available for the selected security level
+        if (el.dataset?.hideAtSl) {
+            arr = JSON.parse(el.dataset.hideAtSl);
+            if (arr[sl] === true) {
+                document.querySelector('#hidden_input_note').style.display = 'block';
+            }
+            //el.parentElement.style.display = 'none';
+            el.parentElement.style.display = (arr[sl] === true) ? 'none':'block';
+        }
         if (!el.dataset?.slDefaults) continue;
         arr = JSON.parse(el.dataset.slDefaults);
         slDefault = arr[sl];
@@ -62,10 +73,10 @@ function prevalidateSecuritySettings() {
             value < slDefault && el.dataset.moreSecure === 'true') {
             el.classList.add('mismatch');
             el.dataset.target = slDefault;
-            el.parentElement.style.display = 'none'; // TODO: consider separate dataset for visibility of disallowed settings
+            //el.parentElement.style.display = 'none'; // TODO: consider separate dataset for visibility of disallowed settings
         } else {
             el.classList.remove('mismatch');
-            el.parentElement.style.display = 'block'; // TODO: consider separate dataset for visibility of disallowed settings
+            //el.parentElement.style.display = 'block'; // TODO: consider separate dataset for visibility of disallowed settings
         }
     }
     renderMismatchWarning();

--- a/trustpoint/sysconf/forms.py
+++ b/trustpoint/sysconf/forms.py
@@ -71,7 +71,8 @@ class SecurityConfigForm(forms.ModelForm):
     
     auto_gen_pki = forms.BooleanField(required=False, label=_('Enable local auto-generated PKI'),
                                 widget=forms.CheckboxInput(
-                                    attrs={'data-sl-defaults': '[true,true,false,false,false]',
+                                    attrs={'data-sl-defaults': '[true, true, false, false, false]',
+                                           'data-hide-at-sl': '[false, false, true, true, true]',
                                            'data-more-secure': 'false'}))
 
     class Meta:

--- a/trustpoint/sysconf/forms.py
+++ b/trustpoint/sysconf/forms.py
@@ -61,13 +61,19 @@ class SecurityConfigForm(forms.ModelForm):
             ),
             Fieldset(
                 _('Advanced security settings'),
+                'enable_auto_gen_pki'
             )
         )
 
 
     security_mode = forms.ChoiceField(choices=SecurityConfig.SecurityModeChoices.choices,
-                                      widget=forms.Select(),
+                                      widget=forms.RadioSelect(),
                                       label='')
+    
+    enable_auto_gen_pki = forms.BooleanField(required=False, label=_('Enable local auto-generated PKI'),
+                                widget=forms.CheckboxInput(
+                                    attrs={'data-sl-defaults': '[true,true,false,false,false]',
+                                           'data-more-secure': 'false'}))
 
     class Meta:
         """Meta class"""

--- a/trustpoint/sysconf/forms.py
+++ b/trustpoint/sysconf/forms.py
@@ -6,7 +6,7 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Fieldset
 
 from .models import LoggingConfig, NetworkConfig, NTPConfig, SecurityConfig
-
+from .security import SecurityModeChoices
 
 class NTPConfigForm(forms.ModelForm):
     """NTP configuration form"""
@@ -61,16 +61,15 @@ class SecurityConfigForm(forms.ModelForm):
             ),
             Fieldset(
                 _('Advanced security settings'),
-                'enable_auto_gen_pki'
+                'auto_gen_pki'
             )
         )
 
-
-    security_mode = forms.ChoiceField(choices=SecurityConfig.SecurityModeChoices.choices,
+    security_mode = forms.ChoiceField(choices=SecurityModeChoices.choices,
                                       widget=forms.RadioSelect(),
                                       label='')
     
-    enable_auto_gen_pki = forms.BooleanField(required=False, label=_('Enable local auto-generated PKI'),
+    auto_gen_pki = forms.BooleanField(required=False, label=_('Enable local auto-generated PKI'),
                                 widget=forms.CheckboxInput(
                                     attrs={'data-sl-defaults': '[true,true,false,false,false]',
                                            'data-more-secure': 'false'}))
@@ -79,8 +78,8 @@ class SecurityConfigForm(forms.ModelForm):
         """Meta class"""
         model = SecurityConfig
         fields = ['security_mode',
-                  'enable_auto_gen_pki']
+                  'auto_gen_pki']
         labels = {
             'security_mode': _('Security Level'),
-            'enable_auto_gen_pki': _('Enable local auto-generated PKI'),
+            'auto_gen_pki': _('Enable local auto-generated PKI'),
         }

--- a/trustpoint/sysconf/forms.py
+++ b/trustpoint/sysconf/forms.py
@@ -78,7 +78,9 @@ class SecurityConfigForm(forms.ModelForm):
     class Meta:
         """Meta class"""
         model = SecurityConfig
-        fields = ['security_mode']
+        fields = ['security_mode',
+                  'enable_auto_gen_pki']
         labels = {
             'security_mode': _('Security Level'),
+            'enable_auto_gen_pki': _('Enable local auto-generated PKI'),
         }

--- a/trustpoint/sysconf/models.py
+++ b/trustpoint/sysconf/models.py
@@ -63,7 +63,7 @@ class SecurityConfig(models.Model):
         HIGHEST = '4', _('Highest')
 
     security_mode = models.CharField(max_length=6, choices=SecurityModeChoices.choices, default=SecurityModeChoices.LOW)
-
+    enable_auto_gen_pki = models.BooleanField(default=False)
 
     def __str__(self) -> str:
         """Output as string"""

--- a/trustpoint/sysconf/models.py
+++ b/trustpoint/sysconf/models.py
@@ -3,6 +3,8 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 from django.core.validators import MaxValueValidator, MinValueValidator
 
+from pki.util.keys import AutoGenPkiKeyAlgorithm
+
 from sysconf.security import SecurityFeatures, SecurityModeChoices
 from sysconf.security.manager import SecurityManager
 
@@ -58,7 +60,11 @@ class SecurityConfig(models.Model):
     """Security Configuration model"""
 
     security_mode = models.CharField(max_length=6, choices=SecurityModeChoices.choices, default=SecurityModeChoices.LOW)
+    
     auto_gen_pki = models.BooleanField(default=False)
+    auto_gen_pki_key_algorithm = models.CharField(max_length=12,
+                                                  choices=AutoGenPkiKeyAlgorithm,
+                                                  default=AutoGenPkiKeyAlgorithm.RSA2048)
 
     _original_values = {}
 

--- a/trustpoint/sysconf/security/__init__.py
+++ b/trustpoint/sysconf/security/__init__.py
@@ -1,7 +1,16 @@
 from enum import Enum
+from django.db import models
+from django.utils.translation import gettext_lazy as _
 
+class SecurityModeChoices(models.TextChoices):
+    """Types of security modes"""
+    DEV = '0', _('Testing env')
+    LOW = '1', _('Basic')
+    MEDIUM = '2', _('Medium')
+    HIGH = '3', _('High')
+    HIGHEST = '4', _('Highest')
 
 class SecurityFeatures(Enum):
     """A class that defines various security features used throughout the application."""
-    LOCAL_ROOT_CA = 'local root ca'
+    AUTO_GEN_PKI = 'Auto-Generated PKI'
     LOG_ACCESS = 'Log Access'

--- a/trustpoint/sysconf/security/manager.py
+++ b/trustpoint/sysconf/security/manager.py
@@ -1,8 +1,6 @@
 from django.core.cache import cache
 
-from sysconf.models import SecurityConfig
-
-from . import SecurityFeatures
+from . import SecurityFeatures, SecurityModeChoices
 
 
 class SecurityManager:
@@ -10,26 +8,30 @@ class SecurityManager:
     highest_features = (SecurityFeatures.LOG_ACCESS, )
     high_features = (*highest_features, )
     medium_features = (*high_features, )
-    low_features = (*medium_features, SecurityFeatures.LOCAL_ROOT_CA, )
+    low_features = (*medium_features, SecurityFeatures.AUTO_GEN_PKI, )
 
 
     @classmethod
-    def is_feature_allowed(cls, feature_name: SecurityFeatures):
+    def is_feature_allowed(cls, feature_name: SecurityFeatures, target_level: SecurityModeChoices = None):
         print(f'highest_features:  {cls.highest_features}')
         print(f'high_features:  {cls.high_features}')
         print(f'medium_features:  {cls.medium_features}')
         print(f'low_features:  {cls.low_features}')
 
-        sec_level = cls.get_security_level()
-        if sec_level == SecurityConfig.SecurityModeChoices.DEV:
+        if (target_level is None):
+            sec_level = cls.get_security_level()
+        else:
+            sec_level = target_level
+
+        if sec_level == SecurityModeChoices.DEV:
             return True
-        elif sec_level == SecurityConfig.SecurityModeChoices.LOW:
+        elif sec_level == SecurityModeChoices.LOW:
             return feature_name in cls.low_features
-        elif sec_level == SecurityConfig.SecurityModeChoices.MEDIUM:
+        elif sec_level == SecurityModeChoices.MEDIUM:
             return feature_name in cls.medium_features
-        elif sec_level == SecurityConfig.SecurityModeChoices.HIGH:
+        elif sec_level == SecurityModeChoices.HIGH:
             return feature_name in cls.high_features
-        elif sec_level == SecurityConfig.SecurityModeChoices.HIGHEST:
+        elif sec_level == SecurityModeChoices.HIGHEST:
             return feature_name in cls.highest_features
         return False
 
@@ -50,6 +52,8 @@ class SecurityManager:
     @classmethod
     def _set_cache(cls) -> None:
         """Sets the security level in the cache by fetching it from the database."""
+        from sysconf.models import SecurityConfig
+        
         current_sec_config = SecurityConfig.objects.first()
         if current_sec_config:
             cache.set('security_level', current_sec_config.security_mode)

--- a/trustpoint/sysconf/security/manager.py
+++ b/trustpoint/sysconf/security/manager.py
@@ -13,10 +13,10 @@ class SecurityManager:
 
     @classmethod
     def is_feature_allowed(cls, feature_name: SecurityFeatures, target_level: SecurityModeChoices = None):
-        print(f'highest_features:  {cls.highest_features}')
-        print(f'high_features:  {cls.high_features}')
-        print(f'medium_features:  {cls.medium_features}')
-        print(f'low_features:  {cls.low_features}')
+        # print(f'highest_features:  {cls.highest_features}')
+        # print(f'high_features:  {cls.high_features}')
+        # print(f'medium_features:  {cls.medium_features}')
+        # print(f'low_features:  {cls.low_features}')
 
         if (target_level is None):
             sec_level = cls.get_security_level()

--- a/trustpoint/sysconf/signals.py
+++ b/trustpoint/sysconf/signals.py
@@ -1,9 +1,14 @@
+import logging
+
 from django.core.cache import cache
-from django.db.models.signals import post_delete, post_save
+from django.db.models.signals import post_delete, post_init, post_save
 from django.dispatch import receiver
+from pki.auto_gen_pki import AutoGenPki
 
 from .models import SecurityConfig
+from .security import SecurityModeChoices
 
+log = logging.getLogger('tp.sysconf')
 
 @receiver(post_save, sender=SecurityConfig)
 @receiver(post_delete, sender=SecurityConfig)
@@ -11,5 +16,26 @@ def update_security_level(sender, instance, **kwargs):
     if instance:
         security_level = instance.security_mode
         cache.set('security_level', security_level)
+
+        if instance.security_mode != instance._original_values['security_mode']:
+            log.warning('! Security level changed from %s to %s !',
+                        SecurityModeChoices(instance._original_values['security_mode']).label,
+                        SecurityModeChoices(instance.security_mode).label)
+
+        if instance.auto_gen_pki and instance._original_values['auto_gen_pki'] == False:
+            AutoGenPki.enable_auto_gen_pki()
+        elif not instance.auto_gen_pki and instance._original_values['auto_gen_pki'] == True:
+            AutoGenPki.disable_auto_gen_pki()
+
+        # save newly saved values as new original values
+        save_original_values(sender, instance, **kwargs)
     else:
         cache.delete('security_level')
+
+
+
+@receiver(post_init, sender=SecurityConfig)
+def save_original_values(sender, instance, **kwargs):
+    if instance:
+        instance._original_values['security_mode'] = instance.security_mode
+        instance._original_values['auto_gen_pki'] = instance.auto_gen_pki

--- a/trustpoint/sysconf/signals.py
+++ b/trustpoint/sysconf/signals.py
@@ -23,7 +23,7 @@ def update_security_level(sender, instance, **kwargs):
                         SecurityModeChoices(instance.security_mode).label)
 
         if instance.auto_gen_pki and instance._original_values['auto_gen_pki'] == False:
-            AutoGenPki.enable_auto_gen_pki()
+            AutoGenPki.enable_auto_gen_pki(instance.auto_gen_pki_key_algorithm)
         elif not instance.auto_gen_pki and instance._original_values['auto_gen_pki'] == True:
             AutoGenPki.disable_auto_gen_pki()
 

--- a/trustpoint/sysconf/templates/sysconf/security.html
+++ b/trustpoint/sysconf/templates/sysconf/security.html
@@ -20,7 +20,7 @@
             </form>
             <div id="mismatch_warning" class="alert alert-warning tp-d-none align-items-center mt-3" role="alert">  
                 <svg class="bi flex-shrink-0 me-2" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-warning"/></svg>
-                <div id="mismatch_warning_text" class="flex-grow-1 text-start"></div>                
+                <div id="mismatch_warning_text" class="flex-grow-1 text-start"></div>
             </div>
         </div>
         <div class="card-footer text-body-secondary">

--- a/trustpoint/sysconf/templates/sysconf/security.html
+++ b/trustpoint/sysconf/templates/sysconf/security.html
@@ -18,14 +18,14 @@
                     {% crispy security_config_form %}
                 </fieldset>
             </form>
-            <div id="auto_gen_pki_disable_warning" class="alert alert-danger tp-d-none align-items-center mt-3" role="alert">
-                <svg class="bi flex-shrink-0 me-2" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-warning"/></svg>
+            <div id="auto_gen_pki_disable_warning" class="alert alert-danger tp-d-none mt-3" role="alert">
+                <svg class="bi flex-shrink-0 tp-msg-icon-margin" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-warning"/></svg>
                 <div class="flex-grow-1 text-start"><strong>WARNING!</strong> By saving, you will disable the local auto-generated PKI. This revokes all certificates issued by the local auto-generated PKI and deletes the auto-generated Issuing CA.
                 <strong>This action is irreversible.</strong>
                 </div>
             </div>
-            <div id="mismatch_warning" class="alert alert-warning tp-d-none align-items-center mt-3" role="alert">  
-                <svg class="bi flex-shrink-0 me-2" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-warning"/></svg>
+            <div id="mismatch_warning" class="alert alert-warning tp-d-none mt-3" role="alert">  
+                <svg class="bi flex-shrink-0 tp-msg-icon-margin" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-warning"/></svg>
                 <div id="mismatch_warning_text" class="flex-grow-1 text-start"></div>
             </div>
         </div>

--- a/trustpoint/sysconf/templates/sysconf/security.html
+++ b/trustpoint/sysconf/templates/sysconf/security.html
@@ -18,6 +18,12 @@
                     {% crispy security_config_form %}
                 </fieldset>
             </form>
+            <div id="auto_gen_pki_disable_warning" class="alert alert-danger tp-d-none align-items-center mt-3" role="alert">
+                <svg class="bi flex-shrink-0 me-2" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-warning"/></svg>
+                <div class="flex-grow-1 text-start"><strong>WARNING!</strong> By saving, you will disable the local auto-generated PKI. This revokes all certificates issued by the local auto-generated PKI and deletes the auto-generated Issuing CA.
+                <strong>This action is irreversible.</strong>
+                </div>
+            </div>
             <div id="mismatch_warning" class="alert alert-warning tp-d-none align-items-center mt-3" role="alert">  
                 <svg class="bi flex-shrink-0 me-2" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-warning"/></svg>
                 <div id="mismatch_warning_text" class="flex-grow-1 text-start"></div>

--- a/trustpoint/sysconf/templates/sysconf/security.html
+++ b/trustpoint/sysconf/templates/sysconf/security.html
@@ -18,6 +18,9 @@
                     {% crispy security_config_form %}
                 </fieldset>
             </form>
+            <div id="hidden_input_note" class="tp-d-none text-start">
+                <i>Some settings are hidden as they are unavailable for the selected security level.</i>
+            </div>
             <div id="auto_gen_pki_disable_warning" class="alert alert-danger tp-d-none mt-3" role="alert">
                 <svg class="bi flex-shrink-0 tp-msg-icon-margin" width="20" height="20" fill="currentColor" role="img" aria-label="State: "><use xlink:href="{% static 'img/icons.svg' %}#icon-warning"/></svg>
                 <div class="flex-grow-1 text-start"><strong>WARNING!</strong> By saving, you will disable the local auto-generated PKI. This revokes all certificates issued by the local auto-generated PKI and deletes the auto-generated Issuing CA.

--- a/trustpoint/sysconf/views.py
+++ b/trustpoint/sysconf/views.py
@@ -219,7 +219,7 @@ def ssh(request: HttpRequest) -> HttpResponse:
     return render(request, 'sysconf/ssh.html', context=context)
 
 def security(request: HttpRequest) -> HttpResponse:
-    """Handle ssh Configuration
+    """Handle Security Configuration
 
     Returns: HTTPResponse
     """
@@ -237,8 +237,11 @@ def security(request: HttpRequest) -> HttpResponse:
         if security_configuration_form.is_valid():
             security_configuration_form.save()
             messages.success(request, _('Your changes were saved successfully.'))
-        else:
-            messages.error(request, _('Error saving the configuration'))
+            # use a new form instance to apply new original values
+            context['security_config_form'] = SecurityConfigForm(instance=security_config)
+            return render(request, 'sysconf/security.html', context=context)
+
+        messages.error(request, _('Error saving the configuration'))
         context['security_config_form'] = security_configuration_form
         return render(request, 'sysconf/security.html', context=context)
 

--- a/trustpoint/trustpoint/api.py
+++ b/trustpoint/trustpoint/api.py
@@ -17,16 +17,16 @@ class AuthBearer(HttpBearer):
         return PersonalAccessToken.get_from_string(token)
 
 
-# api = NinjaAPI(
-#     auth=(AuthBearer(), django_auth),
-#     title='Trustpoint API',
-#     version='0.1.0'
-# )
+api = NinjaAPI(
+    auth=(AuthBearer(), django_auth),
+    title='Trustpoint API',
+    version='0.1.0'
+)
 
-# api.add_router('/devices/', devices_router, tags=['Devices'])
-# api.add_router('/onboarding/', onboarding_router, tags=['Onboarding'])
-# # api.add_router('/pki/', pki_router, tags=['PKI'])
-# api.add_router('/users/', users_router, tags=['Users'])
+api.add_router('/devices/', devices_router, tags=['Devices'])
+api.add_router('/onboarding/', onboarding_router, tags=['Onboarding'])
+# api.add_router('/pki/', pki_router, tags=['PKI'])
+api.add_router('/users/', users_router, tags=['Users'])
 
 # TODO(Air): Couldn't get non-GET requests to work with CSRF using Django-auth reliably
 # Therefore a simple bearer personal access token login system is implemented for now with a separate /login endpoint

--- a/trustpoint/trustpoint/api.py
+++ b/trustpoint/trustpoint/api.py
@@ -17,16 +17,16 @@ class AuthBearer(HttpBearer):
         return PersonalAccessToken.get_from_string(token)
 
 
-api = NinjaAPI(
-    auth=(AuthBearer(), django_auth),
-    title='Trustpoint API',
-    version='0.1.0'
-)
+# api = NinjaAPI(
+#     auth=(AuthBearer(), django_auth),
+#     title='Trustpoint API',
+#     version='0.1.0'
+# )
 
-api.add_router('/devices/', devices_router, tags=['Devices'])
-api.add_router('/onboarding/', onboarding_router, tags=['Onboarding'])
-# api.add_router('/pki/', pki_router, tags=['PKI'])
-api.add_router('/users/', users_router, tags=['Users'])
+# api.add_router('/devices/', devices_router, tags=['Devices'])
+# api.add_router('/onboarding/', onboarding_router, tags=['Onboarding'])
+# # api.add_router('/pki/', pki_router, tags=['PKI'])
+# api.add_router('/users/', users_router, tags=['Users'])
 
 # TODO(Air): Couldn't get non-GET requests to work with CSRF using Django-auth reliably
 # Therefore a simple bearer personal access token login system is implemented for now with a separate /login endpoint

--- a/trustpoint/trustpoint/settings.py
+++ b/trustpoint/trustpoint/settings.py
@@ -52,7 +52,7 @@ INSTALLED_APPS = [
     'crispy_forms',
     'crispy_bootstrap5',
     'django_tables2',
-    'ninja',
+    #'ninja',
     # TODO(Aircoookie): Required only for HTTPS testing with Django runserver_plus, remove for production
     'django_extensions',
     # use "python manage.py runserver_plus 8000 --cert-file ../tests/data/x509/https_server.crt

--- a/trustpoint/trustpoint/templates/trustpoint/base.html
+++ b/trustpoint/trustpoint/templates/trustpoint/base.html
@@ -125,9 +125,9 @@
                                 {% else %}
                                     alert-{{ message.tags }}
                                 {% endif %}
-                            {% endif %} d-flex align-items-center" role="alert">
+                            {% endif %} d-flex" role="alert">
 
-                            <svg class="bi flex-shrink-0 me-2" width="20" height="20" fill="currentColor" role="img" aria-label="{{ message.tags }}:">
+                            <svg class="bi flex-shrink-0 tp-msg-icon-margin" width="20" height="20" fill="currentColor" role="img" aria-label="{{ message.tags }}:">
                                 <use xlink:href="{% static 'img/icons.svg' %}#icon-{{ message.tags }}"/></svg>
                             <div>
                               {{ message }}

--- a/trustpoint/trustpoint/urls.py
+++ b/trustpoint/trustpoint/urls.py
@@ -32,7 +32,7 @@ last_modified_date = timezone.now()
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/', api.api.urls),
+    #path('api/', api.api.urls),
     path('users/', include('users.urls')),
     path('pki/', include('pki.urls.pki')),
     path('.well-known/est/', include('pki.urls.est')),

--- a/trustpoint/trustpoint/urls.py
+++ b/trustpoint/trustpoint/urls.py
@@ -32,7 +32,7 @@ last_modified_date = timezone.now()
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    #path('api/', api.api.urls),
+    path('api/', api.api.urls),
     path('users/', include('users.urls')),
     path('pki/', include('pki.urls.pki')),
     path('.well-known/est/', include('pki.urls.est')),

--- a/trustpoint/users/tasks.py
+++ b/trustpoint/users/tasks.py
@@ -2,7 +2,7 @@ import datetime
 from django.utils import timezone
 
 from devices.models import Device
-from pki.models import CertificateModel, IssuingCaModel, DomainModel
+from pki.models import CertificateModel, BaseCaModel, DomainModel
 from home.models import NotificationModel, NotificationMessage, NotificationStatus
 import logging
 
@@ -164,12 +164,12 @@ def check_issuing_ca_validity():
     current_time = timezone.now()
     expiring_threshold = current_time + datetime.timedelta(days=60)
 
-    expiring_issuing_cas = IssuingCaModel.objects.filter(
+    expiring_issuing_cas = BaseCaModel.objects.filter(
         issuing_ca_certificate__not_valid_after__lte=expiring_threshold,
         issuing_ca_certificate__not_valid_after__gt=current_time  # Still valid, not expired
     )
 
-    expired_issuing_cas = IssuingCaModel.objects.filter(
+    expired_issuing_cas = BaseCaModel.objects.filter(
         issuing_ca_certificate__not_valid_after__lte=current_time
     )
 

--- a/trustpoint/users/templates/users/login.html
+++ b/trustpoint/users/templates/users/login.html
@@ -14,9 +14,9 @@
                         {% else %}
                             alert-{{ message.tags }}
                         {% endif %}
-                    {% endif %} d-flex align-items-center" role="alert">
+                    {% endif %} d-flex" role="alert">
 
-                    <svg class="bi flex-shrink-0 me-2" width="20" height="20" fill="currentColor" role="img" aria-label="{{ message.tags }}:">
+                    <svg class="bi flex-shrink-0 tp-msg-icon-margin" width="20" height="20" fill="currentColor" role="img" aria-label="{{ message.tags }}:">
                         <use xlink:href="{% static 'img/icons.svg' %}#icon-{{ message.tags }}"/></svg>
                     <div>
                         {{ message }}


### PR DESCRIPTION
<!-- related issue number, remove if n/a -->
Related to #127, #122

**Description of changes**
Added Auto-Generated PKI
- Generates a root CA with a selectable key algorithm
- Safeguards to prevent operation in higher security levels than 1 (Basic).
- Disabling the auto-gen PKI revokes all (device) certificates and revokes + deletes the issuing CA
- Prominent warning to prevent accidental disabling of the auto-gen PKI
- Slightly changed revocation logic to no longer fail hard on revocation attempt with deleted CA (#118)
- Improved icon rendering on multiline messages

**Notes** <!-- optional -->
`reset_db` is probably required as the IssuingCAModel database structure was changed to a BaseCAModel with proxy classes for root and issuing CAs (to prevent our CA management APIs and views to modify root CAs)

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.