### PR TITLE
docker static files fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,5 @@ tests/data/issuing_cas
 *.p12
 
 docs/build/
+
+collected_static

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,10 @@ RUN yes | python manage.py reset_db
 # change permission for db file
 RUN chmod 664 db.sqlite3
 
+# collect static files
+RUN python manage.py collectstatic --noinput
+
+
 # Change owner and group
 RUN chown -R www-data:www-data .
 

--- a/trustpoint-apache-https.conf
+++ b/trustpoint-apache-https.conf
@@ -2,7 +2,7 @@ WSGIPythonPath /var/www/html/trustpoint/trustpoint
 
 <VirtualHost *:443>
     DocumentRoot /var/www/html/trustpoint
-    Alias /static "/var/www/html/trustpoint/trustpoint/static"
+    Alias /static "/var/www/html/trustpoint/trustpoint/collected_static"
     WSGIScriptAlias / /var/www/html/trustpoint/trustpoint/trustpoint/wsgi.py
 
     SSLEngine on

--- a/trustpoint/trustpoint/settings.py
+++ b/trustpoint/trustpoint/settings.py
@@ -178,3 +178,5 @@ DJANGO_LOG_LEVEL = 'INFO'
 LOGGING = logging_config
 
 TAGGIT_CASE_INSENSITIVE = True
+
+STATIC_ROOT = 'collected_static'


### PR DESCRIPTION
Related to #186 

**Description of changes**
Properly executes python manage.py collectstatic while building the container.
STATIC_ROOT is set to collected_static and served by apache.


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ x ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.