### PR TITLE
Behave complete R_013 steps (Remote Credential Download)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+behave-report.html
 
 # Translations
 *.mo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "sphinx>=8.1.3,<9",
     "sphinxcontrib-plantuml>=0.30",
     "werkzeug>=3.1.3,<4",
+    "beautifulsoup4>=4.13.3",
 ]
 
 # Optional dependencies used for the pip env created by readthedocs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dev = [
     "sphinx>=8.1.3,<9",
     "sphinxcontrib-plantuml>=0.30",
     "werkzeug>=3.1.3,<4",
+    "beautifulsoup4>=4.13.3",
 ]
 
 [build-system]

--- a/trustpoint/features/R_013_remote_credential_download.feature
+++ b/trustpoint/features/R_013_remote_credential_download.feature
@@ -1,3 +1,4 @@
+@fixture.r013.setup
 Feature: Remote Credential Download
 	The system must allow users to securely download an issued application credential from a remote device without requiring user authentication.
 	Instead, a one-time password (OTP) should be used to authorize the download.
@@ -6,7 +7,7 @@ Feature: Remote Credential Download
 		Given the TPC_Web application is running
 		
 	Scenario: Admin creates one time password
-		Given an issued credential with ID 15 is successfully issued
+		Given an issued credential is successfully issued
     	And the admin user is logged into TPC_Web
 		When the admin visits the associated "Download on Device browser" view
 		Then a one-time password is displayed which can be used to download the credential from a remote device

--- a/trustpoint/features/environment.py
+++ b/trustpoint/features/environment.py
@@ -1,1 +1,55 @@
-"""Environment file for behave test. Some configuration could be done here."""
+"""Environment file for behave tests."""
+
+import functools
+import traceback
+from collections.abc import Callable
+
+from behave import given, runner, step, then, when
+
+
+# Function to wrap steps and enforce failure on any exception
+def fail_on_exception(func: Callable) -> Callable:
+    """Wrapper that ensures uncaught exceptions fail the scenario and are logged to the HTML report."""
+    @functools.wraps(func)
+    def wrapper(context: runner.Context, *args: tuple, **kwargs: dict) -> Callable:
+        try:
+            return func(context, *args, **kwargs)
+        except AssertionError:
+            raise
+        except Exception as e:
+            traceback.print_exc()  # Print full traceback for debugging
+            exc_msg = f'Step failed due to exception: {e}'
+            raise AssertionError(exc_msg) from e
+    return wrapper
+
+# Monkey-patch Behave's step decorators to automatically wrap all steps
+original_step = step
+original_given = given
+original_when = when
+original_then = then
+
+def patched_step(*args, **kwargs):
+    def decorator(func):
+        return original_step(*args, **kwargs)(fail_on_exception(func))
+    return decorator
+
+def patched_given(*args, **kwargs):
+    def decorator(func):
+        return original_given(*args, **kwargs)(fail_on_exception(func))
+    return decorator
+
+def patched_when(*args, **kwargs):
+    def decorator(func):
+        return original_when(*args, **kwargs)(fail_on_exception(func))
+    return decorator
+
+def patched_then(*args, **kwargs):
+    def decorator(func):
+        return original_then(*args, **kwargs)(fail_on_exception(func))
+    return decorator
+
+# Override Behave's step registration functions
+step = patched_step
+given = patched_given
+when = patched_when
+then = patched_then

--- a/trustpoint/features/environment.py
+++ b/trustpoint/features/environment.py
@@ -28,23 +28,27 @@ original_given = given
 original_when = when
 original_then = then
 
-def patched_step(*args, **kwargs):
-    def decorator(func):
+def patched_step(*args: tuple, **kwargs: dict) -> Callable:
+    """Monkey-patched step decorator that wraps the step function to fail on any exception."""
+    def decorator(func: Callable) -> Callable:
         return original_step(*args, **kwargs)(fail_on_exception(func))
     return decorator
 
-def patched_given(*args, **kwargs):
-    def decorator(func):
+def patched_given(*args: tuple, **kwargs: dict) -> Callable:
+    """Monkey-patched given decorator that wraps the step function to fail on any exception."""
+    def decorator(func: Callable) -> Callable:
         return original_given(*args, **kwargs)(fail_on_exception(func))
     return decorator
 
