### PR TITLE
- Fixed missing domain_credential_onboarding and pki_protocol for man…

### DIFF
--- a/trustpoint/pki/management/commands/add_domains_and_devices.py
+++ b/trustpoint/pki/management/commands/add_domains_and_devices.py
@@ -108,12 +108,24 @@ class Command(BaseCommand):
                     if onboarding_protocol == DeviceModel.OnboardingProtocol.NO_ONBOARDING \
                     else DeviceModel.OnboardingStatus.PENDING
 
+                domain_credential_onboarding = False \
+                    if onboarding_protocol == DeviceModel.OnboardingProtocol.NO_ONBOARDING \
+                    else True
+
+                pki_protocol = DeviceModel.PkiProtocol.CMP_CLIENT_CERTIFICATE.value \
+                    if (onboarding_protocol == DeviceModel.OnboardingProtocol.CMP_IDEVID or
+                        onboarding_protocol == DeviceModel.OnboardingProtocol.CMP_SHARED_SECRET) \
+                    else random.choice([DeviceModel.PkiProtocol.MANUAL.value,
+                                        DeviceModel.PkiProtocol.CMP_SHARED_SECRET.value])
+
                 dev = DeviceModel(
                     unique_name=device_name,
                     serial_number=serial_number,
                     domain=domain,
                     onboarding_protocol=onboarding_protocol,
-                    onboarding_status=onboarding_status
+                    onboarding_status=onboarding_status,
+                    domain_credential_onboarding=domain_credential_onboarding,
+                    pki_protocol=pki_protocol
                 )
 
                 try:


### PR DESCRIPTION
- Fixed missing domain_credential_onboarding and pki_protocol for management command add_domains_and_devices


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.