### PR TITLE
Prevent re-onboarding of already onboarded device (resolves #198)

### DIFF
--- a/trustpoint/devices/models.py
+++ b/trustpoint/devices/models.py
@@ -187,10 +187,12 @@ class Device(models.Model):
 
             return False, f'Onboarding protocol {label} is not implemented.'
 
-        # TODO(Air): check that device is not already onboarded
+        # check that device is not already onboarded
         # Re-onboarding might be a valid use case, e.g. to renew a certificate
+        # TODO (Air): Consider allowing re-onboarding,
+        # but needs a way to handle multiple simultaneously active certificates
         if device.device_onboarding_status == DeviceOnboardingStatus.ONBOARDED:
-            log.warning('Re-onboarding device %s which is already onboarded.', device.device_name)
+            return False, (_('Device %s is already onboarded.') % device.device_name)
 
         return True, None
 

--- a/trustpoint/onboarding/views.py
+++ b/trustpoint/onboarding/views.py
@@ -64,9 +64,6 @@ class OnboardingUtilMixin:
             messages.error(request, msg)
             return False
 
-        # TODO(Air): check that device is not already onboarded
-        # Re-onboarding might be a valid use case, e.g. to renew a certificate
-
         return True
 
 


### PR DESCRIPTION
Related to #198

**Description of changes**
Disallow creation of an onboarding process if the device is already onboarded.

**Notes**
This check may need to be updated to take onboarding to multiple domains into account. It should only allow onboarding to a domain if no LDevID is currently active for that domain (or alternatively, the existing LDevID is revoked).

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.