### PR TITLE
Make login required by default

### DIFF
--- a/trustpoint/devices/views.py
+++ b/trustpoint/devices/views.py
@@ -43,7 +43,7 @@ from devices.models import (
     RemoteDeviceCredentialDownloadModel)
 from devices.revocation import DeviceCredentialRevocation
 from trustpoint.settings import UIConfig
-from trustpoint.views.base import ListInDetailView, SortableTableMixin, TpLoginRequiredMixin
+from trustpoint.views.base import ListInDetailView, SortableTableMixin, no_login
 
 if TYPE_CHECKING:
     from typing import Any, ClassVar
@@ -94,7 +94,7 @@ class DownloadTokenRequiredMixin:
         return super().dispatch(request, *args, **kwargs)
 
 
-class DeviceTableView(DeviceContextMixin, TpLoginRequiredMixin, SortableTableMixin, ListView):
+class DeviceTableView(DeviceContextMixin, SortableTableMixin, ListView):
     """Device Table View."""
 
     model = DeviceModel
@@ -151,7 +151,7 @@ class DeviceTableView(DeviceContextMixin, TpLoginRequiredMixin, SortableTableMix
 
 
 
-class CreateDeviceView(DeviceContextMixin, TpLoginRequiredMixin, CreateView):
+class CreateDeviceView(DeviceContextMixin, CreateView):
     """Device Create View."""
 
     http_method_names = ('get', 'post')
@@ -190,7 +190,7 @@ class CreateDeviceView(DeviceContextMixin, TpLoginRequiredMixin, CreateView):
         return super().form_valid(form)
 
 
-class NoOnboardingCmpSharedSecretHelpView(DeviceContextMixin, TpLoginRequiredMixin, Detail404RedirectView[DeviceModel]):
+class NoOnboardingCmpSharedSecretHelpView(DeviceContextMixin, Detail404RedirectView[DeviceModel]):
 
     model = DeviceModel
     template_name = 'devices/help/no_onboarding/cmp_shared_secret.html'
@@ -216,7 +216,7 @@ class NoOnboardingCmpSharedSecretHelpView(DeviceContextMixin, TpLoginRequiredMix
         return context
 
 
-class OnboardingCmpSharedSecretHelpView(DeviceContextMixin, TpLoginRequiredMixin, Detail404RedirectView[DeviceModel]):
+class OnboardingCmpSharedSecretHelpView(DeviceContextMixin, Detail404RedirectView[DeviceModel]):
 
     model = DeviceModel
     template_name = 'devices/help/onboarding/cmp_shared_secret.html'
@@ -249,7 +249,7 @@ class OnboardingCmpSharedSecretHelpView(DeviceContextMixin, TpLoginRequiredMixin
         return context
 
 
-class OnboardingCmpIdevidHelpView(DeviceContextMixin, TpLoginRequiredMixin, Detail404RedirectView[DeviceModel]):
+class OnboardingCmpIdevidHelpView(DeviceContextMixin, Detail404RedirectView[DeviceModel]):
 
     model = DeviceModel
     template_name = 'devices/help/onboarding/cmp_idevid.html'
@@ -282,7 +282,7 @@ class OnboardingCmpIdevidHelpView(DeviceContextMixin, TpLoginRequiredMixin, Deta
         return context
 
 
-class DeviceDetailsView(DeviceContextMixin, TpLoginRequiredMixin, Detail404RedirectView[DeviceModel]):
+class DeviceDetailsView(DeviceContextMixin, Detail404RedirectView[DeviceModel]):
     """Device Details View."""
 
     http_method_names = ('get',)
@@ -293,7 +293,7 @@ class DeviceDetailsView(DeviceContextMixin, TpLoginRequiredMixin, Detail404Redir
     context_object_name = 'device'
 
 
-class DeviceConfigureView(DeviceContextMixin, TpLoginRequiredMixin, Detail404RedirectView[DeviceModel]):
+class DeviceConfigureView(DeviceContextMixin, Detail404RedirectView[DeviceModel]):
     """Device Configuration View."""
 
     http_method_names = ('get',)
@@ -432,13 +432,13 @@ class DeviceBaseCredentialDownloadView(DeviceContextMixin,
         return cast('HttpResponse', response)
 
 
-class DeviceManualCredentialDownloadView(TpLoginRequiredMixin, DeviceBaseCredentialDownloadView):
+class DeviceManualCredentialDownloadView(DeviceBaseCredentialDownloadView):
     """View to download a password protected domain or application credential in the desired format.
 
     This CBV does intentionally not require the authentication mixin.
     """
 
-
+@no_login
 class DeviceBrowserCredentialDownloadView(DownloadTokenRequiredMixin, DeviceBaseCredentialDownloadView):
     """View to download a password protected domain or app credential in the desired format from a remote client.
 
@@ -449,7 +449,7 @@ class DeviceBrowserCredentialDownloadView(DownloadTokenRequiredMixin, DeviceBase
 
 
 class DeviceIssueTlsClientCredential(
-    DeviceContextMixin, TpLoginRequiredMixin, DetailView[DeviceModel], FormView[IssueTlsClientCredentialForm]
+    DeviceContextMixin, DetailView[DeviceModel], FormView[IssueTlsClientCredentialForm]
 ):
     """View to issue a new TLS client credential."""
 
@@ -519,7 +519,7 @@ class DeviceIssueTlsClientCredential(
 
 
 class DeviceIssueTlsServerCredential(
-    DeviceContextMixin, TpLoginRequiredMixin, DetailView[DeviceModel], FormView[IssueTlsServerCredentialForm]
+    DeviceContextMixin, DetailView[DeviceModel], FormView[IssueTlsServerCredentialForm]
 ):
     """View to issue a new TLS server credential."""
 
@@ -604,7 +604,7 @@ class DeviceIssueTlsServerCredential(
 
 
 class DeviceCertificateLifecycleManagementSummaryView(
-    DeviceContextMixin, TpLoginRequiredMixin, SortableTableMixin, ListInDetailView[DeviceModel]
+    DeviceContextMixin, SortableTableMixin, ListInDetailView[DeviceModel]
 ):
     """This is the CLM summary view in the devices section."""
 
@@ -703,7 +703,7 @@ class DeviceCertificateLifecycleManagementSummaryView(
                            record.pk, _('Revoke'))
 
 
-class DeviceRevocationView(DeviceContextMixin, TpLoginRequiredMixin, FormMixin, ListView):
+class DeviceRevocationView(DeviceContextMixin, FormMixin, ListView):
     """Revokes all active credentials for a given device."""
 
     http_method_names = ('get', 'post')
@@ -755,7 +755,7 @@ class DeviceRevocationView(DeviceContextMixin, TpLoginRequiredMixin, FormMixin, 
         return super().form_valid(form)
 
 
-class DeviceCredentialRevocationView(DeviceContextMixin, TpLoginRequiredMixin, Detail404RedirectView, FormView):
+class DeviceCredentialRevocationView(DeviceContextMixin, Detail404RedirectView, FormView):
     """Revokes a specific issued credential."""
 
     http_method_names = ('get', 'post')
@@ -791,7 +791,7 @@ class DeviceCredentialRevocationView(DeviceContextMixin, TpLoginRequiredMixin, D
         return super().form_valid(form)
 
 
-class DeviceBrowserOnboardingOTPView(DeviceContextMixin, TpLoginRequiredMixin, Detail404RedirectView, RedirectView):
+class DeviceBrowserOnboardingOTPView(DeviceContextMixin, Detail404RedirectView, RedirectView):
     """View to display the OTP for remote credential download (aka. browser onboarding)."""
 
     model = IssuedCredentialModel
@@ -822,7 +822,7 @@ class DeviceBrowserOnboardingOTPView(DeviceContextMixin, TpLoginRequiredMixin, D
         return render(request, self.template_name, context)
 
 
-class DeviceBrowserOnboardingCancelView(DeviceContextMixin, TpLoginRequiredMixin, Detail404RedirectView, RedirectView):
+class DeviceBrowserOnboardingCancelView(DeviceContextMixin, Detail404RedirectView, RedirectView):
     """View to cancel the browser onboarding process and delete the associated RemoteDeviceCredentialDownloadModel."""
 
     model = IssuedCredentialModel
@@ -847,7 +847,7 @@ class DeviceBrowserOnboardingCancelView(DeviceContextMixin, TpLoginRequiredMixin
 
         return redirect(self.get_redirect_url())
 
-
+@no_login
 class DeviceOnboardingBrowserLoginView(FormView):
     """View to handle certificate download requests."""
 
@@ -880,7 +880,7 @@ class DeviceOnboardingBrowserLoginView(FormView):
         return redirect(url)
 
 
-class HelpDispatchView(DeviceContextMixin, TpLoginRequiredMixin, SingleObjectMixin, RedirectView):
+class HelpDispatchView(DeviceContextMixin, SingleObjectMixin, RedirectView):
 
     model: type[DeviceModel] = DeviceModel
     permanent = False
@@ -901,7 +901,7 @@ class HelpDispatchView(DeviceContextMixin, TpLoginRequiredMixin, SingleObjectMix
         return f"{reverse('devices:devices')}"
 
 
-class DownloadPageDispatcherView(DeviceContextMixin, TpLoginRequiredMixin, SingleObjectMixin, RedirectView):
+class DownloadPageDispatcherView(DeviceContextMixin, SingleObjectMixin, RedirectView):
 
     model: type[IssuedCredentialModel] = IssuedCredentialModel
     permanent = False
@@ -913,7 +913,7 @@ class DownloadPageDispatcherView(DeviceContextMixin, TpLoginRequiredMixin, Singl
         return f'{reverse("devices:certificate-download", kwargs={"pk": issued_credential.id})}'
 
 
-class CertificateDownloadView(DeviceContextMixin, TpLoginRequiredMixin, DetailView):
+class CertificateDownloadView(DeviceContextMixin, DetailView):
 
     http_method_names = ('get',)
 
@@ -922,7 +922,7 @@ class CertificateDownloadView(DeviceContextMixin, TpLoginRequiredMixin, DetailVi
     context_object_name = 'issued_credential'
 
 
-class OnboardingIdevidRegistrationHelpView(DeviceContextMixin, TpLoginRequiredMixin, Detail404RedirectView[DevIdRegistration]):
+class OnboardingIdevidRegistrationHelpView(DeviceContextMixin, Detail404RedirectView[DevIdRegistration]):
 
     model = DevIdRegistration
     template_name = 'devices/help/onboarding/cmp_idevid_registration.html'

--- a/trustpoint/home/views.py
+++ b/trustpoint/home/views.py
@@ -23,7 +23,7 @@ from django.views.generic.list import ListView
 from pki.models import CertificateModel, IssuingCaModel
 
 from trustpoint.settings import UIConfig
-from trustpoint.views.base import SortableTableMixin, TpLoginRequiredMixin
+from trustpoint.views.base import SortableTableMixin
 
 from .filters import NotificationFilter
 from .models import NotificationModel, NotificationStatus
@@ -35,14 +35,14 @@ SUCCESS = 25
 ERROR = 40
 
 
-class IndexView(TpLoginRequiredMixin, RedirectView):
+class IndexView(RedirectView):
     """Redirects authenticated users to the dashboard page."""
 
     permanent = False
     pattern_name = 'home:dashboard'
 
 
-class DashboardView(TpLoginRequiredMixin, SortableTableMixin, ListView):
+class DashboardView(SortableTableMixin, ListView):
     """Renders the dashboard page for authenticated users. Uses the 'home/dashboard.html' template."""
 
     template_name = 'home/dashboard.html'
@@ -159,7 +159,7 @@ def mark_as_solved(request: HttpRequest, pk: int | str) -> HttpResponse:
     return render(request, 'home/notification_details.html', context)
 
 
-class AddDomainsAndDevicesView(TpLoginRequiredMixin, TemplateView):
+class AddDomainsAndDevicesView(TemplateView):
     """View to execute the add_domains_and_devices management command and pass status to the template."""
 
     _logger = logging.getLogger(__name__)
@@ -177,7 +177,7 @@ class AddDomainsAndDevicesView(TpLoginRequiredMixin, TemplateView):
         return redirect('home:dashboard')
 
 
-class DashboardChartsAndCountsView(TpLoginRequiredMixin, TemplateView):
+class DashboardChartsAndCountsView(TemplateView):
     """View to mark the notification as Solved."""
 
     _logger = logging.getLogger(__name__)

--- a/trustpoint/pki/views/certificates.py
+++ b/trustpoint/pki/views/certificates.py
@@ -14,13 +14,13 @@ from django.views.generic.list import ListView
 
 from pki.models import CertificateModel
 from trustpoint.settings import UIConfig
-from trustpoint.views.base import PrimaryKeyListFromPrimaryKeyString, SortableTableMixin, TpLoginRequiredMixin
+from trustpoint.views.base import PrimaryKeyListFromPrimaryKeyString, SortableTableMixin
 
 if TYPE_CHECKING:
     from typing import ClassVar
 
 
-class CertificatesRedirectView(TpLoginRequiredMixin, RedirectView):
+class CertificatesRedirectView(RedirectView):
     """View that redirects to the index of the PKI Issuing CA application: Issuing CAs."""
 
     permanent = False
@@ -33,7 +33,7 @@ class CertificatesContextMixin:
     extra_context: ClassVar = {'page_category': 'pki', 'page_name': 'certificates'}
 
 
-class CertificateTableView(CertificatesContextMixin, TpLoginRequiredMixin, SortableTableMixin, ListView):
+class CertificateTableView(CertificatesContextMixin, SortableTableMixin, ListView):
     """Certificate Table View."""
 
     model = CertificateModel
@@ -42,7 +42,7 @@ class CertificateTableView(CertificatesContextMixin, TpLoginRequiredMixin, Sorta
     paginate_by = UIConfig.paginate_by
     default_sort_param = 'common_name'
 
-class CertificateDetailView(CertificatesContextMixin, TpLoginRequiredMixin, DetailView):
+class CertificateDetailView(CertificatesContextMixin, DetailView):
     """The certificate detail view."""
 
     model = CertificateModel
@@ -51,7 +51,7 @@ class CertificateDetailView(CertificatesContextMixin, TpLoginRequiredMixin, Deta
     template_name = 'pki/certificates/details.html'
     context_object_name = 'cert'
 
-class CmpIssuingCaCertificateDownloadView(CertificatesContextMixin, TpLoginRequiredMixin, DetailView):
+class CmpIssuingCaCertificateDownloadView(CertificatesContextMixin, DetailView):
     """View for downloading a single certificate."""
 
     model = CertificateModel
@@ -89,7 +89,7 @@ class CmpIssuingCaCertificateDownloadView(CertificatesContextMixin, TpLoginRequi
         return response
 
 
-class CertificateDownloadView(CertificatesContextMixin, TpLoginRequiredMixin, DetailView):
+class CertificateDownloadView(CertificatesContextMixin, DetailView):
     """View for downloading a single certificate."""
 
     model = CertificateModel
@@ -142,7 +142,7 @@ class CertificateDownloadView(CertificatesContextMixin, TpLoginRequiredMixin, De
 
 
 class CertificateMultipleDownloadView(
-    CertificatesContextMixin, TpLoginRequiredMixin, PrimaryKeyListFromPrimaryKeyString, ListView
+    CertificatesContextMixin, PrimaryKeyListFromPrimaryKeyString, ListView
 ):
     """View for downloading multiple certificates at once as archived files."""
 

--- a/trustpoint/pki/views/domains.py
+++ b/trustpoint/pki/views/domains.py
@@ -22,7 +22,7 @@ from trustpoint.views.base import (
     ContextDataMixin,
     ListInDetailView,
     SortableTableMixin,
-    TpLoginRequiredMixin,
+    no_login,
 )
 
 
@@ -42,7 +42,7 @@ class DomainContextMixin(ContextDataMixin):
     context_page_name = 'domains'
 
 
-class DomainTableView(DomainContextMixin, TpLoginRequiredMixin, SortableTableMixin, ListView):
+class DomainTableView(DomainContextMixin, SortableTableMixin, ListView):
     """Domain Table View."""
 
     model = DomainModel
@@ -52,7 +52,7 @@ class DomainTableView(DomainContextMixin, TpLoginRequiredMixin, SortableTableMix
     default_sort_param = 'unique_name'
 
 
-class DomainCreateView(DomainContextMixin, TpLoginRequiredMixin, CreateView):
+class DomainCreateView(DomainContextMixin, CreateView):
     """View to create a new domain."""
 
     model = DomainModel
@@ -73,7 +73,7 @@ class DomainCreateView(DomainContextMixin, TpLoginRequiredMixin, CreateView):
         return form
 
 
-class DomainUpdateView(DomainContextMixin, TpLoginRequiredMixin, UpdateView):
+class DomainUpdateView(DomainContextMixin, UpdateView):
     """View to edit a domain."""
 
     # TODO(Air): This view is currently UNUSED.
@@ -98,7 +98,7 @@ class DomainDevIdRegistrationTableMixin(SortableTableMixin, ListInDetailView):
         return super().get_queryset()
 
 
-class DomainConfigView(DomainContextMixin, TpLoginRequiredMixin, DomainDevIdRegistrationTableMixin, ListInDetailView):
+class DomainConfigView(DomainContextMixin, DomainDevIdRegistrationTableMixin, ListInDetailView):
     detail_model = DomainModel
     template_name = 'pki/domains/config.html'
     detail_context_object_name = 'domain'
@@ -134,14 +134,14 @@ class DomainConfigView(DomainContextMixin, TpLoginRequiredMixin, DomainDevIdRegi
         return HttpResponseRedirect(self.success_url)
 
 
-class DomainDetailView(DomainContextMixin, TpLoginRequiredMixin, DomainDevIdRegistrationTableMixin, ListInDetailView):
+class DomainDetailView(DomainContextMixin, DomainDevIdRegistrationTableMixin, ListInDetailView):
 
     detail_model = DomainModel
     template_name = 'pki/domains/details.html'
     detail_context_object_name = 'domain'
 
 
-class DomainCaBulkDeleteConfirmView(DomainContextMixin, TpLoginRequiredMixin, BulkDeleteView):
+class DomainCaBulkDeleteConfirmView(DomainContextMixin, BulkDeleteView):
     """View to confirm the deletion of multiple Domains."""
 
     model = DomainModel
@@ -174,7 +174,7 @@ class DomainCaBulkDeleteConfirmView(DomainContextMixin, TpLoginRequiredMixin, Bu
         return response
 
 
-class DevIdRegistrationCreateView(DomainContextMixin, TpLoginRequiredMixin, FormView):
+class DevIdRegistrationCreateView(DomainContextMixin, FormView):
     """View to create a new DevID Registration."""
 
     http_method_names = ('get', 'post')
@@ -241,7 +241,7 @@ class DevIdRegistrationCreateView(DomainContextMixin, TpLoginRequiredMixin, Form
         domain = self.get_domain()
         return cast('str', reverse_lazy('pki:domains-config', kwargs={'pk': domain.id}))
 
-class DevIdRegistrationDeleteView(DomainContextMixin, TpLoginRequiredMixin, DeleteView):
+class DevIdRegistrationDeleteView(DomainContextMixin, DeleteView):
     """View to delete a DevID Registration."""
     model = DevIdRegistration
     template_name = 'pki/devid_registration/confirm_delete.html'
@@ -253,7 +253,7 @@ class DevIdRegistrationDeleteView(DomainContextMixin, TpLoginRequiredMixin, Dele
         messages.success(request, _('DevID Registration Pattern deleted successfully.'))
         return response
 
-class DevIdMethodSelectView(DomainContextMixin, TpLoginRequiredMixin, FormView):
+class DevIdMethodSelectView(DomainContextMixin, FormView):
     template_name = 'pki/devid_registration/method_select.html'
     form_class = DevIdAddMethodSelectForm
 

--- a/trustpoint/pki/views/issuing_cas.py
+++ b/trustpoint/pki/views/issuing_cas.py
@@ -20,18 +20,17 @@ from trustpoint.views.base import (
     LoggerMixin,
     BulkDeleteView,
     ContextDataMixin,
-    SortableTableMixin,
-    TpLoginRequiredMixin,
+    SortableTableMixin
 )
 
 
-class IssuingCaContextMixin(TpLoginRequiredMixin, ContextDataMixin):
+class IssuingCaContextMixin(ContextDataMixin):
     """Mixin which adds context_data for the PKI -> Issuing CAs pages."""
 
     context_page_category = 'pki'
     context_page_name = 'issuing_cas'
 
-class IssuingCaTableView(IssuingCaContextMixin, TpLoginRequiredMixin, SortableTableMixin, ListView):
+class IssuingCaTableView(IssuingCaContextMixin, SortableTableMixin, ListView):
     """Issuing CA Table View."""
 
     model = IssuingCaModel
@@ -41,7 +40,7 @@ class IssuingCaTableView(IssuingCaContextMixin, TpLoginRequiredMixin, SortableTa
     default_sort_param = 'unique_name'
 
 
-class IssuingCaAddMethodSelectView(IssuingCaContextMixin, TpLoginRequiredMixin, FormView):
+class IssuingCaAddMethodSelectView(IssuingCaContextMixin, FormView):
     template_name = 'pki/issuing_cas/add/method_select.html'
     form_class = IssuingCaAddMethodSelectForm
 
@@ -56,21 +55,21 @@ class IssuingCaAddMethodSelectView(IssuingCaContextMixin, TpLoginRequiredMixin, 
         return HttpResponseRedirect(reverse_lazy('pki:issuing_cas-add-method_select'))
 
 
-class IssuingCaAddFileImportPkcs12View(IssuingCaContextMixin, TpLoginRequiredMixin, FormView):
+class IssuingCaAddFileImportPkcs12View(IssuingCaContextMixin, FormView):
 
     template_name = 'pki/issuing_cas/add/file_import.html'
     form_class = IssuingCaAddFileImportPkcs12Form
     success_url = reverse_lazy('pki:issuing_cas')
 
 
-class IssuingCaAddFileImportSeparateFilesView(IssuingCaContextMixin, TpLoginRequiredMixin, FormView):
+class IssuingCaAddFileImportSeparateFilesView(IssuingCaContextMixin, FormView):
 
     template_name = 'pki/issuing_cas/add/file_import.html'
     form_class = IssuingCaAddFileImportSeparateFilesForm
     success_url = reverse_lazy('pki:issuing_cas')
 
 
-class IssuingCaDetailView(IssuingCaContextMixin, TpLoginRequiredMixin, DetailView):
+class IssuingCaDetailView(IssuingCaContextMixin, DetailView):
 
     http_method_names = ('get', )
 
@@ -82,7 +81,7 @@ class IssuingCaDetailView(IssuingCaContextMixin, TpLoginRequiredMixin, DetailVie
 
 
 
-class IssuingCaConfigView(LoggerMixin, IssuingCaContextMixin, TpLoginRequiredMixin, DetailView):
+class IssuingCaConfigView(LoggerMixin, IssuingCaContextMixin, DetailView):
 
     model = IssuingCaModel
     success_url = reverse_lazy('pki:issuing_cas')
@@ -91,7 +90,7 @@ class IssuingCaConfigView(LoggerMixin, IssuingCaContextMixin, TpLoginRequiredMix
     context_object_name = 'issuing_ca'
 
 
-class IssuingCaBulkDeleteConfirmView(IssuingCaContextMixin, TpLoginRequiredMixin, BulkDeleteView):
+class IssuingCaBulkDeleteConfirmView(IssuingCaContextMixin, BulkDeleteView):
     """View to confirm the deletion of multiple Issuing CAs."""
 
     model = IssuingCaModel
@@ -124,7 +123,7 @@ class IssuingCaBulkDeleteConfirmView(IssuingCaContextMixin, TpLoginRequiredMixin
         return response
 
 
-class IssuingCaCrlGenerationView(IssuingCaContextMixin, TpLoginRequiredMixin, DetailView):
+class IssuingCaCrlGenerationView(IssuingCaContextMixin, DetailView):
     """View to manually generate a CRL for an Issuing CA."""
 
     model = IssuingCaModel

--- a/trustpoint/pki/views/truststores.py
+++ b/trustpoint/pki/views/truststores.py
@@ -25,14 +25,13 @@ from trustpoint.views.base import (
     BulkDeleteView,
     PrimaryKeyListFromPrimaryKeyString,
     SortableTableMixin,
-    TpLoginRequiredMixin,
 )
 
 if TYPE_CHECKING:
     from typing import ClassVar
 
 
-class TruststoresRedirectView(TpLoginRequiredMixin, RedirectView):
+class TruststoresRedirectView(RedirectView):
     """View that redirects to the index of the PKI Truststores application: Truststores."""
 
     permanent = False
@@ -44,7 +43,7 @@ class TruststoresContextMixin:
 
     extra_context: ClassVar = {'page_category': 'pki', 'page_name': 'truststores'}
 
-class TruststoreTableView(TruststoresContextMixin, TpLoginRequiredMixin, SortableTableMixin, ListView):
+class TruststoreTableView(TruststoresContextMixin, SortableTableMixin, ListView):
     """Truststore Table View."""
 
     model = TruststoreModel
@@ -54,7 +53,7 @@ class TruststoreTableView(TruststoresContextMixin, TpLoginRequiredMixin, Sortabl
     default_sort_param = 'unique_name'
 
 
-class TruststoreCreateView(TruststoresContextMixin, TpLoginRequiredMixin, FormView):
+class TruststoreCreateView(TruststoresContextMixin, FormView):
     """View for creating a new Truststore."""
 
     model = TruststoreModel
@@ -83,7 +82,7 @@ class TruststoreCreateView(TruststoresContextMixin, TpLoginRequiredMixin, FormVi
             context["domain"] = get_object_or_404(DomainModel, id=pk)
         return context
 
-class TruststoreDetailView(TruststoresContextMixin, TpLoginRequiredMixin, DetailView):
+class TruststoreDetailView(TruststoresContextMixin, DetailView):
     """The truststore detail view."""
 
     model = TruststoreModel
@@ -92,7 +91,7 @@ class TruststoreDetailView(TruststoresContextMixin, TpLoginRequiredMixin, Detail
     template_name = 'pki/truststores/details.html'
     context_object_name = 'truststore'
 
-class TruststoreDownloadView(TruststoresContextMixin, TpLoginRequiredMixin, DetailView):
+class TruststoreDownloadView(TruststoresContextMixin, DetailView):
     """View for downloading a single truststore."""
 
     model = TruststoreModel
@@ -147,7 +146,7 @@ class TruststoreDownloadView(TruststoresContextMixin, TpLoginRequiredMixin, Deta
         return response
 
 class TruststoreMultipleDownloadView(
-    TruststoresContextMixin, TpLoginRequiredMixin, PrimaryKeyListFromPrimaryKeyString, ListView
+    TruststoresContextMixin, PrimaryKeyListFromPrimaryKeyString, ListView
 ):
     """View for downloading multiple truststores at once as archived files."""
 
@@ -239,7 +238,7 @@ class TruststoreMultipleDownloadView(
 
         return response
 
-class TruststoreBulkDeleteConfirmView(TruststoresContextMixin, TpLoginRequiredMixin, BulkDeleteView):
+class TruststoreBulkDeleteConfirmView(TruststoresContextMixin, BulkDeleteView):
     """View for confirming the deletion of multiple truststores."""
 
     model = TruststoreModel

--- a/trustpoint/settings/views/logging.py
+++ b/trustpoint/settings/views/logging.py
@@ -18,7 +18,7 @@ from django.views.generic.base import RedirectView
 from django.views.generic.list import ListView
 
 from trustpoint.settings import DATE_FORMAT, LOG_DIR_PATH, UIConfig
-from trustpoint.views.base import LoggerMixin, SortableTableMixin, TpLoginRequiredMixin
+from trustpoint.views.base import LoggerMixin, SortableTableMixin
 
 if TYPE_CHECKING:
     from typing import Any, ClassVar
@@ -52,7 +52,7 @@ class LoggingContextMixin:
     }
 
 
-class LoggingFilesTableView(LoggerMixin, TpLoginRequiredMixin, LoggingContextMixin, SortableTableMixin, ListView):
+class LoggingFilesTableView(LoggerMixin, LoggingContextMixin, SortableTableMixin, ListView):
     """View to display all log files in the log directory in a table."""
     http_method_names = ('get', )
 
@@ -113,7 +113,7 @@ class LoggingFilesTableView(LoggerMixin, TpLoginRequiredMixin, LoggingContextMix
         self.queryset = [self._get_log_file_data(log_file_name) for log_file_name in valid_log_files]
         return super().get_queryset()
 
-class LoggingFilesDetailsView(LoggerMixin, LoggingContextMixin, TpLoginRequiredMixin, TemplateView):
+class LoggingFilesDetailsView(LoggerMixin, LoggingContextMixin, TemplateView):
     """Log file detail view, allows to view the content of a single log file without download."""
     http_method_names = ('get', )
 
@@ -136,7 +136,7 @@ class LoggingFilesDetailsView(LoggerMixin, LoggingContextMixin, TpLoginRequiredM
         return context
 
 
-class LoggingFilesDownloadView(LoggerMixin, LoggingContextMixin, TpLoginRequiredMixin, TemplateView):
+class LoggingFilesDownloadView(LoggerMixin, LoggingContextMixin, TemplateView):
     """View to download a single log file"""
     http_method_names = ('get', )
 
@@ -155,7 +155,7 @@ class LoggingFilesDownloadView(LoggerMixin, LoggingContextMixin, TpLoginRequired
         return response
 
 
-class LoggingFilesDownloadMultipleView(LoggerMixin, LoggingContextMixin, TpLoginRequiredMixin, View):
+class LoggingFilesDownloadMultipleView(LoggerMixin, LoggingContextMixin, View):
     """View to download multiple log files as a single archive."""
     http_method_names = ('get', )
 

--- a/trustpoint/settings/views/security.py
+++ b/trustpoint/settings/views/security.py
@@ -14,16 +14,13 @@ from settings.forms import SecurityConfigForm
 from settings.models import SecurityConfig
 from settings.security.features import AutoGenPkiFeature
 from settings.security.mixins import SecurityLevelMixin
-from trustpoint.views.base import (
-    TpLoginRequiredMixin,
-)
 
 if TYPE_CHECKING:
     from typing import Any
 
 
 
-class SecurityView(TpLoginRequiredMixin, SecurityLevelMixin, FormView):
+class SecurityView(SecurityLevelMixin, FormView):
     template_name = 'settings/security.html'
     form_class = SecurityConfigForm
     success_url = reverse_lazy('settings:security')

--- a/trustpoint/setup_wizard/views.py
+++ b/trustpoint/setup_wizard/views.py
@@ -120,7 +120,6 @@ class StartupWizardRedirect:
         err_msg = 'Unknown wizard state found. Failed to redirect by state.'
         raise ValueError(err_msg)
 
-@no_login
 class SetupWizardInitialView(TemplateView):
     """View for the initial step of the setup wizard.
 
@@ -163,7 +162,6 @@ class SetupWizardInitialView(TemplateView):
         return super().get(*args, **kwargs)
 
 
-@no_login
 class SetupWizardGenerateTlsServerCredentialView(FormView):
     """View for generating TLS Server Credentials in the setup wizard.
 
@@ -267,7 +265,6 @@ class SetupWizardGenerateTlsServerCredentialView(FormView):
         return error_messages.get(return_code, 'An unknown error occurred.')
 
 
-@no_login
 class SetupWizardImportTlsServerCredentialView(View):
     """View for handling the import of TLS Server Credentials."""
 
@@ -294,7 +291,6 @@ class SetupWizardImportTlsServerCredentialView(View):
         return redirect('setup_wizard:initial', permanent=False)
 
 
-@no_login
 class SetupWizardTlsServerCredentialApplyView(FormView):
     """View for handling the application of TLS Server Credentials in the setup wizard.
 
@@ -484,7 +480,6 @@ class SetupWizardTlsServerCredentialApplyView(FormView):
         APACHE_CERT_CHAIN_PATH.write_text(trust_store_pem)
 
 
-@no_login
 class SetupWizardTlsServerCredentialApplyCancelView(View):
     """View for handling the cancellation of TLS Server Credential application.
 
@@ -555,7 +550,6 @@ class SetupWizardTlsServerCredentialApplyCancelView(View):
         return error_messages.get(return_code, 'An unknown error occurred during the cancel operation.')
 
 
-@no_login
 class SetupWizardDemoDataView(FormView):
     """View for handling the demo data setup during the setup wizard.
 
@@ -653,7 +647,6 @@ class SetupWizardDemoDataView(FormView):
         return error_messages.get(return_code, 'An unknown error occurred while executing the demo data script.')
 
 
-@no_login
 class SetupWizardCreateSuperUserView(FormView):
     """View for handling the creation of a superuser during the setup wizard.
 

--- a/trustpoint/setup_wizard/views.py
+++ b/trustpoint/setup_wizard/views.py
@@ -22,6 +22,7 @@ from setup_wizard import SetupWizardState
 from setup_wizard.forms import EmptyForm, StartupWizardTlsCertificateForm
 from setup_wizard.tls_credential import Generator
 from trustpoint.settings import DOCKER_CONTAINER
+from trustpoint.views.base import no_login
 
 APACHE_PATH = Path(__file__).parent.parent.parent / 'docker/apache/tls'
 APACHE_KEY_PATH = APACHE_PATH / Path('apache-tls-server-key.key')
@@ -34,7 +35,6 @@ SCRIPT_WIZARD_TLS_SERVER_CREDENTIAL_APPLY = STATE_FILE_DIR / Path('wizard_tls_se
 SCRIPT_WIZARD_TLS_SERVER_CREDENTIAL_APPLY_CANCEL = STATE_FILE_DIR / Path('wizard_tls_server_credential_apply_cancel.sh')
 SCRIPT_WIZARD_DEMO_DATA = STATE_FILE_DIR / Path('wizard_demo_data.sh')
 SCRIPT_WIZARD_CREATE_SUPER_USER = STATE_FILE_DIR / Path('wizard_create_super_user.sh')
-
 
 class TrustpointWizardError(Exception):
     """Custom exception for Trustpoint wizard-related issues."""
@@ -120,7 +120,7 @@ class StartupWizardRedirect:
         err_msg = 'Unknown wizard state found. Failed to redirect by state.'
         raise ValueError(err_msg)
 
-
+@no_login
 class SetupWizardInitialView(TemplateView):
     """View for the initial step of the setup wizard.
 
@@ -163,6 +163,7 @@ class SetupWizardInitialView(TemplateView):
         return super().get(*args, **kwargs)
 
 
+@no_login
 class SetupWizardGenerateTlsServerCredentialView(FormView):
     """View for generating TLS Server Credentials in the setup wizard.
 
@@ -266,6 +267,7 @@ class SetupWizardGenerateTlsServerCredentialView(FormView):
         return error_messages.get(return_code, 'An unknown error occurred.')
 
 
+@no_login
 class SetupWizardImportTlsServerCredentialView(View):
     """View for handling the import of TLS Server Credentials."""
 
@@ -292,6 +294,7 @@ class SetupWizardImportTlsServerCredentialView(View):
         return redirect('setup_wizard:initial', permanent=False)
 
 
+@no_login
 class SetupWizardTlsServerCredentialApplyView(FormView):
     """View for handling the application of TLS Server Credentials in the setup wizard.
 
@@ -481,6 +484,7 @@ class SetupWizardTlsServerCredentialApplyView(FormView):
         APACHE_CERT_CHAIN_PATH.write_text(trust_store_pem)
 
 
+@no_login
 class SetupWizardTlsServerCredentialApplyCancelView(View):
     """View for handling the cancellation of TLS Server Credential application.
 
@@ -551,6 +555,7 @@ class SetupWizardTlsServerCredentialApplyCancelView(View):
         return error_messages.get(return_code, 'An unknown error occurred during the cancel operation.')
 
 
+@no_login
 class SetupWizardDemoDataView(FormView):
     """View for handling the demo data setup during the setup wizard.
 
@@ -648,6 +653,7 @@ class SetupWizardDemoDataView(FormView):
         return error_messages.get(return_code, 'An unknown error occurred while executing the demo data script.')
 
 
+@no_login
 class SetupWizardCreateSuperUserView(FormView):
     """View for handling the creation of a superuser during the setup wizard.
 

--- a/trustpoint/trustpoint/middleware/LoginRequiredMiddleware.py
+++ b/trustpoint/trustpoint/middleware/LoginRequiredMiddleware.py
@@ -3,8 +3,7 @@ from django.contrib.auth.middleware import LoginRequiredMiddleware
 
 
 class LoginRequired(LoginRequiredMiddleware):
-    """asd"""
-
+    """Middleware that redirects all unauthenticated requests to a login page."""
 
     def process_view(self, request, view_func, view_args, view_kwargs):  # noqa: ANN001, ANN201, D102
         if any(request.path.startswith(path) for path in settings.PUBLIC_PATHS) and not request.user.is_authenticated:

--- a/trustpoint/trustpoint/middleware/LoginRequiredMiddleware.py
+++ b/trustpoint/trustpoint/middleware/LoginRequiredMiddleware.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+from django.contrib.auth.middleware import LoginRequiredMiddleware
+
+
+class LoginRequired(LoginRequiredMiddleware):
+    """asd"""
+
+
+    def process_view(self, request, view_func, view_args, view_kwargs):  # noqa: ANN001, ANN201, D102
+        if any(request.path.startswith(path) for path in settings.PUBLIC_PATHS) and not request.user.is_authenticated:
+            return None
+
+        return super().process_view(request, view_func, view_args, view_kwargs) # noqa: ANN001

--- a/trustpoint/trustpoint/settings.py
+++ b/trustpoint/trustpoint/settings.py
@@ -140,6 +140,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.LoginRequiredMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]

--- a/trustpoint/trustpoint/settings.py
+++ b/trustpoint/trustpoint/settings.py
@@ -140,7 +140,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.LoginRequiredMiddleware',
+    'trustpoint.middleware.LoginRequiredMiddleware.LoginRequired',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
@@ -310,3 +310,11 @@ class UIConfig:
     """User interface configuration defaults."""
     paginate_by: ClassVar[int] = 50
     notifications_paginate_by: ClassVar[int] = 5
+
+
+PUBLIC_PATHS = [
+    '/setup-wizard',
+    '/.well-known/cmp',
+    '/.well-known/est',
+    '/crl',
+]


### PR DESCRIPTION
**Description of changes**
Installed a middleware that replaces TpLoginRequiredMixin.
If u want a CBV to be exempt from authentication, simply import the `no_login` decorator from trustpoint.base.view and smack it to the class base view :)

**Notes**
I exempted setup wizard and the browser download from login.
Later we need to add the view/url, where the crl gets hostet. But to my knowledge we do not do it yet, right?
Did i forgot something?


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ x ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.