### PR TITLE
Fix CRL scheduler

### DIFF
--- a/trustpoint/pki/signals.py
+++ b/trustpoint/pki/signals.py
@@ -34,6 +34,9 @@ def initial_database_connection(sender, connection, **kwargs):
     global crl_thread_started
     if crl_thread_started:
         return
-    crl_thread_started = True
 
     logger.info('Initial database connection established: %s', connection.alias)
+
+    from .tasks import start_crl_generation_thread
+    start_crl_generation_thread()
+    crl_thread_started = True


### PR DESCRIPTION
**Description of changes**
- Fixed timezone-naive datetime object
- Fixed heapq exception if two CRLs are scheduled for the same time (tuple comparison tried to compare CA models)
- Fixed CRL being always generated on server start even if not due yet

**Notes** <!-- optional -->
Long-term we might want to integrate CRL scheduler into the Task Scheduler used for notifications. I would keep them separate for the beta release however.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.