### PR TITLE
Fix hardcoded SECP256R1 EC Key for newly issued certificates.

### DIFF
--- a/trustpoint/onboarding/api.py
+++ b/trustpoint/onboarding/api.py
@@ -9,15 +9,13 @@ import logging
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import ec
-from sphinx.util.inspect import signature
+from pki.util.keys import SignatureSuite
 
 from devices.models import Device
 from django.http import HttpRequest, HttpResponse
 from ninja import Router, Schema
 from ninja.responses import Response, codes_4xx
 from pathlib import Path
-from enum import Enum
 
 from onboarding.crypto_backend import CryptoBackend as Crypt
 from onboarding.crypto_backend import VerificationError, OnboardingError
@@ -38,14 +36,6 @@ from onboarding.schema import (
 )
 from pki import ReasonCode
 from pki.models import CertificateModel, TrustStoreModel, DomainModel
-
-class SignatureSuite(Enum):
-
-    RSA2048 = 'RSA2048SHA256'
-    RSA3072 = 'RSA3072SHA256'
-    RSA4096 = 'RSA4096SHA256'
-    SECP256R1 = 'SECP256R1SHA256'
-    SECP384R1 = 'SECP384R1SHA384'
 
 log = logging.getLogger('tp.onboarding')
 

--- a/trustpoint/onboarding/api.py
+++ b/trustpoint/onboarding/api.py
@@ -9,7 +9,7 @@ import logging
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
-from pki.util.keys import SignatureSuite
+from pki.util.keys import SignatureSuite, DigitalSignature
 
 from devices.models import Device
 from django.http import HttpRequest, HttpResponse
@@ -248,10 +248,11 @@ def aoki_init(request: HttpRequest, data: AokiInitMessageSchema):
         'server_tls_cert': Crypt.get_server_tls_cert(),	
     }
     response_bytes = str(response).encode()
-    hash = hashes.Hash(hashes.SHA256())
-    hash.update(response_bytes)
-    log.debug(f'SHA-256 hash of message: {hash.finalize().hex()}')
-    server_signature = ownership_private_key.sign(data=response_bytes, signature_algorithm=ec.ECDSA(hashes.SHA256()))
+    # hash = hashes.Hash(hashes.SHA256())
+    # hash.update(response_bytes)
+    # log.debug(f'SHA-256 hash of message: {hash.finalize().hex()}')
+    server_signature = DigitalSignature.sign(data=response_bytes, private_key=ownership_private_key)
+    #server_signature = ownership_private_key.sign(data=response_bytes, signature_algorithm=server_signature_suite.value)
     print(server_signature)
     server_signature = base64.b64encode(server_signature).decode()
     print(f'Server signature: {server_signature}')

--- a/trustpoint/onboarding/crypto_backend.py
+++ b/trustpoint/onboarding/crypto_backend.py
@@ -18,6 +18,7 @@ from django.db import transaction
 from pki import CertificateTypes, TemplateName
 from pki.oid import NameOid
 from pki.models import CertificateModel
+from pki.util.keys import DigitalSignature
 from pki.pki.request.handler.factory import CaRequestHandlerFactory
 from pki.pki.request.message.rest import PkiRestCsrRequestMessage, PkiRestPkcs12RequestMessage
 from util.strings import StringValidator
@@ -278,4 +279,4 @@ class CryptoBackend:
             raise VerificationError(exc_msg) from e
         
         # print(f'signature: {signature}')
-        signer_public_key.verify(signature=signature, data=message, signature_algorithm=ec.ECDSA(hashes.SHA256()))
+        DigitalSignature.verify(signature=signature, data=message, public_key=signer_public_key)

--- a/trustpoint/pki/initializer/issuing_ca/key_gen.py
+++ b/trustpoint/pki/initializer/issuing_ca/key_gen.py
@@ -8,7 +8,7 @@ from pki.issuing_ca import UnprotectedLocalIssuingCa
 from pki.models import RootCaModel
 from pki.serializer import CertificateCollectionSerializer
 from pki.util.ca import CaGenerator
-from pki.util.keys import KeyAlgorithm, KeyGenerator
+from pki.util.keys import SignatureSuite, KeyGenerator
 
 from .local import LocalIssuingCaInitializer
 
@@ -19,10 +19,10 @@ class KeyGenLocalIssuingCaInitializer(LocalIssuingCaInitializer, abc.ABC):
 
 class UnprotectedKeyGenLocalCaInitializer(KeyGenLocalIssuingCaInitializer):
     """Base class for unprotected local CA initializers."""
