### PR TITLE
Added 6 different signature suites to be used by the management commands to create demo data

### DIFF
--- a/trustpoint/pki/management/commands/add_domains_and_devices.py
+++ b/trustpoint/pki/management/commands/add_domains_and_devices.py
@@ -75,7 +75,15 @@ class Command(BaseCommand):
         print("Starting the process of adding domains and devices...\n")
 
         for domain_name, devices in data.items():
-            issuing_ca = random.choice(['issuing-ca-a', 'issuing-ca-b', 'issuing-ca-c'])
+            issuing_ca = random.choice(
+                [
+                    'issuing-ca-a',
+                    'issuing-ca-b',
+                    'issuing-ca-c',
+                    'issuing-ca-d',
+                    'issuing-ca-e',
+                    'issuing-ca-f',
+                 ])
             domain, created = DomainModel.objects.get_or_create(unique_name=domain_name)
             domain.issuing_ca = IssuingCaModel.objects.get(unique_name=issuing_ca)
             domain.save()

--- a/trustpoint/pki/management/commands/create_multiple_test_issuing_cas.py
+++ b/trustpoint/pki/management/commands/create_multiple_test_issuing_cas.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from django.core.management.base import BaseCommand
 
+from cryptography.hazmat.primitives.asymmetric import rsa, ec
+from cryptography.hazmat.primitives import hashes
 from .base_commands import CertificateCreationCommandMixin
 
 
@@ -12,25 +14,100 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
 
     help = 'Adds a Root CA and three issuing CAs to the database.'
 
-    def handle(self, *_args: dict, **_kwargs: dict) -> None:
+    def handle(self, *args: tuple, **kwargs: dict) -> None:
         """Adds a Root CA and three issuing CAs to the database."""
-        root_1, root_1_key = self.create_root_ca('Root CA')
-        issuing_1, issuing_1_key = self.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA A')
-        issuing_2, issuing_2_key = self.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA B')
-        issuing_3, issuing_3_key = self.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA C')
-
+        rsa2_root_ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        rsa2_issuing_ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        rsa2_root, _ = self.create_root_ca(
+            'Root-CA RSA-2048-SHA256', private_key=rsa2_root_ca_key, hash_algorithm=hashes.SHA256())
+        rsa2_issuing_ca, rsa2_issuing_ca_key = self.create_issuing_ca(
+            issuer_private_key=rsa2_root_ca_key,
+            private_key=rsa2_issuing_ca_key,
+            issuer_cn='Root-CA RSA-2048-SHA256',
+            subject_cn='Issuing CA A',
+            hash_algorithm=hashes.SHA256())
         self.save_issuing_ca(
-            issuing_ca_cert=issuing_1,
-            private_key=issuing_1_key,
-            chain=[root_1],
+            issuing_ca_cert=rsa2_issuing_ca,
+            private_key=rsa2_issuing_ca_key,
+            chain=[rsa2_root],
             unique_name='issuing-ca-a')
+
+        rsa3_root_ca_key = rsa.generate_private_key(public_exponent=65537, key_size=3072)
+        rsa3_issuing_ca_key = rsa.generate_private_key(public_exponent=65537, key_size=3072)
+        rsa3_root, _ = self.create_root_ca(
+            'Root-CA RSA-3072-SHA256', private_key=rsa3_root_ca_key, hash_algorithm=hashes.SHA256())
+        rsa3_issuing_ca, rsa3_issuing_ca_key = self.create_issuing_ca(
+            issuer_private_key=rsa2_root_ca_key,
+            private_key=rsa3_issuing_ca_key,
+            issuer_cn='Root-CA RSA-3072-SHA256',
+            subject_cn='Issuing CA B',
+            hash_algorithm=hashes.SHA256())
         self.save_issuing_ca(
-            issuing_ca_cert=issuing_2,
-            private_key=issuing_2_key,
-            chain=[root_1],
+            issuing_ca_cert=rsa3_issuing_ca,
+            private_key=rsa3_issuing_ca_key,
+            chain=[rsa3_root],
             unique_name='issuing-ca-b')
