### PR TITLE
lock-db-fix (quick hack)

### DIFF
--- a/trustpoint/users/scheduler.py
+++ b/trustpoint/users/scheduler.py
@@ -50,9 +50,10 @@ class TaskScheduler:
         Schedule periodic tasks using a thread pool and sleep for the given interval.
         """
         logger.info("Setting up periodic tasks...")
-        with ThreadPoolExecutor(max_workers=len(self.periodic_tasks)) as self.executor:
+        with ThreadPoolExecutor(max_workers=1) as self.executor:
             while True:
                 logger.info("Triggering periodic tasks.")
+                time.sleep(5)
                 futures = [self.run_task(task_func) for task_func in self.periodic_tasks.values()]
 
                 for future in as_completed(futures):


### PR DESCRIPTION
**Description of changes**
Quick fix for the db-lock issue on server startup.

**Notes**
Just a sleep for now and reduced the workers to 1.
This must be properly resolved in the future.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ x ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.