-def patched_when(*args, **kwargs):
-    def decorator(func):
+def patched_when(*args: tuple, **kwargs: dict) -> Callable:
+    """Monkey-patched when decorator that wraps the step function to fail on any exception."""
+    def decorator(func: Callable) -> Callable:
         return original_when(*args, **kwargs)(fail_on_exception(func))
     return decorator
 
-def patched_then(*args, **kwargs):
-    def decorator(func):
+def patched_then(*args: tuple, **kwargs: dict) -> Callable:
+    """Monkey-patched then decorator that wraps the step function to fail on any exception."""
+    def decorator(func: Callable) -> Callable:
         return original_then(*args, **kwargs)(fail_on_exception(func))
     return decorator
 

--- a/trustpoint/features/steps/r_013_steps.py
+++ b/trustpoint/features/steps/r_013_steps.py
@@ -2,21 +2,25 @@
 
 import logging
 
-from behave import given, runner, then, when
-from devices.models import IssuedCredentialModel
+from behave import runner
+from bs4 import BeautifulSoup
+from common_steps import step_admin_logged_in
+from devices.models import IssuedCredentialModel, RemoteDeviceCredentialDownloadModel
 from devices.tests.conftest import create_mock_models
+from django.test import Client
+from environment import given, then, when  # monkey-patched to not ignore exceptions
 
 HTTP_OK = 200
+HTTP_FOUND = 302
 logger = logging.getLogger(__name__)
 
 
-@given('an issued credential with ID {id} is successfully issued')
-def step_given_issued_credential_with_given_id_exists(context: runner.Context, id: int) -> None:  # noqa: A002, ARG001
-    """Ensures an issued credential with the given ID exists.
+@given('an issued credential is successfully issued')
+def step_given_issued_credential_exists(context: runner.Context) -> None:
+    """Ensures a (mocked) issued credential exists.
 
     Args:
         context (runner.Context): Behave context.
