### PR TITLE
Save deletion of Issuing CAs, Truststores and Domains

### DIFF
--- a/trustpoint/pki/views/domains.py
+++ b/trustpoint/pki/views/domains.py
@@ -142,6 +142,7 @@ class DomainDetailView(DomainContextMixin, TpLoginRequiredMixin, DomainDevIdRegi
 
 
 class DomainCaBulkDeleteConfirmView(DomainContextMixin, TpLoginRequiredMixin, BulkDeleteView):
+    """View to confirm the deletion of multiple Domains."""
 
     model = DomainModel
     success_url = reverse_lazy('pki:domains')
@@ -149,28 +150,28 @@ class DomainCaBulkDeleteConfirmView(DomainContextMixin, TpLoginRequiredMixin, Bu
     template_name = 'pki/domains/confirm_delete.html'
     context_object_name = 'domains'
 
-    def form_valid(self, form):
+    def form_valid(self, form) -> HttpResponse:
+        """Attempt to delete domains if the form is valid."""
         queryset = self.get_queryset()
         deleted_count = queryset.count()
 
         try:
             response = super().form_valid(form)
-
-            messages.success(
-                self.request,
-                _('Successfully deleted {count} Domainss).').format(count=deleted_count)
-            )
-
-            return response
-
-        except ProtectedError as e:
+        except ProtectedError:
             messages.error(
                 self.request,
                 _(
-                    "Cannot delete the selected Domains(s) because they are referenced by other objects."
+                    'Cannot delete the selected Domains(s) because they are referenced by other objects.'
                 )
             )
             return HttpResponseRedirect(self.success_url)
+
+        messages.success(
+            self.request,
+            _('Successfully deleted {count} Domains.').format(count=deleted_count)
+        )
+
+        return response
 
 
 class DevIdRegistrationCreateView(DomainContextMixin, TpLoginRequiredMixin, FormView):

--- a/trustpoint/pki/views/issuing_cas.py
+++ b/trustpoint/pki/views/issuing_cas.py
@@ -92,6 +92,7 @@ class IssuingCaConfigView(LoggerMixin, IssuingCaContextMixin, TpLoginRequiredMix
 
 
 class IssuingCaBulkDeleteConfirmView(IssuingCaContextMixin, TpLoginRequiredMixin, BulkDeleteView):
+    """View to confirm the deletion of multiple Issuing CAs."""
 
     model = IssuingCaModel
     success_url = reverse_lazy('pki:issuing_cas')
@@ -99,28 +100,28 @@ class IssuingCaBulkDeleteConfirmView(IssuingCaContextMixin, TpLoginRequiredMixin
     template_name = 'pki/issuing_cas/confirm_delete.html'
     context_object_name = 'issuing_cas'
 
-    def form_valid(self, form):
+    def form_valid(self, form) -> HttpResponse:
+        """Delete the selected Issuing CAs on valid form."""
         queryset = self.get_queryset()
         deleted_count = queryset.count()
 
         try:
             response = super().form_valid(form)
-
-            messages.success(
-                self.request,
-                _('Successfully deleted {count} Issuing CA(s).').format(count=deleted_count)
-            )
-
-            return response
-
-        except ProtectedError as e:
+        except ProtectedError:
             messages.error(
                 self.request,
                 _(
-                    "Cannot delete the selected Issuing CA(s) because they are referenced by other objects."
+                    'Cannot delete the selected Issuing CA(s) because they are referenced by other objects.'
                 )
             )
             return HttpResponseRedirect(self.success_url)
+
+        messages.success(
+            self.request,
+            _('Successfully deleted {count} Issuing CA(s).').format(count=deleted_count)
+        )
+
+        return response
 
 
 class IssuingCaCrlGenerationView(IssuingCaContextMixin, TpLoginRequiredMixin, DetailView):

--- a/trustpoint/pki/views/truststores.py
+++ b/trustpoint/pki/views/truststores.py
@@ -4,27 +4,29 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from django.db.models import ProtectedError
-from django.shortcuts import get_object_or_404
-from django.views.generic import DeleteView
-
 from core.file_builder.certificate import CertificateCollectionArchiveFileBuilder, CertificateCollectionBuilder
 from core.file_builder.enum import ArchiveFormat, CertificateFileFormat
+from django.contrib import messages
+from django.db.models import ProtectedError
 from django.http import Http404, HttpRequest, HttpResponse, HttpResponseRedirect
-from django.urls import reverse_lazy, reverse
+from django.shortcuts import get_object_or_404
+from django.urls import reverse, reverse_lazy
+from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import RedirectView
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import FormView
 from django.views.generic.list import ListView
-from django.contrib import messages
-from django.utils.translation import gettext_lazy as _
 
 from pki.forms import TruststoreAddForm
 from pki.models import DomainModel
 from pki.models.truststore import TruststoreModel
 from trustpoint.settings import UIConfig
-from trustpoint.views.base import PrimaryKeyListFromPrimaryKeyString, SortableTableMixin, TpLoginRequiredMixin, \
-    BulkDeleteView
+from trustpoint.views.base import (
+    BulkDeleteView,
+    PrimaryKeyListFromPrimaryKeyString,
+    SortableTableMixin,
+    TpLoginRequiredMixin,
+)
 
 if TYPE_CHECKING:
     from typing import ClassVar
@@ -238,6 +240,7 @@ class TruststoreMultipleDownloadView(
         return response
 
 class TruststoreBulkDeleteConfirmView(TruststoresContextMixin, TpLoginRequiredMixin, BulkDeleteView):
+    """View for confirming the deletion of multiple truststores."""
 
     model = TruststoreModel
     success_url = reverse_lazy('pki:truststores')
@@ -245,25 +248,26 @@ class TruststoreBulkDeleteConfirmView(TruststoresContextMixin, TpLoginRequiredMi
     template_name = 'pki/truststores/confirm_delete.html'
     context_object_name = 'truststores'
 
-    def form_valid(self, form):
+    def form_valid(self, form) -> HttpResponse:
+        """Attempts to delete the selected truststores on valid form."""
         queryset = self.get_queryset()
         deleted_count = queryset.count()
 
         try:
             response = super().form_valid(form)
 
-            messages.success(
-                self.request,
-                _('Successfully deleted {count} Truststore(s).').format(count=deleted_count)
-            )
-
-            return response
-
-        except ProtectedError as e:
+        except ProtectedError:
             messages.error(
                 self.request,
                 _(
-                    "Cannot delete the selected Truststore(s) because they are referenced by other objects."
+                    'Cannot delete the selected Truststore(s) because they are referenced by other objects.'
                 )
             )
             return HttpResponseRedirect(self.success_url)
+
+        messages.success(
+            self.request,
+            _('Successfully deleted {count} Truststore(s).').format(count=deleted_count)
+        )
+
+        return response


### PR DESCRIPTION
Catch ProtectedError and return a messages.error for Issuing CAs, Domains and Truststores if there are referenced objects and the object cannot be deleted


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.