### PR TITLE
Application cert issuing only after onboarding

### DIFF
--- a/trustpoint/templates/devices/credentials/certificate_lifecycle_management.html
+++ b/trustpoint/templates/devices/credentials/certificate_lifecycle_management.html
@@ -128,9 +128,11 @@
                     {% if device.pki_protocol != device.PkiProtocol.MANUAL.value %}
                         <h2 class="d-flex justify-content-between align-items-center">
                             <span>{% trans "Issued Application Credentials" %}</span>
-                            <a href="{% url 'devices:help_dispatch' pk=device.pk %}" class="btn btn-primary" style="width: 25rem;">
-                                {% trans "Help - Issue New Credentials" %}
-                            </a>
+                            {% if device.onboarding_status != device.OnboardingStatus.PENDING.value %}
+                                <a href="{% url 'devices:help_dispatch' pk=device.pk %}" class="btn btn-primary" style="width: 25rem;">
+                                    {% trans "Help - Issue New Credentials" %}
+                                </a>
+                            {%  endif %}
                         </h2>
                     {% else %}
                         <h2>{% trans "Issued Application Credentials" %}</h2>


### PR DESCRIPTION
Only show button to issue application certs when the OnboardingStatus is not PENDING


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.