-        id (int): the id
     """
     try:
         models_dict = create_mock_models()
@@ -29,7 +33,7 @@ def step_given_issued_credential_with_given_id_exists(context: runner.Context, i
 
 @when('the admin visits the associated "Download on Device browser" view')
 def step_when_admin_visits_the_given_view(context: runner.Context) -> None:
-    """Ensures teh admin visits the given view.
+    """Ensures the admin visits the given view.
 
     Args:
         context (runner.Context): Behave context.
@@ -37,108 +41,158 @@ def step_when_admin_visits_the_given_view(context: runner.Context) -> None:
     response = context.authenticated_client.get(context.download_view_url)
     assert response.status_code == HTTP_OK, 'Non-OK response code'
 
-    assert 'id="otp-display"' in response.content.decode(), 'otp-display not in response'
+    context.otp_view_response = response.content
+
+
+MIN_OTP_LENGTH = 8
+MAX_OTP_LENGTH = 32
 
 
 @then('a one-time password is displayed which can be used to download the credential from a remote device')
-def step_then_an_otp_is_displayed(context: runner.Context) -> None:  # noqa: ARG001
+def step_then_an_otp_is_displayed(context: runner.Context) -> None:
     """Ensures that a one-time password is displayed which can be used to download the credential from a remote device.
 
     Args:
         context (runner.Context): Behave context.
     """
-    msg = (
-        'STEP: Then a one-time password is displayed which can be used to download the credential from a remote device'
-    )
-    raise AssertionError(msg)
+    soup = BeautifulSoup(context.otp_view_response, 'html.parser')
+    element = soup.find(id='otp-display')
+    assert element is not None, 'otp-display not in response'
+    otp = element.text.strip()
+    print(otp)
+    assert len(otp) >= MIN_OTP_LENGTH, 'OTP string shorter than 9 characters'
+    assert len(otp) <= MAX_OTP_LENGTH, 'OTP string longer than 32 characters'
+
+    context.otp = otp
 
 
 @given('a correct one-time password')
-def step_given_an_otp(context: runner.Context) -> None:  # noqa: ARG001
+def step_given_an_otp(context: runner.Context) -> None:
     """Ensures that a correct one-time password is given.
 
     Args:
         context (runner.Context): Behave context.
     """
-    msg = 'STEP: Given a correct one-time password'
-    raise AssertionError(msg)
+    try:
+        # This is ugly and a bunch of unnecessary repetition,
+        # but there appears to be no way to make scenarios depend on each other
+        # aka. "Given admin created one time password successfully"
+        step_admin_logged_in(context)
+        step_given_issued_credential_exists(context)
+        step_when_admin_visits_the_given_view(context)
+        step_then_an_otp_is_displayed(context)
+    except Exception as e:  # noqa: BLE001
+        msg = f'Error in Scenario prerequisites: {e}'
+        raise AssertionError(msg)  # noqa: B904
+    assert context.otp is not None, 'Correct OTP not in context'
 
 
 @when('the user visits the "/devices/browser" endpoint and enters the OTP')
-def step_when_user_visits_endpoint(context: runner.Context) -> None:  # noqa: ARG001
+def step_when_user_visits_endpoint(context: runner.Context) -> None:
     """Ensures that the user visits the "/devices/browser" endpoint and enters the OTP.
 
     Args:
         context (runner.Context): Behave context.
     """
-    msg = 'STEP: When the user visits the "/devices/browser" endpoint and enters the OTP'
-    raise AssertionError(msg)
+    context.unauthenticated_user_client = Client()
+    response = context.unauthenticated_user_client.get('/devices/browser/')
+    assert response.status_code == HTTP_OK, 'Non-OK response code, GET login page'
+    assert 'id="id_otp"' in response.content.decode(), 'Page does not contain OTP input field'
+    response = context.unauthenticated_user_client.post('/devices/browser/', {'otp': context.otp})
+    if response.status_code == HTTP_FOUND:
+        redirect_url = response.url
+        logger.debug(f'Redirecting to {redirect_url}')  # noqa: G004
+        if '?token=' in redirect_url:
+            context.download_token = redirect_url.split('?token=')[-1]
+        else:
+            context.download_token = None
+        if 'credential-download' in redirect_url:
+            context.download_id = int(redirect_url.split('credential-download/')[1].split('/')[0])
+        else:
+            context.download_id = None
+        response = context.unauthenticated_user_client.get(response.url)
+    assert response.status_code == HTTP_OK, f'Non-OK response code {response.status_code}, POST otp'
+
+    context.otp_post_view_response = response.content
 
 
 @then('they will receive a page to select the format for the credential download')
-def step_then_they_will_receive_page_to_select_the_format(context: runner.Context) -> None:  # noqa: ARG001
+def step_then_they_will_receive_page_to_select_the_format(context: runner.Context) -> None:
     """Ensures that they will receive a page to select the format for the credential download.
 
     Args:
         context (runner.Context): Behave context.
     """
-    msg = 'STEP: Then they will receive a page to select the format for the credential download'
-    raise AssertionError(msg)
+    assert 'value="PEM_ZIP"' in context.otp_post_view_response.decode(), \
+        'Page does not contain "Download as ZIP (PEM)" button'
+
 
 
 @given('an incorrect one-time password')
-def step_given_an_incorrect_otp(context: runner.Context) -> None:  # noqa: ARG001
+def step_given_an_incorrect_otp(context: runner.Context) -> None:
     """Ensures that an incorrect one-time password is given.
 
     Args:
         context (runner.Context): Behave context.
     """
-    msg = 'STEP: Given an incorrect one-time password'
-    raise AssertionError(msg)
+    context.otp = 'very_wrong_otp'
 
 
 @then('they will receive a warning saying the OTP is incorrect')
-def step_then_they_will_receive_a_warning(context: runner.Context) -> None:  # noqa: ARG001
+def step_then_they_will_receive_a_warning(context: runner.Context) -> None:
     """Ensures that they will receive a warning saying the OTP is incorrect.
 
     Args:
         context (runner.Context): Behave context.
     """
-    msg = 'STEP: Then they will receive a warning saying the OTP is incorrect'
-    raise AssertionError(msg)
+    assert 'The provided password is not valid.' in context.otp_post_view_response.decode(), \
+        'Page does not contain OTP error message'
 
 
 @given('the user is on the credential download page')
-def step_given_the_user_is_on_the_page(context: runner.Context) -> None:  # noqa: ARG001
+def step_given_the_user_is_on_the_page(context: runner.Context) -> None:
     """Ensures that the user is on the credential download page.
 
     Args:
         context (runner.Context): Behave context.
     """
-    msg = 'STEP: Given the user is on the credential download page'
-    raise AssertionError(msg)
+    try:
+        # This is ugly and a bunch of unnecessary repetition,
+        # but there appears to be no way to make scenarios depend on each other
+        # aka. "Given admin created one time password successfully"
+        # "And user entered the correct OTP and was forwarded to the format selection page"
+        step_given_an_otp(context)
+        step_when_user_visits_endpoint(context)
+        step_then_they_will_receive_page_to_select_the_format(context)
+    except Exception as e:  # noqa: BLE001
+        msg = f'Error in Scenario prerequisites: {e}'
+        raise AssertionError(msg)  # noqa: B904
 
 
 @given('the download token is not yet expired')
-def step_given_the_download_is_not_yet_expired(context: runner.Context) -> None:  # noqa: ARG001
+def step_given_the_download_is_not_yet_expired(context: runner.Context) -> None:
     """Ensures that the download token is not yet expired.
 
     Args:
         context (runner.Context): Behave context.
     """
-    msg = 'STEP: Given the download token is not yet expired'
-    raise AssertionError(msg)
+    assert context.download_token is not None, 'Download token not in context'
+    assert not RemoteDeviceCredentialDownloadModel.objects.get(id=context.download_id).check_token('dummy_token'), \
+        'Dummy token should not be valid'
+
+    assert RemoteDeviceCredentialDownloadModel.objects.get(id=context.download_id).check_token(context.download_token),\
+        'Actual token from URL should be valid'
+
 
 
 @when('the user enters a password to encrypt the credential private key')
-def step_when_the_user_enters_a_pw_to_encrypt_the_cred_priv_key(context: runner.Context) -> None:  # noqa: ARG001
+def step_when_the_user_enters_a_pw_to_encrypt_the_cred_priv_key(context: runner.Context) -> None:
     """Ensures that the user enters a password to encrypt the credential private key.
 
     Args:
         context (runner.Context): Behave context.
     """
-    msg = 'STEP: When the user enters a password to encrypt the credential private key'
-    raise AssertionError(msg)
+    context.test_password = 'testing321321'  # noqa: S105
 
 
 @when('selects a file format')
@@ -148,16 +202,23 @@ def step_when_user_selects_a_file(context: runner.Context) -> None:  # noqa: ARG
     Args:
         context (runner.Context): Behave context.
     """
