### PR TITLE
Fix Mngt command to create test CA

### DIFF
--- a/trustpoint/pki/management/commands/base_commands.py
+++ b/trustpoint/pki/management/commands/base_commands.py
@@ -128,7 +128,7 @@ class CertificateCreationCommandMixin:
             intermediate_ca_certs.append(CertificateModel.save_certificate(cert))
 
         issuing_ca_model = IssuingCaModel()
-        issuing_ca_model.unique_name = 'Issuing CA'
+        issuing_ca_model.unique_name = 'issuing_ca'
         issuing_ca_model.issuing_ca_certificate = issuing_ca_cert_model
         issuing_ca_model.root_ca_certificate = root_ca_cert_model
         issuing_ca_model.private_key_pem = private_key.private_bytes(

--- a/trustpoint/pki/management/commands/create_test_issuing_ca.py
+++ b/trustpoint/pki/management/commands/create_test_issuing_ca.py
@@ -34,8 +34,8 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
             encipher_only=False
         )
 
-        root_1, root_1_key = self.create_root_ca('Root CA')
-        issuing_1, issuing_1_key = self.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA', validity_days=50)
+        root_1, root_1_key = self.create_root_ca('root_ca')
+        issuing_1, issuing_1_key = self.create_issuing_ca(root_1_key, 'root_ca', 'issuing_ca', validity_days=50)
 
         self.store_issuing_ca(issuing_1, [root_1], issuing_1_key, 'issuing_ca.p12')
         self.save_issuing_ca(issuing_1, root_1, [], issuing_1_key)
@@ -48,7 +48,7 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
             validity_days = random_integer * sign
             ee, key = self.create_ee(
                 issuer_private_key=issuing_1_key,
-                issuer_cn='Issuing CA',
+                issuer_cn='issuing_ca',
                 subject_cn=f'EE {i}',
                 key_usage_extension=key_usage_extension,
                 validity_days=validity_days


### PR DESCRIPTION
**Description of changes**
Updated base_commands.py and create_test_issuing_a.py due to an error that root and issuing CAs must not contain spaces

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.