### PR TITLE
Device configure is not used / empty. therefore we do not need it...

### DIFF
--- a/trustpoint/templates/devices/details.html
+++ b/trustpoint/templates/devices/details.html
@@ -5,7 +5,7 @@
     <div class="card">
         <div class="card-header">
             <div class="">
-                <h1>{% trans "Device details" %}</h1>
+                <h1>{% trans 'Device details' %}</h1>
             </div>
         </div>
         <div class="card-body">
@@ -13,9 +13,9 @@
         </div>
         <div class="card-footer d-flex justify-content-between align-items-center">
             <div class="tp-card-btn-footer m-1">
-                <button type="button" value="Back" class="btn btn-secondary btn-half" onClick="history.back()">{% trans 'Back' %}</button>
-                <a href="{% url 'devices:devices' %}" class="btn btn-secondary btn-half">{% trans 'Cancel' %}</a>
-                <a href="{% url 'devices:config' pk=device.pk%}" class="btn btn-primary">{% trans 'Config' %}</a>
+                <button type="button" value="Back" class="btn btn-secondary {#btn-half#}" onClick="history.back()">{% trans 'Back' %}</button>
+                <a href="{% url 'devices:devices' %}" class="btn btn-secondary {#btn-half#}">{% trans 'Cancel' %}</a>
+                {#<a href="{% url 'devices:config' pk=device.pk%}" class="btn btn-primary">{% trans 'Config' %}</a>#}
             </div>
         </div>
     </div>

--- a/trustpoint/templates/devices/devices.html
+++ b/trustpoint/templates/devices/devices.html
@@ -51,7 +51,7 @@
             </th>
             <th>Certificate Management</th>
             <th>Details</th>
-            <th>Configure</th>
+{#            <th>Configure</th>#}
             <th>Revoke</th>
           </tr>
         </thead>
@@ -78,7 +78,7 @@
             <td>{{ device.get_pki_protocol_display }}</td>
             <td>{{ device.clm_button| safe}}</td>
             <td><a href="details/{{device.id}}/" class="btn btn-primary tp-table-btn w-100">Details</a></td>
-            <td><a href="configure/{{device.id}}/" class="btn btn-primary tp-table-btn w-100">Configure</a></td>
+{#            <td><a href="configure/{{device.id}}/" class="btn btn-primary tp-table-btn w-100">Configure</a></td>#}
             <td>{{ device.revoke_button| safe}}</td>
           </tr>
           {% empty %}

--- a/trustpoint/templates/devices/devices.html
+++ b/trustpoint/templates/devices/devices.html
@@ -83,7 +83,7 @@
           </tr>
           {% empty %}
           <tr>
-            <td colspan="13" class="middle">{% trans 'No devices have been added yet.' %}</td>
+            <td colspan="12" class="middle">{% trans 'No devices have been added yet.' %}</td>
           </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
Device configure is not used / empty. therefore we do not need it...


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.