### PR TITLE
docker manual compose fix

### DIFF
--- a/.github/workflows/docker-manual.yml
+++ b/.github/workflows/docker-manual.yml
@@ -5,23 +5,40 @@ on: workflow_dispatch
 jobs:
 
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      GITHUB_SHA: ${{ github.sha }}
+      TAG_VERSION: v0.2.0
 
     steps:
     - uses: actions/checkout@v4
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag trustpoint:${{ github.sha }} --tag trustpoint:v0.2.0 --tag trustpoint:latest
+
     - name: Log in to Docker Hub
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-        
+
+    - name: Build the Docker images using Docker Compose
+      run: docker compose build
+
     - name: Push the Docker image
       run: |
-        docker tag trustpoint:${{ github.sha }} ${{ secrets.DOCKER_HUB_USERNAME }}/trustpoint:${{ github.sha }}
-        docker tag trustpoint:v0.2.0 ${{ secrets.DOCKER_HUB_USERNAME }}/trustpoint:v0.2.0
-        docker tag trustpoint:latest ${{ secrets.DOCKER_HUB_USERNAME }}/trustpoint:latest
-        docker push ${{ secrets.DOCKER_HUB_USERNAME }}/trustpoint:${{ github.sha }}
-        docker push ${{ secrets.DOCKER_HUB_USERNAME }}/trustpoint:v0.2.0
-        docker push ${{ secrets.DOCKER_HUB_USERNAME }}/trustpoint:latest
+        # For the trustpoint container:
+          docker tag $DOCKER_HUB_USERNAME/trustpoint:$GITHUB_SHA $DOCKER_HUB_USERNAME/trustpoint:$GITHUB_SHA
+          docker tag $DOCKER_HUB_USERNAME/trustpoint:$GITHUB_SHA $DOCKER_HUB_USERNAME/trustpoint:$TAG_VERSION
+          docker tag $DOCKER_HUB_USERNAME/trustpoint:$GITHUB_SHA $DOCKER_HUB_USERNAME/trustpoint:latest
+
+          docker push $DOCKER_HUB_USERNAME/trustpoint:$GITHUB_SHA
+          docker push $DOCKER_HUB_USERNAME/trustpoint:$TAG_VERSION
+          docker push $DOCKER_HUB_USERNAME/trustpoint:latest
+        
+        # For the postgres container:
+          docker tag $DOCKER_HUB_USERNAME/postgres:$GITHUB_SHA $DOCKER_HUB_USERNAME/postgres:$GITHUB_SHA
+          docker tag $DOCKER_HUB_USERNAME/postgres:$GITHUB_SHA $DOCKER_HUB_USERNAME/postgres:$TAG_VERSION
+          docker tag $DOCKER_HUB_USERNAME/postgres:$GITHUB_SHA $DOCKER_HUB_USERNAME/postgres:latest
+
+          docker push $DOCKER_HUB_USERNAME/postgres:$GITHUB_SHA
+          docker push $DOCKER_HUB_USERNAME/postgres:$TAG_VERSION
+          docker push $DOCKER_HUB_USERNAME/postgres:latest


### PR DESCRIPTION
**Description of changes**
Docker compose build must be used for providing the containers on Dockerhub.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ x ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.