### PR TITLE
Added Truststores and IDevID Patterns to demo data generation

### DIFF
--- a/trustpoint/pki/management/commands/add_domains_and_devices.py
+++ b/trustpoint/pki/management/commands/add_domains_and_devices.py
@@ -164,6 +164,7 @@ class Command(BaseCommand):
                         print(f"Creating device '{dev.unique_name}' (ID {dev.pk}) in domain '{dev.domain}' with:")
                         print(f"  - Serial Number: {dev.serial_number}")
                         print(f"  - Onboarding Protocol: {dev.onboarding_protocol}")
+                        print(f"  - PKI Protocol: {dev.pki_protocol}")
                     else:
                         print(f"Device '{device_name}' was not saved correctly.")
                 except Exception as e:

--- a/trustpoint/pki/management/commands/import_idevid_truststores.py
+++ b/trustpoint/pki/management/commands/import_idevid_truststores.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import os
+from django.core.management.base import BaseCommand
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+
+from pki.models import CertificateModel, TruststoreModel, TruststoreOrderModel
+
+
+class Command(BaseCommand):
+    help = 'Imports Truststores from specific PEM files in tests/data/idevid_hierarchies'
+
+    TRUSTSTORE_RELATIVE_PATHS = {
+        'ecc1/ecc1_chain.pem': 'EC-256',
+        'ecc2/ecc2_chain.pem': 'EC-283',
+        'ecc3/ecc3_chain.pem': 'EC-570',
+        'rsa2/rsa2_chain.pem': 'RSA-2048',
+        'rsa3/rsa3_chain.pem': 'RSA-3072',
+        'rsa4/rsa4_chain.pem': 'RSA-4096',
+    }
+
+    def handle(self, *args, **kwargs):
+        base_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../tests/data/idevid_hierarchies"))
+
+        for relative_path, unique_name in self.TRUSTSTORE_RELATIVE_PATHS.items():
+            pem_path = os.path.join(base_path, relative_path)
+
+            if not os.path.exists(pem_path):
+                self.stderr.write(self.style.ERROR(f"File not found: {pem_path}"))
+                continue
+
+            try:
+                with open(pem_path, 'rb') as f:
+                    pem_content = f.read()
+
+                certificates = x509.load_pem_x509_certificates(pem_content)
+
+                self._save_trust_store(
+                    unique_name=f"idevid-truststore-{unique_name}",
+                    intended_usage=TruststoreModel.IntendedUsage.IDEVID,
+                    certificates=certificates
+                )
+
+                self.stdout.write(self.style.SUCCESS(f"Imported Truststore: {unique_name}"))
+            except Exception as e:
+                self.stderr.write(self.style.ERROR(f"Failed to import {pem_path}: {e}"))
+
+    @staticmethod
+    def _save_trust_store(
+        unique_name: str,
+        intended_usage: TruststoreModel.IntendedUsage,
+        certificates: list[x509.Certificate]
+    ) -> TruststoreModel:
+        saved_certs = []
+
+        for certificate in certificates:
+            sha256_fingerprint = certificate.fingerprint(hashes.SHA256()).hex().upper()
+            try:
+                saved_certs.append(CertificateModel.objects.get(sha256_fingerprint=sha256_fingerprint))
+            except CertificateModel.DoesNotExist:
+                saved_certs.append(CertificateModel.save_certificate(certificate))
+
+        trust_store_model = TruststoreModel(
+            unique_name=unique_name,
+            intended_usage=intended_usage
+        )
+        trust_store_model.save()
+
+        for number, certificate in enumerate(saved_certs):
+            TruststoreOrderModel.objects.create(
+                order=number,
+                certificate=certificate,
+                trust_store=trust_store_model
+            )
+
+        return trust_store_model

--- a/trustpoint/pki/models/__init__.py
+++ b/trustpoint/pki/models/__init__.py
@@ -20,3 +20,4 @@ from .issuing_ca import IssuingCaModel
 from .credential import CredentialAlreadyExistsError, CredentialModel, CertificateChainOrderModel
 from .domain import DomainModel
 from .devid_registration import DevIdRegistration
+from .truststore import TruststoreModel, TruststoreOrderModel


### PR DESCRIPTION
- New script to import Truststores: pki/management/commands/import_idevid_truststores.py
- Added truststore according to onboarding protocol: pki/management/commands/add_domains_and_devices.py


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.