-    _key_algorithm: KeyAlgorithm
+    _key_algorithm: SignatureSuite
     _ca_localization: CaLocalization = CaLocalization.AUTO_GEN_PKI
 
-    def __init__(self, unique_name: str, key_algorithm: KeyAlgorithm, auto_crl: bool = True) -> None:
+    def __init__(self, unique_name: str, key_algorithm: SignatureSuite, auto_crl: bool = True) -> None:
         self._unique_name = unique_name
         self._auto_crl = auto_crl
         self._key_algorithm = key_algorithm
@@ -58,7 +58,7 @@ class UnprotectedKeyGenLocalIssuingCaInitializer(UnprotectedKeyGenLocalCaInitial
     """Responsible for initializing the local issuing (subordinate) CA."""
     _root_ca: UnprotectedLocalIssuingCa
 
-    def __init__(self, unique_name: str, key_algorithm: KeyAlgorithm,
+    def __init__(self, unique_name: str, key_algorithm: SignatureSuite,
                  root_ca: UnprotectedLocalIssuingCa, auto_crl: bool = True) -> None:
         """Initialize the arguments."""
         self._unique_name = unique_name

--- a/trustpoint/pki/pki/cmp/protection/signature_protection.py
+++ b/trustpoint/pki/pki/cmp/protection/signature_protection.py
@@ -2,9 +2,9 @@ from pyasn1_modules import rfc4210
 from pyasn1.codec.der import encoder
 from pyasn1.type import univ, tag
 import cryptography.hazmat.primitives.hashes as hashes
-from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives.asymmetric import padding, rsa, ec
 from cryptography import x509
-
+from pki.util.keys import DigitalSignature
 
 class SignatureProtection:
     """
@@ -16,7 +16,7 @@ class SignatureProtection:
         client_public_key (rsa.RSAPublicKey): The client's public key extracted from the certificate.
     """
 
-    def __init__(self, ca_private_key: rsa.RSAPrivateKey, authorized_clients: list):
+    def __init__(self, ca_private_key: rsa.RSAPrivateKey | ec.EllipticCurvePrivateKey, authorized_clients: list):
         """
         Initializes the SignatureProtection with a CA private key and a client certificate.
 
@@ -45,12 +45,7 @@ class SignatureProtection:
 
         encoded_protected_part = encoder.encode(protected_part)
 
-        signature = self.ca_private_key.sign(
-            encoded_protected_part,
-            padding.PKCS1v15(),
-            hashes.SHA256()
-        )
-
+        signature = DigitalSignature.sign(encoded_protected_part, self.ca_private_key)
 
         self.response_protection = rfc4210.PKIProtection(univ.BitString.fromOctetString(signature)).subtype(
             explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))

--- a/trustpoint/pki/pki/cmp/protection/signature_protection.py
+++ b/trustpoint/pki/pki/cmp/protection/signature_protection.py
@@ -1,10 +1,12 @@
 from pyasn1_modules import rfc4210
 from pyasn1.codec.der import encoder
 from pyasn1.type import univ, tag
-import cryptography.hazmat.primitives.hashes as hashes
-from cryptography.hazmat.primitives.asymmetric import padding, rsa, ec
-from cryptography import x509
 from pki.util.keys import DigitalSignature
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cryptography.hazmat.primitives.asymmetric import rsa, ec
 
 class SignatureProtection:
     """
@@ -75,12 +77,13 @@ class SignatureProtection:
         # for cert in self.authorized_clients:
         #     authorized_pub_key = cert.public_key()
         #     try:
-        #         authorized_pub_key.verify(
-        #             signature,
-        #             encoded_protected_part,
-        #             padding.PKCS1v15(),
-        #             hashes.SHA256()
-        #         )
+        #         DigitalSignature.verify(signature, encoded_protected_part, authorized_pub_key)
+        #         #authorized_pub_key.verify(
+        #         #    signature,
+        #         #    encoded_protected_part,
+        #         #    padding.PKCS1v15(),
+        #         #    hashes.SHA256()
+        #         #)
         #         print("Verification successful: The signature of the protection is correct.")
         #         verification_status = True
         #         break

--- a/trustpoint/pki/pki/request/handler/messagehandler/cert_message_handler.py
+++ b/trustpoint/pki/pki/request/handler/messagehandler/cert_message_handler.py
@@ -17,6 +17,7 @@ from pki.models import CertificateModel
 from pki.pki.cmp.builder import PkiBodyCreator, PKIMessageCreator, PKIHeaderCreator, ExtraCerts
 from pki.pki.cmp.validator import ExtraCertsValidator, InitializationReqValidator
 from pki.oid import CertificateExtensionOid
+from pki.util.keys import SignatureSuite
 
 
 class CertMessageHandler:
@@ -643,8 +644,8 @@ class CertMessageHandler:
         #     subject_key_identifier,
         #     critical=False,
         # )
-
-        cert = cert_builder.sign(ca_key, hashes.SHA256())
+        hash_algorithm = SignatureSuite.get_hash_algorithm_by_key(ca_key)
+        cert = cert_builder.sign(ca_key, hash_algorithm)
 
         CertificateModel.save_certificate(cert)
 

--- a/trustpoint/pki/pki/request/handler/rest.py
+++ b/trustpoint/pki/pki/request/handler/rest.py
@@ -11,7 +11,7 @@ from pki.pki.request.handler import CaRequestHandler
 from pki.models import CertificateModel
 from pki.serializer.certificate import CertificateSerializer
 from pki.serializer.credential import CredentialSerializer
-from pki.util.keys import KeyAlgorithm, KeyGenerator
+from pki.util.keys import KeyGenerator, SignatureSuite
 
 from typing import TYPE_CHECKING
 
@@ -107,8 +107,9 @@ class LocalCaRestPkcs12RequestHandler(CaRestRequestHandler):
     _issuing_ca: UnprotectedLocalIssuingCa
 
     def process_request(self) -> PkiResponseMessage:
-        # TODO (Air): Automatically use the same key algorithm as the issuing CA
-        private_key = KeyGenerator(KeyAlgorithm.SECP256R1).generate_key()
+        signature_suite = SignatureSuite.get_signature_suite_by_public_key(
+            self._issuing_ca.get_issuing_ca_public_key_serializer().as_crypto())
+        private_key = KeyGenerator(signature_suite).generate_key()
         public_key = private_key.public_key()
 
         cert_builder = x509.CertificateBuilder()

--- a/trustpoint/pki/pki/request/handler/rest.py
+++ b/trustpoint/pki/pki/request/handler/rest.py
@@ -118,7 +118,7 @@ class LocalCaRestPkcs12RequestHandler(CaRestRequestHandler):
         cert_builder = self._ldevid_add_common_cert_components(cert_builder, public_key)
         cert = cert_builder.sign(
             private_key=self._issuing_ca.private_key,
-            algorithm=hashes.SHA256())
+            algorithm=SignatureSuite.get_hash_algorithm_by_key(public_key))
 
         cert_model = CertificateModel.save_certificate(certificate=cert)
 

--- a/trustpoint/pki/tests/certificate_builder.py
+++ b/trustpoint/pki/tests/certificate_builder.py
@@ -7,6 +7,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa, ec
 from cryptography.x509.oid import NameOID
 import datetime
 
+from pki.util.keys import SignatureSuite
 
 class CertificateBuilder:
     _builder: x509.CertificateBuilder = x509.CertificateBuilder()
@@ -47,6 +48,6 @@ class CertificateBuilder:
 
     def create_cert(self) -> CertificateBuilder:
         self._certificate = self._builder.sign(
-            private_key=self._private_key, algorithm=hashes.SHA256(),
+            private_key=self._private_key, algorithm=SignatureSuite.get_hash_algorithm_by_key(self._private_key)
         )
         return self

--- a/trustpoint/pki/util/ca.py
+++ b/trustpoint/pki/util/ca.py
@@ -3,6 +3,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.types import CertificatePublicKeyTypes, PrivateKeyTypes
 
+from pki.util.keys import SignatureSuite
 
 class CaGenerator:
     @staticmethod
@@ -53,7 +54,7 @@ class CaGenerator:
         ).add_extension(
             x509.AuthorityKeyIdentifier.from_issuer_public_key(signing_key.public_key()), critical=False
         ).sign(
-            signing_key, hashes.SHA256(), default_backend()
+            signing_key, SignatureSuite.get_hash_algorithm_by_key(signing_key), default_backend()
         )
 
         return certificate

