### PR TITLE
Use common variable for pagination

### DIFF
--- a/trustpoint/devices/views.py
+++ b/trustpoint/devices/views.py
@@ -625,7 +625,7 @@ class DeviceCertificateLifecycleManagementSummaryView(
         device = self.get_object()
         qs = super().get_queryset() # inherited from SortableTableMixin, sorted query
 
-        domain_credentials = IssuedCredentialModel.objects.filter(
+        domain_credentials = qs.filter(
             Q(device=device) &
             Q(issued_credential_type=IssuedCredentialModel.IssuedCredentialType.DOMAIN_CREDENTIAL.value)
         )

--- a/trustpoint/home/views.py
+++ b/trustpoint/home/views.py
@@ -22,6 +22,7 @@ from django.views.generic.list import ListView
 from ninja.responses import Response
 from pki.models import CertificateModel, IssuingCaModel
 
+from trustpoint.settings import UIConfig
 from trustpoint.views.base import TpLoginRequiredMixin, SortableTableMixin
 
 from .filters import NotificationFilter
@@ -50,7 +51,7 @@ class DashboardView(TpLoginRequiredMixin, SortableTableMixin, ListView):
     model = NotificationModel
     context_object_name = 'notifications'
     default_sort_param = '-created_at'
-    paginate_by = 5
+    paginate_by = UIConfig.notifications_paginate_by
 
     def __init__(self, *args: tuple, **kwargs: dict) -> None:
         """Initializes the parent class with the given arguments and keyword arguments."""

--- a/trustpoint/pki/views/certificates.py
+++ b/trustpoint/pki/views/certificates.py
@@ -13,6 +13,7 @@ from django.views.generic.detail import DetailView  # type: ignore[import-untype
 from django.views.generic.list import ListView  # type: ignore[import-untyped]
 
 from pki.models import CertificateModel
+from trustpoint.settings import UIConfig
 from trustpoint.views.base import PrimaryKeyListFromPrimaryKeyString, SortableTableMixin, TpLoginRequiredMixin
 
 if TYPE_CHECKING:
@@ -38,7 +39,7 @@ class CertificateTableView(CertificatesContextMixin, TpLoginRequiredMixin, Sorta
     model = CertificateModel
     template_name = 'pki/certificates/certificates.html'  # Template file
     context_object_name = 'certificates'
-    paginate_by = 5  # Number of items per page
+    paginate_by = UIConfig.paginate_by
     default_sort_param = 'common_name'
 
 class CertificateDetailView(CertificatesContextMixin, TpLoginRequiredMixin, DetailView):

--- a/trustpoint/pki/views/domains.py
+++ b/trustpoint/pki/views/domains.py
@@ -16,6 +16,7 @@ from django.views.generic.edit import FormView
 from pki.forms import DevIdRegistrationForm, DevIdAddMethodSelectForm
 from pki.models import DomainModel, DevIdRegistration
 from pki.models.truststore import TruststoreModel
+from trustpoint.settings import UIConfig
 from trustpoint.views.base import (
     ContextDataMixin,
     TpLoginRequiredMixin,
@@ -47,7 +48,7 @@ class DomainTableView(DomainContextMixin, TpLoginRequiredMixin, SortableTableMix
     model = DomainModel
     template_name = 'pki/domains/domain.html'  # Template file
     context_object_name = 'domain-new'
-    paginate_by = 5  # Number of items per page
+    paginate_by = UIConfig.paginate_by
     default_sort_param = 'unique_name'
 
 
@@ -72,7 +73,7 @@ class DomainUpdateView(DomainContextMixin, TpLoginRequiredMixin, UpdateView):
 class DomainDevIdRegistrationTableMixin(SortableTableMixin, ListInDetailView):
 
     model = DevIdRegistration
-    paginate_by = 5  # Number of items per page
+    paginate_by = UIConfig.paginate_by
     context_object_name = 'devid_registrations'
     default_sort_param = 'unique_name'
     

--- a/trustpoint/pki/views/issuing_cas.py
+++ b/trustpoint/pki/views/issuing_cas.py
@@ -14,6 +14,7 @@ from pki.forms import (
     IssuingCaAddMethodSelectForm,
 )
 from pki.models import IssuingCaModel
+from trustpoint.settings import UIConfig
 from trustpoint.views.base import (
     LoggerMixin,
     BulkDeleteView,
@@ -35,7 +36,7 @@ class IssuingCaTableView(IssuingCaContextMixin, TpLoginRequiredMixin, SortableTa
     model = IssuingCaModel
     template_name = 'pki/issuing_cas/issuing_cas.html'  # Template file
     context_object_name = 'issuing_ca'
-    paginate_by = 5  # Number of items per page
+    paginate_by = UIConfig.paginate_by  # Number of items per page
     default_sort_param = 'unique_name'
 
 

--- a/trustpoint/pki/views/truststores.py
+++ b/trustpoint/pki/views/truststores.py
@@ -18,6 +18,7 @@ from django.views.generic.list import ListView
 from pki.forms import TruststoreAddForm
 from pki.models import DomainModel
 from pki.models.truststore import TruststoreModel
+from trustpoint.settings import UIConfig
 from trustpoint.views.base import PrimaryKeyListFromPrimaryKeyString, SortableTableMixin, TpLoginRequiredMixin
 
 if TYPE_CHECKING:
@@ -42,7 +43,7 @@ class TruststoreTableView(TruststoresContextMixin, TpLoginRequiredMixin, Sortabl
     model = TruststoreModel
     template_name = 'pki/truststores/truststores.html'
     context_object_name = 'truststores'
-    paginate_by = 5
+    paginate_by = UIConfig.paginate_by
     default_sort_param = 'unique_name'
 
 

--- a/trustpoint/settings/views.py
+++ b/trustpoint/settings/views.py
@@ -20,7 +20,7 @@ from django.http import Http404, HttpResponse
 from django.views.generic import TemplateView, View
 from django.views.generic.list import ListView
 
-from trustpoint.settings import LOG_DIR_PATH, DATE_FORMAT
+from trustpoint.settings import LOG_DIR_PATH, DATE_FORMAT, UIConfig
 
 from trustpoint.views.base import TpLoginRequiredMixin, LoggerMixin, SortableTableMixin
 
@@ -61,7 +61,7 @@ class LoggingFilesTableView(LoggerMixin, TpLoginRequiredMixin, LoggingContextMix
     template_name = 'settings/logging/logging_files.html'
     context_object_name = 'log_files'
     default_sort_param = 'filename'
-    paginate_by = 5
+    paginate_by = UIConfig.paginate_by
 
     @staticmethod
     @LoggerMixin.log_exceptions

--- a/trustpoint/templates/devices/credentials/certificate_lifecycle_management.html
+++ b/trustpoint/templates/devices/credentials/certificate_lifecycle_management.html
@@ -21,7 +21,7 @@
                         <h2>{% trans "Issued Domain Credentials" %}</h2>
                         <hr>
                         <div>
-                            <table class="table table-striped">
+                            <table class="table">
                                 <thead>
                                   <tr>
                                     <!-- <th id="checkbox-column"><input type="checkbox"/></th> -->
@@ -88,7 +88,7 @@
                     <hr>
 
                     <div>
-                        <table class="table table-striped">
+                        <table class="table">
                             <thead>
                               <tr>
                                 <!-- <th id="checkbox-column"><input type="checkbox"/></th> -->

--- a/trustpoint/templates/devices/devices.html
+++ b/trustpoint/templates/devices/devices.html
@@ -10,7 +10,7 @@
     </div>
 
     <div class="card-body text-start" style="overflow: auto; flex-grow: 1; max-height: 90%;">
-      <table class="table table-striped">
+      <table class="table">
         <thead>
           <tr>
             <th id="checkbox-column"><input type="checkbox"/></th>
@@ -79,7 +79,7 @@
           </tr>
           {% empty %}
           <tr>
-            <td colspan="3">No data available.</td>
+            <td colspan="13" class="middle">{% trans 'No devices have been added yet.' %}</td>
           </tr>
           {% endfor %}
         </tbody>
@@ -94,7 +94,7 @@
             </div>
             <div>
                 <a class="btn btn-primary" href="{% url 'devices:add' %}">
-                    {% trans "Add New Device" %}
+                    {% trans "Add new Device" %}
                 </a>
             </div>
         </div>

--- a/trustpoint/templates/home/notifications-tab.html
+++ b/trustpoint/templates/home/notifications-tab.html
@@ -97,7 +97,7 @@
     </form>
 
     <div>
-        <table class="table table-striped">
+        <table class="table">
             <thead>
               <tr>
                 <!-- <th id="checkbox-column"><input type="checkbox"/></th> -->

--- a/trustpoint/templates/pki/certificates/certificates.html
+++ b/trustpoint/templates/pki/certificates/certificates.html
@@ -12,7 +12,7 @@
     {% endif %}
   </div>
   <div class="card-body text-start" style="overflow: auto; flex-grow: 1; max-height: 90%">
-    <table class="table table-striped">
+    <table class="table">
       <thead>
         <tr>
           <th id="checkbox-column"><input type="checkbox"/></th>
@@ -81,7 +81,7 @@
         </tr>
         {% empty %}
         <tr>
-          <td colspan="3">No data available.</td>
+          <td colspan="11" class="middle">{% trans 'No certificates are available. Add an Issuing CA first.' %}</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/trustpoint/templates/pki/devid_registration/table.html
+++ b/trustpoint/templates/pki/devid_registration/table.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <div class="table-responsive">
-  <table class="table table-striped">
+  <table class="table">
       <thead>
         <tr>
           <th>

--- a/trustpoint/templates/pki/domains/domain.html
+++ b/trustpoint/templates/pki/domains/domain.html
@@ -9,7 +9,7 @@
     </div>
 
     <div class="card-body text-start" style="overflow-y: auto; flex-grow: 1; max-height: 90%;">
-      <table class="table table-striped">
+      <table class="table">
         <thead>
           <tr>
             <th id="checkbox-column"><input type="checkbox"/></th>
@@ -42,7 +42,7 @@
           </tr>
           {% empty %}
           <tr>
-            <td colspan="3">No data available.</td>
+            <td colspan="6" class="middle">{% trans 'No Domain has been added yet.' %}</td>
           </tr>
           {% endfor %}
         </tbody>

--- a/trustpoint/templates/pki/issuing_cas/issuing_cas.html
+++ b/trustpoint/templates/pki/issuing_cas/issuing_cas.html
@@ -8,7 +8,7 @@
         <h1>{% trans "Issuing CAs" %}</h1>
     </div>
     <div class="card-body text-start" style="overflow-y: auto; flex: 1;">
-      <table class="table table-striped">
+      <table class="table">
         <thead>
           <tr>
             <th id="checkbox-column"><input type="checkbox"/></th>
@@ -48,6 +48,7 @@
           </tr>
         </thead>
         <tbody>
+          {# When adding or removing columns, please update the "colspan" attribute in the {% empty %} section accordingly #}
           {% for ca in page_obj %}
           <tr>
             <td class="row_checkbox">
@@ -65,7 +66,7 @@
           </tr>
           {% empty %}
           <tr>
-            <td colspan="3">No data available.</td>
+            <td colspan="10" class="middle">{% trans 'No Issuing CA has been added yet.' %}</td>
           </tr>
           {% endfor %}
         </tbody>

--- a/trustpoint/templates/pki/truststores/truststores.html
+++ b/trustpoint/templates/pki/truststores/truststores.html
@@ -8,7 +8,7 @@
         <h1>{% trans "Truststores" %}</h1>
     </div>
     <div class="card-body text-start" style="overflow: auto; flex-grow: 1; max-height: 90%;">
-      <table class="table table-striped">
+      <table class="table">
         <thead>
           <tr>
             <th id="checkbox-column"><input type="checkbox"/></th>
@@ -24,7 +24,7 @@
             </th>
             <th>
               <a href="?sort={% if current_sort == 'created_at' %}-{% endif %}created_at">
-                Created-At
+                Created at
               </a>
             </th>
             <th>Details</th>
@@ -32,6 +32,7 @@
           </tr>
         </thead>
         <tbody>
+          {# When adding or removing columns, please update the "colspan" attribute in the {% empty %} section accordingly #}
           {% for truststore in page_obj %}
           <tr>
             <td class="row_checkbox">
@@ -45,7 +46,7 @@
           </tr>
           {% empty %}
           <tr>
-            <td colspan="3">No data available.</td>
+            <td colspan="6" class="middle">{% trans 'No Truststore has been added yet.' %}</td>
           </tr>
           {% endfor %}
         </tbody>
@@ -62,7 +63,7 @@
                 {% trans "Download selected" %}
             </button>
         </div>
-        <a class="btn btn-primary" href="{% url 'pki:truststores-add' %}">{% trans "Add New Trust Store" %}</a>
+        <a class="btn btn-primary" href="{% url 'pki:truststores-add' %}">{% trans "Add new Trust Store" %}</a>
     </div>
 </div>
 

--- a/trustpoint/templates/settings/logging/logging_files.html
+++ b/trustpoint/templates/settings/logging/logging_files.html
@@ -8,7 +8,7 @@
             <h1>{% trans 'Logging' %}</h1>
         </div>
         <div class="card-body text-start" style="overflow-y: auto; flex-grow: 1; max-height: 90%;">
-            <table class="table table-striped">
+            <table class="table">
                 <thead>
                   <tr>
                     <th id="checkbox-column"><input type="checkbox"/></th>

--- a/trustpoint/trustpoint/settings.py
+++ b/trustpoint/trustpoint/settings.py
@@ -9,17 +9,18 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
+# ruff: noqa: T201  # print is used for DB connection status prior to log availability
+
 import logging
 import os
 import socket
 import time
 from pathlib import Path
-
-import psycopg
-from django.core.management.utils import get_random_secret_key
-from django.utils.translation import gettext_lazy as _
+from typing import ClassVar
 
 import django_stubs_ext
+import psycopg
+from django.utils.translation import gettext_lazy as _
 
 # Monkeypatching Django, so stubs will work for all generics,
 # see: https://github.com/typeddjango/django-stubs
@@ -61,8 +62,8 @@ def is_postgre_available() -> bool:
     try:
         print(f'Trying to connect to {host}:{port}...')
         with socket.create_connection((host, port), timeout=5):
-            print(f"Connection to {host}:{port} successful.")
-    except socket.error as e:
+            print(f'Connection to {host}:{port} successful.')
+    except OSError as e:
         msg = f'PostgreSQL host {host} on port {port} is unreachable. Error: {e}'
         print(msg)
         return False
@@ -90,12 +91,12 @@ def is_postgre_available() -> bool:
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
-ADMIN_ENABLED = True if DEBUG else False
+ADMIN_ENABLED = bool(DEBUG)
 DEVELOPMENT_ENV = True
 
 # SECURITY WARNING: keep the secret key used in production secret!
 if DEBUG:
-    SECRET_KEY = 'DEV-ENVIRON-SECRET-KEY-lh2rw0b0z$s9e=!4see)@_8ta_up&ad&m01$i+g5z@nz5u$0wi'
+    SECRET_KEY = 'DEV-ENVIRON-SECRET-KEY-lh2rw0b0z$s9e=!4see)@_8ta_up&ad&m01$i+g5z@nz5u$0wi'  # noqa: S105
 else:
     # TODO(AlexHx8472): Use proper docker secrets handling.
     SECRET_KEY = Path('/etc/trustpoint/secrets/django_secret_key.env').read_text()
@@ -215,8 +216,8 @@ AUTH_PASSWORD_VALIDATORS = [
 LANGUAGE_CODE = 'en-us'
 
 LANGUAGES = [
-    ("de", _("German")),
-    ("en", _("English")),
+    ('de', _('German')),
+    ('en', _('English')),
 ]
 
 
@@ -302,4 +303,10 @@ LOGGING = {
     },
 }
 
-TEST_RUNNER = "django_behave.runner.DjangoBehaveTestSuiteRunner"
+TEST_RUNNER = 'django_behave.runner.DjangoBehaveTestSuiteRunner'
+
+# User interface config defaults
+class UIConfig:
+    """User interface configuration defaults."""
+    paginate_by: ClassVar[int] = 50
+    notifications_paginate_by: ClassVar[int] = 5


### PR DESCRIPTION
**Description of changes**
add a shared variable for table pagination
fix ruff errors in settings.py

**Notes**
Pagination count can be exposed as a user setting in the future, either in Trustpoint settings or client JS based & included as a GET URL query parameter.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.