### PR TITLE
Adapt zero touch aoki onboarding to new client revision

### DIFF
--- a/trustpoint/devices/tables.py
+++ b/trustpoint/devices/tables.py
@@ -114,7 +114,7 @@ class DeviceTable(tables.Table):
             )
         if record.device_onboarding_status == Device.DeviceOnboardingStatus.REVOKED:
             return format_html(
-                '<a href="{}" class="btn btn btn-info tp-onboarding-btn">{}</a>',
+                '<a href="{}" class="btn btn-info tp-onboarding-btn">{}</a>',
                 reverse('onboarding:manual-client', kwargs={'device_id': record.pk}),
                 _('Onboard again')
             )
@@ -145,6 +145,11 @@ class DeviceTable(tables.Table):
             return format_html(
                 '<a href="onboarding/reset/{}/" class="btn btn-warning tp-onboarding-btn">{}</a>',
                 record.pk, _('Reset Context')
+            )
+        if record.device_onboarding_status == Device.DeviceOnboardingStatus.REVOKED:
+            return format_html(
+                '<button class="btn btn-info tp-onboarding-btn" disabled>{}</a>',
+                _('Revoked')
             )
         raise UnknownOnboardingStatusError(record.device_onboarding_status)
 

--- a/trustpoint/onboarding/crypto_backend.py
+++ b/trustpoint/onboarding/crypto_backend.py
@@ -163,7 +163,7 @@ class CryptoBackend:
         if not isinstance(cert_model, CertificateModel):
             exc_msg = 'PKI response error: not a certificate: %s' % cert_model
             raise OnboardingError(exc_msg)
-        
+
         try: # Extract device serial number from LDevID subject
             sn = cert_model.get_subject_attributes_for_oid(NameOid.SERIAL_NUMBER)[0].value
             device.device_serial_number = sn

--- a/trustpoint/onboarding/models.py
+++ b/trustpoint/onboarding/models.py
@@ -284,9 +284,6 @@ class LDevIDOnboardingProcessMixin():
             raise
         if ldevid:
             self.state = OnboardingProcessState.LDEVID_SENT
-            if isinstance(self, AokiOnboardingProcess):
-                self._success()
-                self.cancel()
             log.info(f'LDevID issued for device {self.device.device_name} in onboarding process {self.id}.')
         else:
             self._fail('No LDevID was generated.')
@@ -305,6 +302,8 @@ class LDevIDOnboardingProcessMixin():
             raise
 
         self._success()
+        if isinstance(self, AokiOnboardingProcess):
+            self.cancel()
         return chain
 
 

--- a/trustpoint/onboarding/schema.py
+++ b/trustpoint/onboarding/schema.py
@@ -27,3 +27,6 @@ class AokiFinalizationResponseSchema(Schema):
     """Schema for the server response to the finalization message sent by the client."""
     otp: str
     device: str
+    domain: str
+    signature_suite: str
+    pki_protocol: str


### PR DESCRIPTION
**Description of changes**
Zero-touch onboarding was not functional with new changes to the Trustpoint client `provision_auto()` method. This PR contains the required changes on the Trustpoint side to restore AOKI functionality.

**Notes** <!-- optional -->
Associated client commit: https://github.com/TrustPoint-Project/trustpoint-client/commit/a3154049f392f74c458fe0b17fbc26aa65dd36ce

TODO: add a docs page explaining how to use the zero-touch demo

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.