--- a/trustpoint/pki/util/keys.py
+++ b/trustpoint/pki/util/keys.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from enum import Enum
 
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
@@ -5,12 +6,34 @@ from cryptography.hazmat.backends import default_backend
 
 from django.db import models
 
-class KeyAlgorithm(Enum):
-    RSA2048 = 'RSA2048'
-    RSA4096 = 'RSA4096'
-    SECP256R1 = 'SECP256R1'
-    SECP384R1 = 'SECP384R1'
-    SECP521R1 = 'SECP521R1'
+class SignatureSuite(Enum):
+
+    RSA2048 = 'RSA2048SHA256'
+    RSA3072 = 'RSA3072SHA256'
+    RSA4096 = 'RSA4096SHA256'
+    SECP256R1 = 'SECP256R1SHA256'
+    SECP384R1 = 'SECP384R1SHA384'
+
+    @classmethod
+    def get_signature_suite_by_public_key(
+            cls, public_key: rsa.RSAPublicKey | ec.EllipticCurvePublicKey) -> SignatureSuite:
+        if isinstance(public_key, rsa.RSAPublicKey):
+            if public_key.key_size == 2048:
+                return cls.RSA2048
+            if public_key.key_size == 3072:
+                return cls.RSA3072
+            if public_key.key_size == 4096:
+                return cls.RSA4096
+            raise ValueError
+
+        if isinstance(public_key, ec.EllipticCurvePublicKey):
+            if isinstance(public_key.curve, ec.SECP256R1):
+                return cls.SECP256R1
+            if isinstance(public_key.curve, ec.SECP384R1):
+                return cls.SECP384R1
+            raise ValueError
+
+        raise ValueError
 
 class AutoGenPkiKeyAlgorithm(models.TextChoices):
     RSA2048 = 'RSA2048', 'RSA2048'
