### PR TITLE
Bump trustpoint version to 0.2.0-dev

### DIFF
--- a/.github/workflows/docker-manual.yml
+++ b/.github/workflows/docker-manual.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag trustpoint:${{ github.sha }} --tag trustpoint:v0.1.0
+      run: docker build . --file Dockerfile --tag trustpoint:${{ github.sha }} --tag trustpoint:v0.2.0-dev
     - name: Log in to Docker Hub
       uses: docker/login-action@v2
       with:
@@ -20,6 +20,6 @@ jobs:
     - name: Push the Docker image
       run: |
         docker tag trustpoint:${{ github.sha }} ${{ secrets.DOCKER_HUB_USERNAME }}/trustpoint:${{ github.sha }}
-        docker tag trustpoint:v0.1.0 ${{ secrets.DOCKER_HUB_USERNAME }}/trustpoint:v0.1.0
+        docker tag trustpoint:v0.2.0-dev ${{ secrets.DOCKER_HUB_USERNAME }}/trustpoint:v0.2.0-dev
         docker push ${{ secrets.DOCKER_HUB_USERNAME }}/trustpoint:${{ github.sha }}
-        docker push ${{ secrets.DOCKER_HUB_USERNAME }}/trustpoint:v0.1.0
+        docker push ${{ secrets.DOCKER_HUB_USERNAME }}/trustpoint:v0.2.0-dev

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,7 @@ PLANTUML_PATH = Path(__file__).parent.absolute() / Path('plantuml-mit-1.2024.6.j
 project = 'Trustpoint'
 copyright = '2024, Trustpoint Project'
 author = 'Trustpoint Project'
-release = '0.1.0'
+release = '0.2.0-dev'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "trustpoint"
-version = "0.1.0"
+version = "0.2.0-dev"
 description = "Trustpoint Server Software"
 authors = ["TrustPoint-Project"]
 readme = "README.md"

--- a/trustpoint/trustpoint/api.py
+++ b/trustpoint/trustpoint/api.py
@@ -21,7 +21,7 @@ class AuthBearer(HttpBearer):
 api = NinjaAPI(
     auth=(AuthBearer(), django_auth),
     title='Trustpoint API',
-    version='0.1.0'
+    version='0.2.0-dev'
 )
 
 api.add_router('/devices/', devices_router, tags=['Devices'])

--- a/trustpoint/trustpoint/templates/trustpoint/base.html
+++ b/trustpoint/trustpoint/templates/trustpoint/base.html
@@ -109,7 +109,7 @@
 
                 </div>
                 <div id="tp-version">
-                    v0.1.0
+                    v0.2.0-dev
                 </div>
             </div>
         </nav>


### PR DESCRIPTION
**Description of changes**
Bump the version number to `0.2.0-dev` as 0.1.0 release is complete.

**Notes**
This is only a proposal for the naming. We could also go with `0.2.0-alpha0` or `0.2.0-beta1` or similar.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.