### PR TITLE
Fix RecursionError when trying to obtain certificate chain of non-CA self-signed certificate

### DIFF
--- a/trustpoint/pki/models.py
+++ b/trustpoint/pki/models.py
@@ -908,7 +908,7 @@ class CertificateModel(models.Model):
 
     # TODO: check order of chains
     def get_certificate_chains(self, include_self: bool = True) -> list[list[CertificateModel]]:
-        if self.is_root_ca:
+        if self.is_self_signed:
             if include_self:
                 return [[self]]
             else:


### PR DESCRIPTION
**Description of changes**
Skips chain traversal for all self-signed certs, not only CAs.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.