### PR TITLE
Configurable mDNS host in Django settings

### DIFF
--- a/trustpoint/discovery/mdns.py
+++ b/trustpoint/discovery/mdns.py
@@ -5,6 +5,8 @@ import logging
 import socket
 from time import sleep
 
+from django.conf import settings
+
 from zeroconf import IPVersion, ServiceInfo, Zeroconf
 from util.network import get_local_ip
 
@@ -20,12 +22,10 @@ class TrustpointMDNSResponder:
         self.info = ServiceInfo(
             "_http._tcp.local.",
             "trustpoint._http._tcp.local.",
-            # TODO(Air): Do not hardcode IP + port
             # get_local_ip() works, but only for IPv4 without NAT
-            addresses=[socket.inet_aton("127.0.0.1"),
-                       #socket.inet_aton(get_local_ip())
+            addresses=[socket.inet_aton(settings.ADVERTISED_HOST),
                       ],
-            port=443, # TODO: Do not hardcode port
+            port=settings.ADVERTISED_PORT,
             #properties=desc,
             server="tp.local.",
         )

--- a/trustpoint/pki/management/commands/create_tls_certs.py
+++ b/trustpoint/pki/management/commands/create_tls_certs.py
@@ -31,7 +31,9 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs) -> None:
         one_day = datetime.timedelta(1, 0, 0)
         ipv4_addresses = subprocess.check_output('hostname -I', shell=True).decode().strip()
+        #ipv4_addresses = '10.10.0.5 10.10.4.89'
         ipv4_addresses = ipv4_addresses.split(' ')
+        ipv4_addresses.append('127.0.0.1')
         basic_constraints_extension = x509.BasicConstraints(ca=False, path_length=None)
         key_usage_extension = x509.KeyUsage(
             digital_signature=True,

--- a/trustpoint/trustpoint/settings.py
+++ b/trustpoint/trustpoint/settings.py
@@ -31,6 +31,9 @@ DEBUG = True
 
 ALLOWED_HOSTS = ['*']
 
+# mDNS service discovery advertisement
+ADVERTISED_HOST = '127.0.0.1'
+ADVERTISED_PORT = 443
 
 # Application definition
 


### PR DESCRIPTION
<!-- related issue number, remove if n/a -->
Related to #114 

**Description of changes**
Added config variables for the mDNS service broadcast IP and port to django settings.py.
If possible, we'd want to pass a default from Apache in a production enviroment.
Still, it needs to be added to SysConf Network settings for 1.0.0 as even Apache is not aware of the final Trustpoint address due to factors like which interface is used, NATs, ...

**Notes** <!-- optional -->
These are the changes required on the Trustpoint-side to make Client and Zero-Touch Demo onboarding work regardless of IP and port. For the corresponding PR to the client, see https://github.com/TrustPoint-Project/trustpoint-client/pull/8

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.