+
+        rsa4_root_ca_key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
+        rsa4_issuing_ca_key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
+        rsa4_root, _ = self.create_root_ca(
+            'Root-CA RSA-4096-SHA256', private_key=rsa4_root_ca_key, hash_algorithm=hashes.SHA512())
+        rsa4_issuing_ca, rsa4_issuing_ca_key = self.create_issuing_ca(
+            issuer_private_key=rsa4_root_ca_key,
+            private_key=rsa4_issuing_ca_key,
+            issuer_cn='Root-CA RSA-4096-SHA256',
+            subject_cn='Issuing CA C',
+            hash_algorithm=hashes.SHA512())
         self.save_issuing_ca(
-            issuing_ca_cert=issuing_3,
-            private_key=issuing_3_key,
-            chain=[root_1],
+            issuing_ca_cert=rsa4_issuing_ca,
+            private_key=rsa4_issuing_ca_key,
+            chain=[rsa4_root],
             unique_name='issuing-ca-c')
+
+        ecc1_root_ca_key = ec.generate_private_key(curve=ec.SECP256R1())
+        ecc1_issuing_ca_key = ec.generate_private_key(curve=ec.SECP256R1())
+        ecc1_root, _ = self.create_root_ca(
+            'Root-CA SECP256R1-SHA256', private_key=ecc1_root_ca_key, hash_algorithm=hashes.SHA256())
+        ecc1_issuing_ca, ecc1_issuing_ca_key = self.create_issuing_ca(
+            issuer_private_key=ecc1_root_ca_key,
+            private_key=ecc1_issuing_ca_key,
+            issuer_cn='Root-CA SECP256R1-SHA256',
+            subject_cn='Issuing CA D',
+            hash_algorithm=hashes.SHA256())
+        self.save_issuing_ca(
+            issuing_ca_cert=ecc1_issuing_ca,
+            private_key=ecc1_issuing_ca_key,
+            chain=[ecc1_root],
+            unique_name='issuing-ca-d')
+
+        ecc2_root_ca_key = ec.generate_private_key(curve=ec.SECT283R1())
+        ecc2_issuing_ca_key = ec.generate_private_key(curve=ec.SECT283R1())
+        ecc2_root, _ = self.create_root_ca(
+            'Root-CA SECT283R1-SHA256', private_key=ecc2_root_ca_key, hash_algorithm=hashes.SHA256())
+        ecc2_issuing_ca, ecc2_issuing_ca_key = self.create_issuing_ca(
+            issuer_private_key=ecc2_root_ca_key,
+            private_key=ecc2_issuing_ca_key,
+            issuer_cn='Root-CA SECT283R1-SHA256',
+            subject_cn='Issuing CA E',
+            hash_algorithm=hashes.SHA256())
+        self.save_issuing_ca(
+            issuing_ca_cert=ecc2_issuing_ca,
+            private_key=ecc2_issuing_ca_key,
+            chain=[ecc2_root],
+            unique_name='issuing-ca-e')
+
+        ecc3_root_ca_key = ec.generate_private_key(curve=ec.SECT571R1())
+        ecc3_issuing_ca_key = ec.generate_private_key(curve=ec.SECT571R1())
+        ecc3_root, _ = self.create_root_ca(
+            'Root-CA SECT571R1-SHA256', private_key=ecc3_root_ca_key, hash_algorithm=hashes.SHA3_512())
+        ecc3_issuing_ca, ecc3_issuing_ca_key = self.create_issuing_ca(
+            issuer_private_key=ecc3_root_ca_key,
+            private_key=ecc3_issuing_ca_key,
+            issuer_cn='Root-CA SECT571R1-SHA256',
+            subject_cn='Issuing CA F',
+            hash_algorithm=hashes.SHA3_512())
+        self.save_issuing_ca(
+            issuing_ca_cert=ecc3_issuing_ca,
+            private_key=ecc3_issuing_ca_key,
+            chain=[ecc3_root],
+            unique_name='issuing-ca-f')


### PR DESCRIPTION
**Description of changes**
Added 6 different signature suites that will be used for the demo data - issuing ca - creation:
RSA-2048-SHA256
RSA-3072-SHA256
RSA-4092-SHA512
ECC-SECP256R1-SHA256
ECC-SECT283R1-SHA256
ECC-SECT571R1-SHA3-512

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ x ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.