### PR TITLE
Save additional infos to certificate

### DIFF
--- a/trustpoint/devices/models.py
+++ b/trustpoint/devices/models.py
@@ -176,6 +176,14 @@ class Device(models.Model):
             return None
 
     @classmethod
+    def get_by_name(cls: Device, device_name: str) -> Device | None:
+        """Returns the device with a given name."""
+        try:
+            return cls.objects.get(device_name=device_name)
+        except cls.DoesNotExist:
+            return None
+
+    @classmethod
     def check_onboarding_prerequisites(
             cls: Device, device_id: int,
             allowed_onboarding_protocols: list[Device.OnboardingProtocol]) -> tuple[bool, str | None]:

--- a/trustpoint/pki/__init__.py
+++ b/trustpoint/pki/__init__.py
@@ -27,7 +27,8 @@ class CertificateStatus(models.TextChoices):
 class CaLocalization(models.TextChoices):
     """The localization of the CA.
 
-    Auto-Gen PKI is a special case of the local CA, where the root CA is self-signed by the system."""
+    Auto-Gen PKI is a special case of the local CA, where the root CA is self-signed by the system.
+    """
     LOCAL = "L", _('Local')
     REMOTE = "R", _('Remote')
     AUTO_GEN_PKI = "A", _('AutoGenPKI')
@@ -40,5 +41,5 @@ class CertificateTypes(models.TextChoices):
 
 class TemplateName(models.TextChoices):
     GENERIC = 'Generic', _('Generic')
-    TLSSERVER = 'TLS_Server', _('TLS Server')
-    
+    TLSSERVER = 'TLS-Server', _('TLS Server')
+    TLSCLIENT = 'TLS-Client', _('TLS Client')


### PR DESCRIPTION
**Description of changes**
Parses the device unique name and adds the relation between cmp issued application certs to device.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.