-    msg = 'STEP: When selects a file format'
-    raise AssertionError(msg)
+    url = f'/devices/browser/credential-download/{context.download_id}/?token={context.download_token}'
+    post_data = {
+        'password': context.test_password,
+        'confirm_password': context.test_password,
+        'file_format': 'PEM_ZIP'
+    }
+    download_response = context.unauthenticated_user_client.post(url, post_data)
+    assert download_response.status_code == HTTP_OK, 'Non-OK response code'
+    context.download_response = download_response
 
 
 @then('the credential will be downloaded to their browser in the requested format')
-def step_when_the_cred_will_be_downloaded(context: runner.Context) -> None:  # noqa: ARG001
+def step_then_the_cred_will_be_downloaded(context: runner.Context) -> None:  # noqa: ARG001
     """Ensures that the credential will be downloaded to their browser in the requested format.
 
     Args:
         context (runner.Context): Behave context.
     """
-    msg = 'STEP: Then the credential will be downloaded to their browser in the requested format'
-    raise AssertionError(msg)
+    assert 'application/zip' in context.download_response['Content-Type'], 'Downloaded file is not a ZIP file'
+    assert 'attachment; filename=' in context.download_response['Content-Disposition'], 'No filename in response'

--- a/trustpoint/features/steps/r_013_steps.py
+++ b/trustpoint/features/steps/r_013_steps.py
@@ -25,9 +25,9 @@ def step_given_issued_credential_exists(context: runner.Context) -> None:
     try:
         models_dict = create_mock_models()
         context.issued_credential_model = IssuedCredentialModel.objects.get(id=models_dict['issued_credential'].id)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         msg = f'Error: {e}'