@@ -18,25 +41,25 @@ class AutoGenPkiKeyAlgorithm(models.TextChoices):
     SECP256R1 = 'SECP256R1', 'SECP256R1'
     # omitting the rest of the choices as an example that Auto Gen PKI doesn't have to support all key algorithms
 
-    def to_key_algorithm(self) -> KeyAlgorithm:
-        return KeyAlgorithm(str(self))
+    def to_key_algorithm(self) -> SignatureSuite:
+        return SignatureSuite(str(self))
 
 class KeyGenerator:
-    def __init__(self, algorithm: KeyAlgorithm):
+    def __init__(self, algorithm: SignatureSuite):
         self._algorithm = algorithm
 
     def generate_key(self):
         """Generates a private key."""
         match self._algorithm:
-            case KeyAlgorithm.SECP256R1:
+            case SignatureSuite.SECP256R1:
                 key = ec.generate_private_key(ec.SECP256R1(), backend=default_backend())
-            case KeyAlgorithm.SECP384R1:
+            case SignatureSuite.SECP384R1:
                 key = ec.generate_private_key(ec.SECP384R1(), backend=default_backend())
-            case KeyAlgorithm.SECP521R1:
-                key = ec.generate_private_key(ec.SECP521R1(), backend=default_backend())
-            case KeyAlgorithm.RSA2048:
+            case SignatureSuite.RSA2048:
                 key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
-            case KeyAlgorithm.RSA4096:
+            case SignatureSuite.RSA2048:
+                key = rsa.generate_private_key(public_exponent=65537, key_size=3072, backend=default_backend())
+            case SignatureSuite.RSA4096:
                 key = rsa.generate_private_key(public_exponent=65537, key_size=4096, backend=default_backend())
             case _:  # Invalid algorithm
                 raise ValueError("Unsupported key algorithm type")

--- a/trustpoint/pki/util/keys.py
+++ b/trustpoint/pki/util/keys.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 from enum import Enum
 
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.backends import default_backend
 
 from django.db import models
@@ -34,10 +36,25 @@ class SignatureSuite(Enum):
             raise ValueError
 
         raise ValueError
+    
+    @classmethod
+    def get_hash_algorithm_by_key(
+        cls, key: rsa.RSAPublicKey | ec.EllipticCurvePublicKey
+              | rsa.RSAPrivateKey | ec.EllipticCurvePrivateKey) -> hashes.HashAlgorithm:
+        """Returns the hash algorithm based on the public or private key type
+
+        SHA384 is used for EC keys with the SECP384R1 curve, otherwise SHA256 is used.
+        """
+        if isinstance(key, ec.EllipticCurvePublicKey) or isinstance(key, ec.EllipticCurvePrivateKey):
+            if isinstance(key.curve, ec.SECP384R1):
+                return hashes.SHA384()
+            
+        return hashes.SHA256()
+
 
 class AutoGenPkiKeyAlgorithm(models.TextChoices):
