### PR TITLE
renamed provision to onboard

### DIFF
--- a/trustpoint/onboarding/cli_builder.py
+++ b/trustpoint/onboarding/cli_builder.py
@@ -27,7 +27,7 @@ class CliCommandBuilder:
                 return f' -{short_flag} {val}'
             return f' --{key} {val}'
 
-        cmd = 'trustpoint-client provision auto'
+        cmd = 'trustpoint-client onboard auto'
         cmd += _flag('otp', 'o')
         cmd += _flag('device', 'd')
         cmd += _flag('host', 'h')


### PR DESCRIPTION
**Description of changes**
Renamed the command for the client for the onboarding process.
provision -> onboard

**Notes**
We should use the term provision for injecting the IDevID only, but not for the actual onboarding process.


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ x ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.