-        raise AssertionError(msg)  # noqa: B904
+        raise AssertionError(msg) from e
     context.download_view_url = f'/devices/credential-download/browser/{context.issued_credential_model.id}/'
 
 
@@ -59,7 +59,6 @@ def step_then_an_otp_is_displayed(context: runner.Context) -> None:
     element = soup.find(id='otp-display')
     assert element is not None, 'otp-display not in response'
     otp = element.text.strip()
-    print(otp)
     assert len(otp) >= MIN_OTP_LENGTH, 'OTP string shorter than 9 characters'
     assert len(otp) <= MAX_OTP_LENGTH, 'OTP string longer than 32 characters'
 
@@ -81,9 +80,9 @@ def step_given_an_otp(context: runner.Context) -> None:
         step_given_issued_credential_exists(context)
         step_when_admin_visits_the_given_view(context)
         step_then_an_otp_is_displayed(context)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         msg = f'Error in Scenario prerequisites: {e}'
-        raise AssertionError(msg)  # noqa: B904
+        raise AssertionError(msg) from e
     assert context.otp is not None, 'Correct OTP not in context'
 
 
@@ -164,9 +163,9 @@ def step_given_the_user_is_on_the_page(context: runner.Context) -> None:
         step_given_an_otp(context)
         step_when_user_visits_endpoint(context)
         step_then_they_will_receive_page_to_select_the_format(context)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         msg = f'Error in Scenario prerequisites: {e}'
-        raise AssertionError(msg)  # noqa: B904
+        raise AssertionError(msg) from e
 
 
 @given('the download token is not yet expired')
@@ -184,7 +183,6 @@ def step_given_the_download_is_not_yet_expired(context: runner.Context) -> None:
         'Actual token from URL should be valid'
 
 
-
 @when('the user enters a password to encrypt the credential private key')
 def step_when_the_user_enters_a_pw_to_encrypt_the_cred_priv_key(context: runner.Context) -> None:
     """Ensures that the user enters a password to encrypt the credential private key.
@@ -196,7 +194,7 @@ def step_when_the_user_enters_a_pw_to_encrypt_the_cred_priv_key(context: runner.
 
 
 @when('selects a file format')
-def step_when_user_selects_a_file(context: runner.Context) -> None:  # noqa: ARG001
+def step_when_user_selects_a_file(context: runner.Context) -> None:
     """Ensures that the user selects a file format.
 
     Args:
@@ -214,7 +212,7 @@ def step_when_user_selects_a_file(context: runner.Context) -> None:  # noqa: ARG
 
 
 @then('the credential will be downloaded to their browser in the requested format')
-def step_then_the_cred_will_be_downloaded(context: runner.Context) -> None:  # noqa: ARG001
+def step_then_the_cred_will_be_downloaded(context: runner.Context) -> None:
     """Ensures that the credential will be downloaded to their browser in the requested format.
 
     Args:

--- a/uv.lock
+++ b/uv.lock
@@ -1286,6 +1286,7 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "beautifulsoup4" },
     { name = "behave" },
     { name = "behave-django" },
     { name = "behave-html-pretty-formatter" },
@@ -1349,6 +1350,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "beautifulsoup4", specifier = ">=4.13.3" },
     { name = "behave", specifier = ">=1.2.7.dev6" },
     { name = "behave-django", specifier = ">=1.5.0" },
     { name = "behave-html-pretty-formatter", specifier = ">=1.12.3" },


### PR DESCRIPTION
**Description of changes**
Implements all steps for client-server testing of remote credential download

**Notes** <!-- optional -->
Had to fight behave in two ways to a) fail on uncaught exceptions and b) to handle scenarios that build upon one another, both of which is not supported by default. If you have a cleaner approach, I'd be happy to know!

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.