-    RSA2048 = 'RSA2048', 'RSA2048'
-    RSA4096 = 'RSA4096', 'RSA4096'
+    RSA2048 = 'RSA2048SHA256', 'RSA2048'
+    RSA4096 = 'RSA4096SHA256', 'RSA4096'
     SECP256R1 = 'SECP256R1', 'SECP256R1'
     # omitting the rest of the choices as an example that Auto Gen PKI doesn't have to support all key algorithms
 
@@ -65,3 +82,54 @@ class KeyGenerator:
                 raise ValueError("Unsupported key algorithm type")
 
         return key
+    
+class DigitalSignature:
+    """A class that uses an appropriate digital signature algortihm based on the key type.
+    
+    Uses the RSA-PKCS1.5 signature scheme for RSA keys and ECDSA for EC keys."""
+
+    @staticmethod
+    def sign(data: bytes, private_key: rsa.RSAPrivateKey | ec.EllipticCurvePrivateKey) -> bytes:
+        if isinstance(private_key, rsa.RSAPrivateKey):
+            return private_key.sign(
+                data,
+                padding=padding.PKCS1v15(),
+                # padding.PSS(
+                #     mgf=padding.MGF1(hashes.SHA256()),
+                #     salt_length=padding.PSS.MAX_LENGTH
+                # ),
+                hash=hashes.SHA256()
+            )
+        if isinstance(private_key, ec.EllipticCurvePrivateKey):
+            if isinstance(private_key.curve, ec.SECP256R1):
+                return private_key.sign(data, signature_algorithm=ec.ECDSA(hashes.SHA256()))
+            if isinstance(private_key.curve, ec.SECP384R1):
+                return private_key.sign(data, signature_algorithm=ec.ECDSA(hashes.SHA384()))
+            raise ValueError
+        
+        raise ValueError
+    
+    @staticmethod
+    def verify(signature: bytes, data: bytes, public_key: rsa.RSAPublicKey | ec.EllipticCurvePublicKey) -> None:
+        if isinstance(public_key, rsa.RSAPublicKey):
+            public_key.verify(
+                signature,
+                data,
+                padding=padding.PKCS1v15(),
+                # padding.PSS(
+                #     mgf=padding.MGF1(hashes.SHA256()),
+                #     salt_length=padding.PSS.MAX_LENGTH
+                # ),
+                hash=hashes.SHA256()
+            )
+            return True
+        if isinstance(public_key, ec.EllipticCurvePublicKey):
+            if isinstance(public_key.curve, ec.SECP256R1):
+                public_key.verify(signature, data, signature_algorithm=ec.ECDSA(hashes.SHA256()))
+                return True
+            if isinstance(public_key.curve, ec.SECP384R1):
+                public_key.verify(signature, data, signature_algorithm=ec.ECDSA(hashes.SHA384()))
+                return True
+            raise ValueError
+        
+        raise ValueError

--- a/trustpoint/sysconf/models.py
+++ b/trustpoint/sysconf/models.py
@@ -62,7 +62,7 @@ class SecurityConfig(models.Model):
     security_mode = models.CharField(max_length=6, choices=SecurityModeChoices.choices, default=SecurityModeChoices.LOW)
 
     auto_gen_pki = models.BooleanField(default=False)
-    auto_gen_pki_key_algorithm = models.CharField(max_length=12,
+    auto_gen_pki_key_algorithm = models.CharField(max_length=24,
                                                   choices=AutoGenPkiKeyAlgorithm,
                                                   default=AutoGenPkiKeyAlgorithm.RSA2048)
 

--- a/trustpoint/util/protocols/est_remote.py
+++ b/trustpoint/util/protocols/est_remote.py
@@ -16,6 +16,7 @@ from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.hazmat.primitives.serialization import pkcs7
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from pki.models import IssuingCa
+from pki.util.keys import SignatureSuite
 from requests import Response, auth, get, post
 
 from util.x509.credentials import CredentialUploadHandler
@@ -67,7 +68,7 @@ class ESTProtocolHandler:
         csr = (
             x509.CertificateSigningRequestBuilder()
             .subject_name(subject_)
-            .sign(key, hashes.SHA256(), default_backend())
+            .sign(key, SignatureSuite.get_hash_algorithm_by_key(key), default_backend())
         )
 
         # Return PEM encoded key and CSR


### PR DESCRIPTION
**Description of changes**
Fix hardcoded SECP256R1 EC Key for newly issued certificates.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ x ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.