### PR TITLE
add-test-data-container-fix (permissions / removed file storage from …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,5 @@ tests/data/issuing_cas
 docs/build/
 
 collected_static
+
+*.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,11 +55,6 @@ RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
     -subj "/C=DE/ST=BW/L=Stuttgart/O=Trustpoint/OU=Trustpoint/CN=localhost"
 
 
-## change permissions for files
-### TODO(AlexHx8472): Temporary. However, only test data lives in here. It's not a security issue here.
-#RUN chmod -R 777 /var/www/html/trustpoint/tests/data/
-
-
 # Copy Apache configuration
 ADD ./trustpoint-apache-http.conf /etc/apache2/sites-available/000-default.conf
 ADD ./trustpoint-apache-https.conf /etc/apache2/sites-available/localhost.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ RUN yes | python manage.py reset_db
 # change permission for db file
 RUN chmod 664 db.sqlite3
 
+
+
 # collect static files
 RUN python manage.py collectstatic --noinput
 
@@ -45,11 +47,17 @@ RUN python manage.py collectstatic --noinput
 # Change owner and group
 RUN chown -R www-data:www-data .
 
+
 # Generate self-signed certificates
 RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
  -keyout /etc/ssl/private/apache-selfsigned.key \
   -out /etc/ssl/certs/apache-selfsigned.crt  \
     -subj "/C=DE/ST=BW/L=Stuttgart/O=Trustpoint/OU=Trustpoint/CN=localhost"
+
+
+## change permissions for files
+### TODO(AlexHx8472): Temporary. However, only test data lives in here. It's not a security issue here.
+#RUN chmod -R 777 /var/www/html/trustpoint/tests/data/
 
 
 # Copy Apache configuration

--- a/trustpoint/home/views.py
+++ b/trustpoint/home/views.py
@@ -1,14 +1,20 @@
-import json
+import logging
 from django.views.generic.base import RedirectView, TemplateView
 from django.shortcuts import render, get_object_or_404, redirect
 from django_tables2 import RequestConfig
 from datetime import datetime, timedelta
+
+from django.contrib import messages
+
 from trustpoint.views.base import TpLoginRequiredMixin, ContextDataMixin
 from .filters import NotificationFilter
 from django.core.management import call_command
 
 from .models import NotificationModel, NotificationStatus
 from .tables import NotificationTable
+
+SUCCESS = 25
+ERROR = 40
 
 class IndexView(TpLoginRequiredMixin, RedirectView):
     permanent = False
@@ -104,20 +110,24 @@ def mark_as_solved(request, pk):
 class AddDomainsAndDevicesView(TpLoginRequiredMixin, TemplateView):
     """View to execute the add_domains_and_devices management command and pass status to the template."""
 
+    _logger = logging.getLogger(__name__)
+
     def get(self, request, *args, **kwargs):
-        context = {}
 
         try:
-            # Call the management command
             call_command('add_domains_and_devices')
 
-            # Define success message
-            context['status'] = 'success'
-            context['message'] = 'The add_domains_and_devices command has been executed successfully.'
+            messages.add_message(
+                request,
+                SUCCESS,
+                'Successfully added test data.'
+            )
         except Exception as e:
-            # Define error message
-            context['status'] = 'error'
-            context['message'] = f'Error executing command: {e}'
+            # TODO(AlexHx8472): Catch the correct and proper error messages.
+            messages.add_message(
+                request,
+                ERROR,
+                f'Test data already available in the Database.'
+            )
 
-        # Render the template with the context
-        return render(request, 'home/command_status.html', context)
+        return redirect('home:dashboard')

--- a/trustpoint/pki/management/commands/add_domains_and_devices.py
+++ b/trustpoint/pki/management/commands/add_domains_and_devices.py
@@ -9,32 +9,12 @@ from devices.models import Device
 from django.core.management import call_command
 from pki.initializer import UnprotectedFileImportLocalIssuingCaFromPkcs12Initializer
 
-BASE_DIR = Path(__file__).parent.parent.parent.parent.parent / 'tests/data/issuing_cas'
-ISSUING_CA_A_FILE_PATH = BASE_DIR / 'A.p12'
-ISSUING_CA_B_FILE_PATH = BASE_DIR / 'B.p12'
-ISSUING_CA_C_FILE_PATH = BASE_DIR / 'C.p12'
-P12_PW = b'testing321'
-
 
 class Command(BaseCommand):
     help = 'Add domains and associated device names with random onboarding protocol and serial number'
 
-    @classmethod
-    def _save_issuing_ca(cls, unique_name: str, file_path: Path) -> None:
-        initializer = UnprotectedFileImportLocalIssuingCaFromPkcs12Initializer(
-            unique_name=unique_name,
-            p12=file_path.read_bytes(),
-            password=P12_PW,
-            auto_crl=True)
-        initializer.initialize()
-        initializer.save()
-
     def handle(self, *args, **kwargs):
-        call_command('create_multiple_issuing_ca_files')
-
-        self._save_issuing_ca('issuing-ca-a', ISSUING_CA_A_FILE_PATH)
-        self._save_issuing_ca('issuing-ca-b', ISSUING_CA_B_FILE_PATH)
-        self._save_issuing_ca('issuing-ca-c', ISSUING_CA_C_FILE_PATH)
+        call_command('create_multiple_test_issuing_cas')
 
         data = {
             "arburg": [

--- a/trustpoint/pki/management/commands/add_domains_and_devices.py
+++ b/trustpoint/pki/management/commands/add_domains_and_devices.py
@@ -3,6 +3,7 @@ import random
 import string
 from pathlib import Path
 from django.core.management.base import BaseCommand
+
 from pki.models import DomainModel, IssuingCaModel
 from devices.models import Device
 from django.core.management import call_command
@@ -18,8 +19,8 @@ P12_PW = b'testing321'
 class Command(BaseCommand):
     help = 'Add domains and associated device names with random onboarding protocol and serial number'
 
-    @staticmethod
-    def _save_issuing_ca(unique_name: str, file_path: Path) -> None:
+    @classmethod
+    def _save_issuing_ca(cls, unique_name: str, file_path: Path) -> None:
         initializer = UnprotectedFileImportLocalIssuingCaFromPkcs12Initializer(
             unique_name=unique_name,
             p12=file_path.read_bytes(),

--- a/trustpoint/pki/management/commands/add_domains_and_devices_certs.py
+++ b/trustpoint/pki/management/commands/add_domains_and_devices_certs.py
@@ -10,33 +10,15 @@ from pki import CertificateTypes, TemplateName
 from django.core.management import call_command
 from pki.initializer import UnprotectedFileImportLocalIssuingCaFromPkcs12Initializer
 
-BASE_DIR = Path(__file__).parent.parent.parent.parent.parent / 'tests/data/issuing_cas'
-ISSUING_CA_A_FILE_PATH = BASE_DIR / 'A.p12'
-ISSUING_CA_B_FILE_PATH = BASE_DIR / 'B.p12'
-ISSUING_CA_C_FILE_PATH = BASE_DIR / 'C.p12'
-P12_PW = b'testing321'
-
 
 class Command(BaseCommand):
     help = 'Add domains, associated device names with random onboarding protocol and serial \
     number, and their certificates. make sure you have certificates added in the CertificateModel'
 
-    @staticmethod
-    def _save_issuing_ca(unique_name: str, file_path: Path) -> None:
-        initializer = UnprotectedFileImportLocalIssuingCaFromPkcs12Initializer(
-            unique_name=unique_name,
-            p12=file_path.read_bytes(),
-            password=P12_PW,
-            auto_crl=True)
-        initializer.initialize()
-        initializer.save()
 
     def handle(self, *args, **kwargs):
-        call_command('create_multiple_issuing_ca_files')
+        call_command('create_multiple_test_issuing_cas')
 
-        self._save_issuing_ca('issuing-ca-a', ISSUING_CA_A_FILE_PATH)
-        self._save_issuing_ca('issuing-ca-b', ISSUING_CA_B_FILE_PATH)
-        self._save_issuing_ca('issuing-ca-c', ISSUING_CA_C_FILE_PATH)
         certificates = CertificateModel.objects.all()
         certificate_list = list(certificates)
         certificate_types = [choice.value for choice in CertificateTypes]

--- a/trustpoint/pki/management/commands/base_commands.py
+++ b/trustpoint/pki/management/commands/base_commands.py
@@ -99,18 +99,18 @@ class CertificateCreationCommandMixin:
         )
         return certificate, private_key
 
-
-    @staticmethod
+    @classmethod
     def store_issuing_ca(
+            cls,
             issuing_ca_cert: x509.Certificate,
             chain: list[x509.Certificate],
             private_key: rsa.RSAPrivateKey,
             filename: str) -> None:
+
         tests_data_path = Path(__file__).parent.parent.parent.parent.parent / Path('tests/data/issuing_cas')
         issuing_ca_path = tests_data_path / Path(filename)
         # shutil.rmtree(tests_data_path, ignore_errors=True)
         tests_data_path.mkdir(exist_ok=True)
-
         print('\nSaving Issuing CA and Certificates\n')
 
         p12 = pkcs12.serialize_key_and_certificates(

--- a/trustpoint/pki/management/commands/base_commands.py
+++ b/trustpoint/pki/management/commands/base_commands.py
@@ -131,16 +131,17 @@ class CertificateCreationCommandMixin:
             issuing_ca_cert: x509.Certificate,
             root_ca_cert: x509.Certificate,
             chain: list[x509.Certificate],
-            private_key: rsa.RSAPrivateKey) -> None:
+            private_key: rsa.RSAPrivateKey,
+            unique_name: str ='issuing_ca') -> None:
         issuing_ca_cert_model = CertificateModel.save_certificate(issuing_ca_cert)
-        root_ca_cert_model = CertificateModel.save_certificate(root_ca_cert)
+        root_ca_cert_model = CertificateModel.save_certificate(root_ca_cert, exist_ok=True)
 
         intermediate_ca_certs = []
         for cert in chain:
             intermediate_ca_certs.append(CertificateModel.save_certificate(cert))
 
         issuing_ca_model = IssuingCaModel()
-        issuing_ca_model.unique_name = 'issuing_ca'
+        issuing_ca_model.unique_name = unique_name
         issuing_ca_model.issuing_ca_certificate = issuing_ca_cert_model
         issuing_ca_model.root_ca_certificate = root_ca_cert_model
         issuing_ca_model.private_key_pem = private_key.private_bytes(

--- a/trustpoint/pki/management/commands/create_multiple_issuing_ca_files.py
+++ b/trustpoint/pki/management/commands/create_multiple_issuing_ca_files.py
@@ -22,12 +22,6 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
     def handle(self, *args, **kwargs) -> None:
 
         root_1, root_1_key = self.create_root_ca('Root CA')
-        issuing_1, issuing_1_key = self.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA A')
-        issuing_2, issuing_2_key = self.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA B')
-        issuing_3, issuing_3_key = self.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA C')
-
-        self.store_issuing_ca(issuing_1, [root_1], issuing_1_key, 'A.p12')
-        self.store_issuing_ca(issuing_2, [root_1], issuing_2_key, 'B.p12')
-        self.store_issuing_ca(issuing_3, [root_1], issuing_3_key, 'C.p12')
-
-        self.store_issuing_ca(root_1, [], root_1_key, 'D_Root.p12')
+        _, _ = self.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA A')
+        _, _ = self.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA B')
+        _, _ = self.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA C')

--- a/trustpoint/pki/management/commands/create_multiple_test_issuing_cas.py
+++ b/trustpoint/pki/management/commands/create_multiple_test_issuing_cas.py
@@ -26,6 +26,6 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
         issuing_2, issuing_2_key = self.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA B')
         issuing_3, issuing_3_key = self.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA C')
 
-        self.save_issuing_ca(issuing_1, root_1, [], issuing_1_key, 'issuing_ca_a')
-        self.save_issuing_ca(issuing_2, root_1, [], issuing_2_key, 'issuing_ca_b')
-        self.save_issuing_ca(issuing_3, root_1, [], issuing_3_key, 'issuing_ca_c')
+        self.save_issuing_ca(issuing_1, root_1, [], issuing_1_key, 'issuing-ca-a')
+        self.save_issuing_ca(issuing_2, root_1, [], issuing_2_key, 'issuing-ca-b')
+        self.save_issuing_ca(issuing_3, root_1, [], issuing_3_key, 'issuing-ca-c')

--- a/trustpoint/pki/management/commands/create_multiple_test_issuing_cas.py
+++ b/trustpoint/pki/management/commands/create_multiple_test_issuing_cas.py
@@ -1,4 +1,4 @@
-"""Something."""
+"""Django management command for adding issuing CA test data."""
 
 
 from __future__ import annotations
@@ -17,11 +17,15 @@ PrivateKey = Union[rsa.RSAPrivateKey, ec.EllipticCurvePrivateKey, ed448.Ed448Pri
 class Command(CertificateCreationCommandMixin, BaseCommand):
     """Django management command for adding issuing CA test data."""
 
-    help = 'Removes all migrations, deletes db and runs makemigrations and migrate afterwards.'
+    help = 'Adds a Root CA and three issuing CAs to the database.'
 
     def handle(self, *args, **kwargs) -> None:
 
         root_1, root_1_key = self.create_root_ca('Root CA')
-        _, _ = self.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA A')
-        _, _ = self.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA B')
-        _, _ = self.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA C')
+        issuing_1, issuing_1_key = self.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA A')
+        issuing_2, issuing_2_key = self.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA B')
+        issuing_3, issuing_3_key = self.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA C')
+
+        self.save_issuing_ca(issuing_1, root_1, [], issuing_1_key, 'issuing_ca_a')
+        self.save_issuing_ca(issuing_2, root_1, [], issuing_2_key, 'issuing_ca_b')
+        self.save_issuing_ca(issuing_3, root_1, [], issuing_3_key, 'issuing_ca_c')


### PR DESCRIPTION
Related to #190 

**Description of changes**
Removed file storage in test data.
Test data will only be stored in DB -> resolves file permission issues.
Since we do not need the data as files, this should be sufficient.

Furthermore, added proper django message and an redirect to the dashboard on test data population.


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ x ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.