### PR TITLE
OPC UA Application Certs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 dependencies = [
     "crispy-bootstrap5~=2024.10",
     "cryptography>=44.0.1",
-    "django>=5.1.6,<6",
+    "django>=5.1.6",
     "django-crispy-forms~=2.3",
     "django-filter~=25.1",
     "django-stubs>=5.1.3,<6",
@@ -94,14 +94,10 @@ multiline-quotes = "double"
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
-    "ANN401",
-    "D203", "D213", "D415",
+    "ANN401",   # Since django makes extensive use of the Any type, we are OK with using it.
+    "COM812",   # Not compatible with the formatter
+    # TODO(AlexHx8472): We should use this in the future:
     "TD003",
-    # TODO(Alex): FIX should be added again, after we are departing from the PoC phase
-    "FIX",
-    "COM812", # Not compatible with the formatter
-    "ISC001", # Not compatible with the formatter
-    "S101",
 ]
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,9 @@ ignore = [
     "TD003",
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"**/tests/**/**.py" = ["S101"]
+
 [tool.ruff.format]
 quote-style = "single"
 indent-style = "space"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,8 @@ convention = "google"
 [tool.mypy]
 strict = true
 plugins = ["mypy_django_plugin.main"]
+# TODO(AlexHx8472): Are we sure to exclude the tests?
+exclude = "^(tests/|.*/tests/|migrations/|.*/migrations/)"
 
 [[tool.mypy.overrides]]
 module = ["crispy_bootstrap5.*", "crispy_forms.*"]

--- a/trustpoint/cmp/views.py
+++ b/trustpoint/cmp/views.py
@@ -17,8 +17,13 @@ from cryptography.hazmat.primitives import hashes, hmac
 from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
 from cryptography.hazmat.primitives.serialization import Encoding, load_der_public_key, load_pem_private_key
 from cryptography.x509.oid import ExtensionOID
-from devices.issuer import LocalDomainCredentialIssuer, LocalTlsClientCredentialIssuer, LocalTlsServerCredentialIssuer, \
-    OpcUaServerCredentialIssuer, OpcUaClientCredentialIssuer
+from devices.issuer import (
+    LocalDomainCredentialIssuer,
+    LocalTlsClientCredentialIssuer,
+    LocalTlsServerCredentialIssuer,
+    OpcUaServerCredentialIssuer,
+    OpcUaClientCredentialIssuer,
+)
 from devices.models import DeviceModel
 from django.http import HttpResponse
 from django.utils.decorators import method_decorator
@@ -1333,11 +1338,11 @@ class CmpCertificationRequestView(
                         if str(extension['extnID']) == ExtensionOID.SUBJECT_ALTERNATIVE_NAME.dotted_string
                     ]
                     if len(san_extensions) != 1:
-                        raise ValueError("Invalid SAN extension count")
+                        raise ValueError('Invalid SAN extension count')
 
                     san_extension = san_extensions[0]
-                    #san_critical = str(san_extension['critical']) == 'True'
-                    #TODO (FHKatCSW): san_critical not supported in OpcUaServerCredentialIssuer
+                    # san_critical = str(san_extension['critical']) == 'True'
+                    # TODO (FHKatCSW): san_critical not supported in OpcUaServerCredentialIssuer
                     san_extension_bytes = bytes(san_extension['extnValue'])
                     san_asn1, _ = decoder.decode(san_extension_bytes, asn1Spec=rfc2459.SubjectAltName())
 
@@ -1363,10 +1368,10 @@ class CmpCertificationRequestView(
                             application_uri = str(value)
 
                     if not application_uri:
-                        raise ValueError("Missing OPC UA Application URI in SAN extension")
+                        raise ValueError('Missing OPC UA Application URI in SAN extension')
 
                 else:
-                    raise ValueError("SAN extension is required for OPC UA Server Certificates")
+                    raise ValueError('SAN extension is required for OPC UA Server Certificates')
 
                 issuer = OpcUaServerCredentialIssuer(device=self.device, domain=self.device.domain)
                 issued_app_cred = issuer.issue_opcua_server_certificate(
@@ -1376,7 +1381,7 @@ class CmpCertificationRequestView(
                     ipv6_addresses=ipv6_addresses,
                     domain_names=dns_names,
                     validity_days=validity_in_days,
-                    public_key=loaded_public_key
+                    public_key=loaded_public_key,
                 )
 
             elif self.application_certificate_template == ApplicationCertificateTemplateNames.OPCUA_CLIENT:
@@ -1387,11 +1392,11 @@ class CmpCertificationRequestView(
                         if str(extension['extnID']) == ExtensionOID.SUBJECT_ALTERNATIVE_NAME.dotted_string
                     ]
                     if len(san_extensions) != 1:
-                        raise ValueError("Invalid SAN extension count")
+                        raise ValueError('Invalid SAN extension count')
 
                     san_extension = san_extensions[0]
-                    #san_critical = str(san_extension['critical']) == 'True'
-                    #TODO (FHKatCSW): san_critical not supported in OpcUaClientCredentialIssuer
+                    # san_critical = str(san_extension['critical']) == 'True'
+                    # TODO (FHKatCSW): san_critical not supported in OpcUaClientCredentialIssuer
                     san_extension_bytes = bytes(san_extension['extnValue'])
                     san_asn1, _ = decoder.decode(san_extension_bytes, asn1Spec=rfc2459.SubjectAltName())
 
@@ -1405,17 +1410,17 @@ class CmpCertificationRequestView(
                             application_uri = str(value)
 
                     if not application_uri:
-                        raise ValueError("Missing OPC UA Application URI in SAN extension")
+                        raise ValueError('Missing OPC UA Application URI in SAN extension')
 
                 else:
-                    raise ValueError("SAN extension is required for OPC UA Client Certificates")
+                    raise ValueError('SAN extension is required for OPC UA Client Certificates')
 
                 issuer = OpcUaClientCredentialIssuer(device=self.device, domain=self.device.domain)
                 issued_app_cred = issuer.issue_opcua_client_certificate(
                     common_name=common_name_value,
                     application_uri=application_uri,
                     validity_days=validity_in_days,
-                    public_key=loaded_public_key
+                    public_key=loaded_public_key,
                 )
             else:
                 raise ValueError
@@ -1742,10 +1747,10 @@ class CmpCertificationRequestView(
                         if str(extension['extnID']) == ExtensionOID.SUBJECT_ALTERNATIVE_NAME.dotted_string
                     ]
                     if len(san_extensions) != 1:
-                        raise ValueError("Invalid SAN extension count")
+                        raise ValueError('Invalid SAN extension count')
 
                     san_extension = san_extensions[0]
-                    #san_critical = str(san_extension['critical']) == 'True'
+                    # san_critical = str(san_extension['critical']) == 'True'
                     san_extension_bytes = bytes(san_extension['extnValue'])
                     san_asn1, _ = decoder.decode(san_extension_bytes, asn1Spec=rfc2459.SubjectAltName())
 
@@ -1771,10 +1776,10 @@ class CmpCertificationRequestView(
                             application_uri = str(value)
 
                     if not application_uri:
-                        raise ValueError("Missing OPC UA Application URI in SAN extension")
+                        raise ValueError('Missing OPC UA Application URI in SAN extension')
 
                 else:
-                    raise ValueError("SAN extension is required for OPC UA Server Certificates")
+                    raise ValueError('SAN extension is required for OPC UA Server Certificates')
 
                 issuer = OpcUaServerCredentialIssuer(device=self.device, domain=self.device.domain)
                 issued_app_cred = issuer.issue_opcua_server_certificate(
@@ -1784,7 +1789,7 @@ class CmpCertificationRequestView(
                     ipv6_addresses=ipv6_addresses,
                     domain_names=dns_names,
                     validity_days=validity_in_days,
-                    public_key=loaded_public_key
+                    public_key=loaded_public_key,
                 )
 
             elif self.application_certificate_template == ApplicationCertificateTemplateNames.OPCUA_CLIENT:
@@ -1795,10 +1800,10 @@ class CmpCertificationRequestView(
                         if str(extension['extnID']) == ExtensionOID.SUBJECT_ALTERNATIVE_NAME.dotted_string
                     ]
                     if len(san_extensions) != 1:
-                        raise ValueError("Invalid SAN extension count")
+                        raise ValueError('Invalid SAN extension count')
 
                     san_extension = san_extensions[0]
-                    #san_critical = str(san_extension['critical']) == 'True'
+                    # san_critical = str(san_extension['critical']) == 'True'
                     san_extension_bytes = bytes(san_extension['extnValue'])
                     san_asn1, _ = decoder.decode(san_extension_bytes, asn1Spec=rfc2459.SubjectAltName())
 
@@ -1812,17 +1817,17 @@ class CmpCertificationRequestView(
                             application_uri = str(value)
 
                     if not application_uri:
-                        raise ValueError("Missing OPC UA Application URI in SAN extension")
+                        raise ValueError('Missing OPC UA Application URI in SAN extension')
 
                 else:
-                    raise ValueError("SAN extension is required for OPC UA Client Certificates")
+                    raise ValueError('SAN extension is required for OPC UA Client Certificates')
 
                 issuer = OpcUaClientCredentialIssuer(device=self.device, domain=self.device.domain)
                 issued_app_cred = issuer.issue_opcua_client_certificate(
                     common_name=common_name_value,
                     application_uri=application_uri,
                     validity_days=validity_in_days,
-                    public_key=loaded_public_key
+                    public_key=loaded_public_key,
                 )
             else:
                 raise ValueError

--- a/trustpoint/cmp/views.py
+++ b/trustpoint/cmp/views.py
@@ -17,7 +17,8 @@ from cryptography.hazmat.primitives import hashes, hmac
 from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
 from cryptography.hazmat.primitives.serialization import Encoding, load_der_public_key, load_pem_private_key
 from cryptography.x509.oid import ExtensionOID
-from devices.issuer import LocalDomainCredentialIssuer, LocalTlsClientCredentialIssuer, LocalTlsServerCredentialIssuer
+from devices.issuer import LocalDomainCredentialIssuer, LocalTlsClientCredentialIssuer, LocalTlsServerCredentialIssuer, \
+    OpcUaServerCredentialIssuer, OpcUaClientCredentialIssuer
 from devices.models import DeviceModel
 from django.http import HttpResponse
 from django.utils.decorators import method_decorator
@@ -51,6 +52,8 @@ class ApplicationCertificateTemplateNames(enum.Enum):
 
     TLS_CLIENT = 'tls-client'
     TLS_SERVER = 'tls-server'
+    OPCUA_SERVER = 'opcua-server'
+    OPCUA_CLIENT = 'opcua-client'
 
 
 IMPLICIT_CONFIRM_OID = '1.3.6.1.5.5.7.4.13'
@@ -1322,6 +1325,98 @@ class CmpCertificationRequestView(
                     domain_names=dns_names,
                     public_key=loaded_public_key,
                 )
+            elif self.application_certificate_template == ApplicationCertificateTemplateNames.OPCUA_SERVER:
+                if cert_req_template['extensions'].hasValue():
+                    san_extensions = [
+                        extension
+                        for extension in cert_req_template['extensions']
+                        if str(extension['extnID']) == ExtensionOID.SUBJECT_ALTERNATIVE_NAME.dotted_string
+                    ]
+                    if len(san_extensions) != 1:
+                        raise ValueError("Invalid SAN extension count")
+
+                    san_extension = san_extensions[0]
+                    #san_critical = str(san_extension['critical']) == 'True'
+                    #TODO (FHKatCSW): san_critical not supported in OpcUaServerCredentialIssuer
+                    san_extension_bytes = bytes(san_extension['extnValue'])
+                    san_asn1, _ = decoder.decode(san_extension_bytes, asn1Spec=rfc2459.SubjectAltName())
+
+                    dns_names = []
+                    ipv4_addresses = []
+                    ipv6_addresses = []
+                    application_uri = None
+
+                    for general_name in san_asn1:
+                        name_type = general_name.getName()
+                        value = general_name.getComponent()
+
+                        if name_type == 'iPAddress':
+                            try:
+                                ipv4_addresses.append(ipaddress.IPv4Address(value.asOctets()))
+                            except (ValueError, TypeError):
+                                ipv6_addresses.append(ipaddress.IPv6Address(value.asOctets()))
+
+                        elif name_type == 'dNSName':
+                            dns_names.append(str(value))
+
+                        elif name_type == 'uniformResourceIdentifier':
+                            application_uri = str(value)
+
+                    if not application_uri:
+                        raise ValueError("Missing OPC UA Application URI in SAN extension")
+
+                else:
+                    raise ValueError("SAN extension is required for OPC UA Server Certificates")
+
+                issuer = OpcUaServerCredentialIssuer(device=self.device, domain=self.device.domain)
+                issued_app_cred = issuer.issue_opcua_server_certificate(
+                    common_name=common_name_value,
+                    application_uri=application_uri,
+                    ipv4_addresses=ipv4_addresses,
+                    ipv6_addresses=ipv6_addresses,
+                    domain_names=dns_names,
+                    validity_days=validity_in_days,
+                    public_key=loaded_public_key
+                )
+
+            elif self.application_certificate_template == ApplicationCertificateTemplateNames.OPCUA_CLIENT:
+                if cert_req_template['extensions'].hasValue():
+                    san_extensions = [
+                        extension
+                        for extension in cert_req_template['extensions']
+                        if str(extension['extnID']) == ExtensionOID.SUBJECT_ALTERNATIVE_NAME.dotted_string
+                    ]
+                    if len(san_extensions) != 1:
+                        raise ValueError("Invalid SAN extension count")
+
+                    san_extension = san_extensions[0]
+                    #san_critical = str(san_extension['critical']) == 'True'
+                    #TODO (FHKatCSW): san_critical not supported in OpcUaClientCredentialIssuer
+                    san_extension_bytes = bytes(san_extension['extnValue'])
+                    san_asn1, _ = decoder.decode(san_extension_bytes, asn1Spec=rfc2459.SubjectAltName())
+
+                    application_uri = None
+
+                    for general_name in san_asn1:
+                        name_type = general_name.getName()
+                        value = general_name.getComponent()
+
+                        if name_type == 'uniformResourceIdentifier':
+                            application_uri = str(value)
+
+                    if not application_uri:
+                        raise ValueError("Missing OPC UA Application URI in SAN extension")
+
+                else:
+                    raise ValueError("SAN extension is required for OPC UA Client Certificates")
+
+                issuer = OpcUaClientCredentialIssuer(device=self.device, domain=self.device.domain)
+                issued_app_cred = issuer.issue_opcua_client_certificate(
+                    common_name=common_name_value,
+                    application_uri=application_uri,
+                    validity_days=validity_in_days,
+                    public_key=loaded_public_key
+                )
             else:
                 raise ValueError
 
@@ -1638,6 +1733,96 @@ class CmpCertificationRequestView(
                     san_critical=san_critical,
                     domain_names=dns_names,
                     public_key=loaded_public_key,
+                )
+            elif self.application_certificate_template == ApplicationCertificateTemplateNames.OPCUA_SERVER:
+                if cert_req_template['extensions'].hasValue():
+                    san_extensions = [
+                        extension
+                        for extension in cert_req_template['extensions']
+                        if str(extension['extnID']) == ExtensionOID.SUBJECT_ALTERNATIVE_NAME.dotted_string
+                    ]
+                    if len(san_extensions) != 1:
+                        raise ValueError("Invalid SAN extension count")
+
+                    san_extension = san_extensions[0]
+                    #san_critical = str(san_extension['critical']) == 'True'
+                    san_extension_bytes = bytes(san_extension['extnValue'])
+                    san_asn1, _ = decoder.decode(san_extension_bytes, asn1Spec=rfc2459.SubjectAltName())
+
+                    dns_names = []
+                    ipv4_addresses = []
+                    ipv6_addresses = []
+                    application_uri = None
+
+                    for general_name in san_asn1:
+                        name_type = general_name.getName()
+                        value = general_name.getComponent()
+
+                        if name_type == 'iPAddress':
+                            try:
+                                ipv4_addresses.append(ipaddress.IPv4Address(value.asOctets()))
+                            except (ValueError, TypeError):
+                                ipv6_addresses.append(ipaddress.IPv6Address(value.asOctets()))
+
+                        elif name_type == 'dNSName':
+                            dns_names.append(str(value))
+
+                        elif name_type == 'uniformResourceIdentifier':
+                            application_uri = str(value)
+
+                    if not application_uri:
+                        raise ValueError("Missing OPC UA Application URI in SAN extension")
+
+                else:
+                    raise ValueError("SAN extension is required for OPC UA Server Certificates")
+
+                issuer = OpcUaServerCredentialIssuer(device=self.device, domain=self.device.domain)
+                issued_app_cred = issuer.issue_opcua_server_certificate(
+                    common_name=common_name_value,
+                    application_uri=application_uri,
+                    ipv4_addresses=ipv4_addresses,
+                    ipv6_addresses=ipv6_addresses,
+                    domain_names=dns_names,
+                    validity_days=validity_in_days,
+                    public_key=loaded_public_key
+                )
+
+            elif self.application_certificate_template == ApplicationCertificateTemplateNames.OPCUA_CLIENT:
+                if cert_req_template['extensions'].hasValue():
+                    san_extensions = [
+                        extension
+                        for extension in cert_req_template['extensions']
+                        if str(extension['extnID']) == ExtensionOID.SUBJECT_ALTERNATIVE_NAME.dotted_string
+                    ]
+                    if len(san_extensions) != 1:
+                        raise ValueError("Invalid SAN extension count")
+
+                    san_extension = san_extensions[0]
+                    #san_critical = str(san_extension['critical']) == 'True'
+                    san_extension_bytes = bytes(san_extension['extnValue'])
+                    san_asn1, _ = decoder.decode(san_extension_bytes, asn1Spec=rfc2459.SubjectAltName())
+
+                    application_uri = None
+
+                    for general_name in san_asn1:
+                        name_type = general_name.getName()
+                        value = general_name.getComponent()
+
+                        if name_type == 'uniformResourceIdentifier':
+                            application_uri = str(value)
+
+                    if not application_uri:
+                        raise ValueError("Missing OPC UA Application URI in SAN extension")
+
+                else:
+                    raise ValueError("SAN extension is required for OPC UA Client Certificates")
+
+                issuer = OpcUaClientCredentialIssuer(device=self.device, domain=self.device.domain)
+                issued_app_cred = issuer.issue_opcua_client_certificate(
+                    common_name=common_name_value,
+                    application_uri=application_uri,
+                    validity_days=validity_in_days,
+                    public_key=loaded_public_key
                 )
             else:
                 raise ValueError

--- a/trustpoint/devices/admin.py
+++ b/trustpoint/devices/admin.py
@@ -13,7 +13,5 @@ class IssuedCredentialModelAdmin(admin.ModelAdmin[IssuedCredentialModel]):
     """Registers the IssuedCredentialModelAdmin with Django Admin."""
 
 
-
 admin.site.register(DeviceModel, DeviceModelAdmin)
 admin.site.register(IssuedCredentialModel, IssuedCredentialModelAdmin)
-

--- a/trustpoint/devices/admin.py
+++ b/trustpoint/devices/admin.py
@@ -2,7 +2,7 @@
 
 from django.contrib import admin
 
-from .models import DeviceModel, IssuedCredentialModel
+from .models import DeviceModel, IssuedCredentialModel, RemoteDeviceCredentialDownloadModel
 
 
 class DeviceModelAdmin(admin.ModelAdmin[DeviceModel]):
@@ -13,5 +13,10 @@ class IssuedCredentialModelAdmin(admin.ModelAdmin[IssuedCredentialModel]):
     """Registers the IssuedCredentialModelAdmin with Django Admin."""
 
 
+class RemoteDeviceCredentialDownloadModelAdmin(admin.ModelAdmin[RemoteDeviceCredentialDownloadModel]):
+    """Registers the RemoteDeviceCredentialDownloadModel with Django Admin."""
+
+
 admin.site.register(DeviceModel, DeviceModelAdmin)
 admin.site.register(IssuedCredentialModel, IssuedCredentialModelAdmin)
+admin.site.register(RemoteDeviceCredentialDownloadModel, RemoteDeviceCredentialDownloadModelAdmin)

--- a/trustpoint/devices/forms.py
+++ b/trustpoint/devices/forms.py
@@ -221,7 +221,7 @@ class BrowserLoginForm(CleanedDataNotNoneMixin, forms.Form):
         cleaned_data['credential_download'] = credential_download
 
         if not credential_download.check_otp(otp_parts[1]):
-            err_msg = 'OTP is invalid.'
+            err_msg = _('OTP is invalid.')
             raise forms.ValidationError(err_msg)
 
         return cleaned_data

--- a/trustpoint/devices/forms.py
+++ b/trustpoint/devices/forms.py
@@ -3,24 +3,21 @@
 from __future__ import annotations
 
 import ipaddress
-from typing import Any, cast
 import secrets
+from typing import Any, cast
 
+from crispy_bootstrap5.bootstrap5 import Field
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import HTML, Div, Layout
 from django import forms
+from django.db.models.query import QuerySet
 from django.utils.translation import gettext_lazy as _
-
-from devices.models import DeviceModel, IssuedCredentialModel
 from pki.models.certificate import RevokedCertificateModel
 from pki.models.domain import DomainModel
-
-from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Layout, HTML, Div
-from crispy_bootstrap5.bootstrap5 import Field
-
 from pki.models.truststore import TruststoreModel
-from devices.widgets import DisableSelectOptionsWidget
-from django.db.models.query import QuerySet
 
+from devices.models import DeviceModel, IssuedCredentialModel
+from devices.widgets import DisableSelectOptionsWidget
 
 PASSWORD_MIN_LENGTH = 12
 
@@ -67,7 +64,7 @@ class BaseCredentialForm(forms.Form):
     serial_number = forms.CharField(max_length=255, label=_('Serial Number'), required=True, disabled=True)
     validity = forms.IntegerField(label=_('Validity (days)'), initial=10, required=True)
 
-    def __init__(self, *args: Any, device, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, device: DeviceModel, **kwargs: Any) -> None:
         """Overwrite the constructor to accept the current device instance."""
         self.device = device
         super().__init__(*args, **kwargs)
@@ -98,7 +95,9 @@ class BaseServerCredentialForm(BaseCredentialForm):
         label=_('IPv4-Addresses (comma-separated list)'), initial='127.0.0.1, ', required=False
     )
     ipv6_addresses = forms.CharField(label=_('IPv6-Addresses (comma-separated list)'), initial='::1, ', required=False)
-    domain_names = forms.CharField(label=_('Domain-Names (comma-separated list)'), initial='localhost, ', required=False)
+    domain_names = forms.CharField(label=_('Domain-Names (comma-separated list)'),
+                                   initial='localhost, ',
+                                   required=False)
 
     def clean_ipv4_addresses(self) -> list[ipaddress.IPv4Address]:
         """Checks the IPv4 addresses."""
@@ -134,7 +133,9 @@ class BaseServerCredentialForm(BaseCredentialForm):
     def clean(self) -> dict[str, Any]:
         """Ensures at least one SAN entry is set."""
         cleaned_data = super().clean()
-        if not (cleaned_data.get('ipv4_addresses') or cleaned_data.get('ipv6_addresses') or cleaned_data.get('domain_names')):
+        if not (cleaned_data.get('ipv4_addresses') or
+                cleaned_data.get('ipv6_addresses') or
+                cleaned_data.get('domain_names')):
             err_msg = _('At least one SAN entry is required.')
             raise forms.ValidationError(err_msg)
         return cleaned_data
@@ -142,12 +143,10 @@ class BaseServerCredentialForm(BaseCredentialForm):
 
 class IssueTlsClientCredentialForm(BaseCredentialForm):
     """Form to issue a new TLS client credential."""
-    pass
 
 
 class IssueTlsServerCredentialForm(BaseServerCredentialForm):
     """Form to issue a new TLS server credential."""
-    pass
 
 
 class IssueOpcUaClientCredentialForm(BaseCredentialForm):
@@ -271,7 +270,8 @@ class CreateDeviceForm(forms.ModelForm):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self.fields['idevid_trust_store'].queryset = TruststoreModel.objects.filter(intended_usage=TruststoreModel.IntendedUsage.IDEVID)
+        self.fields['idevid_trust_store'].queryset = TruststoreModel.objects.filter(
+            intended_usage=TruststoreModel.IntendedUsage.IDEVID)
 
         self.helper = FormHelper()
         self.helper.form_tag = False

--- a/trustpoint/devices/forms.py
+++ b/trustpoint/devices/forms.py
@@ -182,7 +182,7 @@ class IssueOpcUaClientCredentialForm(CleanedDataNotNoneMixin, ApplicationUriForm
     """Form to issue a new OPC UA client credential."""
 
 
-class IssueOpcUaServerCredentialForm(BaseServerCredentialForm):
+class IssueOpcUaServerCredentialForm(ApplicationUriFormMixin, BaseServerCredentialForm):
     """Form to issue a new OPC UA server credential."""
 
 

--- a/trustpoint/devices/forms.py
+++ b/trustpoint/devices/forms.py
@@ -22,7 +22,6 @@ from devices.models import DeviceModel, IssuedCredentialModel, RemoteDeviceCrede
 from devices.widgets import DisableSelectOptionsWidget
 from trustpoint.forms import CleanedDataNotNoneMixin
 
-
 if TYPE_CHECKING:
     from django.db.models.query import QuerySet
 
@@ -194,7 +193,6 @@ class BrowserLoginForm(CleanedDataNotNoneMixin, forms.Form):
 
     def clean(self) -> dict[str, Any]:
         """Cleans the form data, extracting the credential ID and OTP."""
-
         cleaned_data = super().clean()
 
         otp: str = cleaned_data.get('otp', '')
@@ -341,7 +339,7 @@ class CreateDeviceForm(CleanedDataNotNoneMixin, forms.ModelForm[DeviceModel]):
             instance.onboarding_status = DeviceModel.OnboardingStatus.PENDING
             onboarding_and_pki_configuration = cleaned_data.get('onboarding_and_pki_configuration')
 
-            # TODO(AlexHx8472): Integrate EST
+            # TODO(AlexHx8472): Integrate EST   # noqa: FIX002
             match onboarding_and_pki_configuration:
                 case 'cmp_shared_secret':
                     instance.onboarding_protocol = DeviceModel.OnboardingProtocol.CMP_SHARED_SECRET
@@ -368,7 +366,7 @@ class CreateDeviceForm(CleanedDataNotNoneMixin, forms.ModelForm[DeviceModel]):
             instance.idevid_trust_store = None
             pki_configuration = cleaned_data.get('pki_configuration')
 
-            # TODO(AlexHx8472): Integrate EST
+            # TODO(AlexHx8472): Integrate EST   # noqa: FIX002
             match pki_configuration:
                 case 'manual_download':
                     instance.pki_protocol = DeviceModel.PkiProtocol.MANUAL

--- a/trustpoint/devices/forms.py
+++ b/trustpoint/devices/forms.py
@@ -58,63 +58,19 @@ class CredentialDownloadForm(forms.Form):
 
         return cleaned_data
 
+class BaseCredentialForm(forms.Form):
+    """Base form for issuing credentials."""
 
-class IssueTlsClientCredentialForm(forms.Form):
-    """Form to issue a new TLS client credential."""
-
-    def __init__(self, *args: Any, device: DeviceModel, **kwargs: Any) -> None:
-        """Overwrite the constructor to accept the current device instance."""
-        self.device = device
-        super().__init__(*args, **kwargs)
-
-    common_name = forms.CharField(
-        max_length=255,
-        label=_('Common Name'),
-        required=True,
-    )
+    common_name = forms.CharField(max_length=255, label=_('Common Name'), required=True)
     pseudonym = forms.CharField(max_length=255, label=_('Pseudonym'), required=True, disabled=True)
     domain_component = forms.CharField(max_length=255, label=_('Domain Component'), required=True, disabled=True)
     serial_number = forms.CharField(max_length=255, label=_('Serial Number'), required=True, disabled=True)
     validity = forms.IntegerField(label=_('Validity (days)'), initial=10, required=True)
 
-    def clean_common_name(self) -> str:
-        """Checks the common name."""
-        common_name = cast(str, self.cleaned_data['common_name'])
-        if IssuedCredentialModel.objects.filter(common_name=common_name, device=self.device).exists():
-            err_msg = (
-                f'Credential with common name {common_name} ' f'already exists for device {self.device.unique_name}.'
-            )
-            raise forms.ValidationError(err_msg)
-        return common_name
-
-    def clean_validity(self) -> int:
-        """Checks the validity."""
-        validity = cast(int, self.cleaned_data['validity'])
-        if validity <= 0:
-            err_msg = _('Validity must be a positive integer.')
-            raise forms.ValidationError(err_msg)
-        return validity
-
-class IssueTlsServerCredentialForm(forms.Form):
-    """Form to issue a new TLS server credential."""
-
-    def __init__(self, *args: Any, device: DeviceModel, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, device, **kwargs: Any) -> None:
         """Overwrite the constructor to accept the current device instance."""
         self.device = device
         super().__init__(*args, **kwargs)
-
-    common_name = forms.CharField(max_length=100, label=_('Common Name'), required=True)
-    pseudonym = forms.CharField(max_length=100, label=_('Pseudonym'), required=True, disabled=True)
-    serial_number = forms.CharField(max_length=100, label=_('Serial Number'), required=True, disabled=True)
-    domain_component = forms.CharField(max_length=255, label=_('Domain Component'), required=True, disabled=True)
-    validity = forms.IntegerField(label=_('Validity (days)'), initial=10, required=True)
-    ipv4_addresses = forms.CharField(
-        label=_('IPv4-Addresses (comma-separated list)'), initial='127.0.0.1, ', required=False
-    )
-    ipv6_addresses = forms.CharField(label=_('IPv6-Addresses (comma-separated list)'), initial='::1, ', required=False)
-    domain_names = forms.CharField(
-        label=_('Domain-Names (comma-separated list)'), initial='localhost, ', required=False
-    )
 
     def clean_common_name(self) -> str:
         """Checks the common name."""
@@ -134,6 +90,15 @@ class IssueTlsServerCredentialForm(forms.Form):
             err_msg = _('Validity must be a positive integer.')
             raise forms.ValidationError(err_msg)
         return validity
+
+class BaseServerCredentialForm(BaseCredentialForm):
+    """Base form for issuing server credentials."""
+
+    ipv4_addresses = forms.CharField(
+        label=_('IPv4-Addresses (comma-separated list)'), initial='127.0.0.1, ', required=False
+    )
+    ipv6_addresses = forms.CharField(label=_('IPv6-Addresses (comma-separated list)'), initial='::1, ', required=False)
+    domain_names = forms.CharField(label=_('Domain-Names (comma-separated list)'), initial='localhost, ', required=False)
 
     def clean_ipv4_addresses(self) -> list[ipaddress.IPv4Address]:
         """Checks the IPv4 addresses."""
@@ -164,154 +129,50 @@ class IssueTlsServerCredentialForm(forms.Form):
     def clean_domain_names(self) -> list[str]:
         """Checks the domain names."""
         data = self.cleaned_data['domain_names'].strip()
-        if not data:
-            return []
-
-        domain_names = data.split(',')
-        # TODO(AlexHx8472): Check for valid domains.
-        return [domain_name.strip() for domain_name in domain_names if domain_name.strip() != '']
+        return [domain.strip() for domain in data.split(',') if domain.strip()]
 
     def clean(self) -> dict[str, Any]:
-        """Checks that at least one of IPv4, IPv6 and Domain Names is set."""
-        cleaned_data = cast(dict[str, Any], super().clean())
-        ipv4_addresses = cleaned_data.get('ipv4_addresses')
-        ipv6_addresses = cleaned_data.get('ipv6_addresses')
-        domain_names = cleaned_data.get('domain_names')
-        if not (ipv4_addresses or ipv6_addresses or domain_names):
+        """Ensures at least one SAN entry is set."""
+        cleaned_data = super().clean()
+        if not (cleaned_data.get('ipv4_addresses') or cleaned_data.get('ipv6_addresses') or cleaned_data.get('domain_names')):
             err_msg = _('At least one SAN entry is required.')
             raise forms.ValidationError(err_msg)
         return cleaned_data
 
-class IssueOpcUaClientCredentialForm(forms.Form):
+
+class IssueTlsClientCredentialForm(BaseCredentialForm):
+    """Form to issue a new TLS client credential."""
+    pass
+
+
+class IssueTlsServerCredentialForm(BaseServerCredentialForm):
+    """Form to issue a new TLS server credential."""
+    pass
+
+
+class IssueOpcUaClientCredentialForm(BaseCredentialForm):
     """Form to issue a new OPC UA client credential."""
 
-    def __init__(self, *args: Any, device: DeviceModel, **kwargs: Any) -> None:
-        """Overwrite the constructor to accept the current device instance."""
-        self.device = device
-        super().__init__(*args, **kwargs)
-
-    common_name = forms.CharField(
-        max_length=255,
-        label=_('Common Name'),
-        required=True,
-    )
     application_uri = forms.CharField(max_length=100, label=_('Application URI'), required=True)
-    pseudonym = forms.CharField(max_length=255, label=_('Pseudonym'), required=True, disabled=True)
-    domain_component = forms.CharField(max_length=255, label=_('Domain Component'), required=True, disabled=True)
-    serial_number = forms.CharField(max_length=255, label=_('Serial Number'), required=True, disabled=True)
-    validity = forms.IntegerField(label=_('Validity (days)'), initial=10, required=True)
-
-    def clean_common_name(self) -> str:
-        """Checks the common name."""
-        common_name = cast(str, self.cleaned_data['common_name'])
-        if IssuedCredentialModel.objects.filter(common_name=common_name, device=self.device).exists():
-            err_msg = (
-                f'Credential with common name {common_name} ' f'already exists for device {self.device.unique_name}.'
-            )
-            raise forms.ValidationError(err_msg)
-        return common_name
-
-    def clean_validity(self) -> int:
-        """Checks the validity."""
-        validity = cast(int, self.cleaned_data['validity'])
-        if validity <= 0:
-            err_msg = _('Validity must be a positive integer.')
-            raise forms.ValidationError(err_msg)
-        return validity
 
     def clean(self) -> dict[str, Any]:
-        """Checks that at least the Application URI is set."""
-        cleaned_data = cast(dict[str, Any], super().clean())
-        application_uri = cleaned_data.get('application_uri')
-        if not (application_uri):
-            err_msg = _('Application URI entry is required.')
-            raise forms.ValidationError(err_msg)
+        """Ensures the Application URI is set."""
+        cleaned_data = super().clean()
+        if not cleaned_data.get('application_uri'):
+            raise forms.ValidationError(_('Application URI entry is required.'))
         return cleaned_data
 
-class IssueOpcUaServerCredentialForm(forms.Form):
-    """Form to issue a new TLS server credential."""
 
-    def __init__(self, *args: Any, device: DeviceModel, **kwargs: Any) -> None:
-        """Overwrite the constructor to accept the current device instance."""
-        self.device = device
-        super().__init__(*args, **kwargs)
+class IssueOpcUaServerCredentialForm(BaseServerCredentialForm):
+    """Form to issue a new OPC UA server credential."""
 
-    common_name = forms.CharField(max_length=100, label=_('Common Name'), required=True)
-    pseudonym = forms.CharField(max_length=100, label=_('Pseudonym'), required=True, disabled=True)
-    serial_number = forms.CharField(max_length=100, label=_('Serial Number'), required=True, disabled=True)
-    domain_component = forms.CharField(max_length=255, label=_('Domain Component'), required=True, disabled=True)
-    validity = forms.IntegerField(label=_('Validity (days)'), initial=10, required=True)
     application_uri = forms.CharField(max_length=100, label=_('Application URI'), required=True)
-    ipv4_addresses = forms.CharField(
-        label=_('IPv4-Addresses (comma-separated list)'), initial='127.0.0.1, ', required=False
-    )
-    ipv6_addresses = forms.CharField(label=_('IPv6-Addresses (comma-separated list)'), initial='::1, ', required=False)
-    domain_names = forms.CharField(
-        label=_('Domain-Names (comma-separated list)'), initial='localhost, ', required=False
-    )
-
-    def clean_common_name(self) -> str:
-        """Checks the common name."""
-        common_name = cast(str, self.cleaned_data['common_name'])
-        if IssuedCredentialModel.objects.filter(common_name=common_name, device=self.device).exists():
-            err_msg = _('Credential with common name %s already exists for device %s.') % (
-                common_name,
-                self.device.unique_name,
-            )
-            raise forms.ValidationError(err_msg)
-        return common_name
-
-    def clean_validity(self) -> int:
-        """Checks the validity."""
-        validity = cast(int, self.cleaned_data['validity'])
-        if validity <= 0:
-            err_msg = _('Validity must be a positive integer.')
-            raise forms.ValidationError(err_msg)
-        return validity
-
-    def clean_ipv4_addresses(self) -> list[ipaddress.IPv4Address]:
-        """Checks the IPv4 addresses."""
-        data = self.cleaned_data['ipv4_addresses'].strip()
-        if not data:
-            return []
-
-        addresses = data.split(',')
-        try:
-            return [ipaddress.IPv4Address(address.strip()) for address in addresses if address.strip() != '']
-        except ipaddress.AddressValueError as exception:
-            err_msg = _('Contains an invalid IPv4-Address.')
-            raise forms.ValidationError(err_msg) from exception
-
-    def clean_ipv6_addresses(self) -> list[ipaddress.IPv6Address]:
-        """Checks the IPv6 addresses."""
-        data = self.cleaned_data['ipv6_addresses'].strip()
-        if not data:
-            return []
-
-        addresses = data.split(',')
-        try:
-            return [ipaddress.IPv6Address(address.strip()) for address in addresses if address.strip() != '']
-        except ipaddress.AddressValueError as exception:
-            err_msg = _('Contains an invalid IPv6-Address.')
-            raise forms.ValidationError(err_msg) from exception
-
-    def clean_domain_names(self) -> list[str]:
-        """Checks the domain names."""
-        data = self.cleaned_data['domain_names'].strip()
-        if not data:
-            return []
-
-        domain_names = data.split(',')
-        # TODO(AlexHx8472): Check for valid domains.
-        return [domain_name.strip() for domain_name in domain_names if domain_name.strip() != '']
 
     def clean(self) -> dict[str, Any]:
-        """Checks that at least the Application URI is set."""
-        cleaned_data = cast(dict[str, Any], super().clean())
-        application_uri = cleaned_data.get('application_uri')
-        if not (application_uri):
-            err_msg = _('Application URI entry is required.')
-            raise forms.ValidationError(err_msg)
+        """Ensures the Application URI is set."""
+        cleaned_data = super().clean()
+        if not cleaned_data.get('application_uri'):
+            raise forms.ValidationError(_('Application URI entry is required.'))
         return cleaned_data
 
 class BrowserLoginForm(forms.Form):

--- a/trustpoint/devices/issuer.py
+++ b/trustpoint/devices/issuer.py
@@ -512,7 +512,7 @@ class LocalDomainCredentialIssuer(BaseTlsCredentialIssuer):
         Returns:
             IssuedCredentialModel: The issued domain credential certificate model.
         """
-        # TODO(AlexHx8472): Check matching public_key and signature suite.
+        # TODO(AlexHx8472): Check matching public_key and signature suite.  # noqa: FIX002
 
         certificate = self._build_certificate(
             common_name=self._pseudonym,

--- a/trustpoint/devices/models.py
+++ b/trustpoint/devices/models.py
@@ -16,6 +16,7 @@ from pki.models.truststore import TruststoreModel
 from pyasn1_modules.rfc3280 import common_name  # type: ignore[import-untyped]
 from trustpoint_core import oid  # type: ignore[import-untyped]
 from util.field import UniqueNameValidator
+from django_stubs_ext.db.models import TypedModelMeta
 
 if TYPE_CHECKING:
     from typing import Any
@@ -33,6 +34,9 @@ class DeviceModel(models.Model):
     """The DeviceModel."""
 
     objects: models.Manager[DeviceModel]
+
+    class Meta(TypedModelMeta):
+        """Meta class configuration."""
 
     id = models.AutoField(primary_key=True)
     unique_name = models.CharField(
@@ -132,6 +136,9 @@ class IssuedCredentialModel(models.Model):
 
     objects: models.Manager[IssuedCredentialModel]
 
+    class Meta(TypedModelMeta):
+        """Meta class configuration."""
+
     class IssuedCredentialType(models.IntegerChoices):
         """The type of the credential."""
 
@@ -179,6 +186,11 @@ class IssuedCredentialModel(models.Model):
 
 class RemoteDeviceCredentialDownloadModel(models.Model):
     """Model to associate a credential model with an OTP and token for unauthenticated remoted download."""
+
+    objects: models.Manager[RemoteDeviceCredentialDownloadModel]
+
+    class Meta(TypedModelMeta):
+        """Meta class configuration."""
 
     BROWSER_MAX_OTP_ATTEMPTS = 3
     TOKEN_VALIDITY = datetime.timedelta(minutes=3)

--- a/trustpoint/devices/models.py
+++ b/trustpoint/devices/models.py
@@ -1,19 +1,24 @@
+"""This modules contains all models specific to the device abstractions."""
+
 from __future__ import annotations
 
 import datetime
 import logging
 import secrets
+from typing import TYPE_CHECKING
 
 from django.db import models
-from django.utils.translation import gettext_lazy as _
 from django.utils import timezone
-from django.contrib.contenttypes.models import ContentType
-from util.field import UniqueNameValidator
-from trustpoint_core import oid
-
-from pki.models import CertificateModel, DomainModel, CredentialModel, IssuingCaModel
+from django.utils.translation import gettext_lazy as _
 from pki.models.credential import CredentialModel
+from pki.models.domain import DomainModel
 from pki.models.truststore import TruststoreModel
+from pyasn1_modules.rfc3280 import common_name  # type: ignore[import-untyped]
+from trustpoint_core import oid  # type: ignore[import-untyped]
+from util.field import UniqueNameValidator
+
+if TYPE_CHECKING:
+    from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -21,15 +26,13 @@ __all__ = [
     'DeviceModel',
     'IssuedCredentialModel',
     'RemoteDeviceCredentialDownloadModel',
-
 ]
 
+
 class DeviceModel(models.Model):
+    """The DeviceModel."""
 
     objects: models.Manager[DeviceModel]
-
-    def __str__(self) -> str:
-        return f'DeviceModel(unique_name={self.unique_name})'
 
     id = models.AutoField(primary_key=True)
     unique_name = models.CharField(
@@ -37,22 +40,15 @@ class DeviceModel(models.Model):
     )
     serial_number = models.CharField(_('Serial-Number'), max_length=100)
     domain = models.ForeignKey(
-        DomainModel,
-        verbose_name=_('Domain'),
-        related_name='devices',
-        blank=True,
-        null=True,
-        on_delete=models.PROTECT
+        DomainModel, verbose_name=_('Domain'), related_name='devices', blank=True, null=True, on_delete=models.PROTECT
     )
 
     domain_credential_onboarding = models.BooleanField(
-        verbose_name=_('Domain Credential Onboarding'),
-        default=True,
-        blank=False,
-        null=False
+        verbose_name=_('Domain Credential Onboarding'), default=True, blank=False, null=False
     )
 
     class OnboardingStatus(models.IntegerChoices):
+        """The onboarding status."""
 
         NO_ONBOARDING = 0, _('No Onboarding')
         PENDING = 1, _('Pending')
@@ -66,6 +62,7 @@ class DeviceModel(models.Model):
     )
 
     class OnboardingProtocol(models.IntegerChoices):
+        """Choices of onboarding protocols."""
 
         NO_ONBOARDING = 0, _('No Onboarding')
         EST_PASSWORD = 1, _('EST - Username & Password')
@@ -79,9 +76,11 @@ class DeviceModel(models.Model):
         choices=OnboardingProtocol,
         verbose_name=_('Onboarding Protocol'),
         null=False,
-        default=OnboardingProtocol.NO_ONBOARDING)
+        default=OnboardingProtocol.NO_ONBOARDING,
+    )
 
     class PkiProtocol(models.IntegerChoices):
+        """Choices of pki protocols."""
 
         MANUAL = 0, _('Manual Download')
         EST_PASSWORD = 1, _('EST - Username & Password')
@@ -90,59 +89,58 @@ class DeviceModel(models.Model):
         CMP_CLIENT_CERTIFICATE = 4, _('CMP - LDevID')
 
     pki_protocol = models.IntegerField(
-        choices=PkiProtocol,
-        verbose_name=_('Pki Protocol'),
-        null=False,
-        default=PkiProtocol.MANUAL
+        choices=PkiProtocol, verbose_name=_('Pki Protocol'), null=False, default=PkiProtocol.MANUAL
     )
 
-
-    @property
-    def est_username(self) -> str:
-        return self.unique_name
-
-    est_password = models.CharField(
-        verbose_name=_('EST Password'),
-        max_length=128,
-        null=True,
-        blank=True,
-        default=None)
-    cmp_shared_secret = models.CharField(
-        verbose_name=_('CMP Shared Secret'),
-        max_length=128,
-        null=True,
-        blank=True,
-        default=None)
+    est_password = models.CharField(verbose_name=_('EST Password'), max_length=128, blank=True, default='')
+    cmp_shared_secret = models.CharField(verbose_name=_('CMP Shared Secret'), max_length=128, blank=True, default='')
 
     idevid_trust_store = models.ForeignKey(
         TruststoreModel,
         verbose_name=_('IDevID Manufacturer Truststore'),
         null=True,
         blank=True,
-        on_delete=models.DO_NOTHING)
+        on_delete=models.DO_NOTHING,
+    )
 
     created_at = models.DateTimeField(verbose_name=_('Created'), auto_now_add=True)
 
+    def __str__(self) -> str:
+        """Returns a human-readable string representation."""
+        return f'DeviceModel(unique_name={self.unique_name})'
+
+    @property
+    def est_username(self) -> str:
+        """Gets the EST username."""
+        return self.unique_name
+
     @property
     def signature_suite(self) -> oid.SignatureSuite:
+        """Gets the corresponding SignatureSuite object."""
         return oid.SignatureSuite.from_certificate(
-            self.domain.issuing_ca.credential.get_certificate_serializer().as_crypto())
+            self.domain.issuing_ca.credential.get_certificate_serializer().as_crypto()
+        )
 
     @property
     def public_key_info(self) -> oid.PublicKeyInfo:
+        """Gets the corresponding PublicKeyInfo object."""
         return self.signature_suite.public_key_info
 
 
 class IssuedCredentialModel(models.Model):
     """Model for all credentials and certificates that have been issued or requested by the Trustpoint."""
 
-    objects: models.Manager['IssuedCredentialModel']
+    objects: models.Manager[IssuedCredentialModel]
 
     class IssuedCredentialType(models.IntegerChoices):
+        """The type of the credential."""
+
         DOMAIN_CREDENTIAL = 0, _('Domain Credential')
         APPLICATION_CREDENTIAL = 1, _('Application Credential')
 
     class IssuedCredentialPurpose(models.IntegerChoices):
+        """The purpose of the issued credential."""
+
         DOMAIN_CREDENTIAL = 0, _('Domain Credential')
         GENERIC = 1, _('Generic')
         TLS_CLIENT = 2, _('TLS-Client')
@@ -150,46 +148,38 @@ class IssuedCredentialModel(models.Model):
         OPCUA_CLIENT = 4, _('OpcUa-Client')
         OPCUA_SERVER = 5, _('OpcUa-Server')
 
-
-
     id = models.AutoField(primary_key=True)
 
     common_name = models.CharField(verbose_name=_('Common Name'), max_length=255)
-    issued_credential_type = models.IntegerField(
-        choices=IssuedCredentialType,
-        verbose_name=_('Credential Type'))
+    issued_credential_type = models.IntegerField(choices=IssuedCredentialType, verbose_name=_('Credential Type'))
     issued_credential_purpose = models.IntegerField(
-        choices=IssuedCredentialPurpose,
-        verbose_name=_('Credential Purpose'))
+        choices=IssuedCredentialPurpose, verbose_name=_('Credential Purpose')
+    )
     credential = models.OneToOneField(
         CredentialModel,
         verbose_name=_('Credential'),
         on_delete=models.PROTECT,
         related_name='issued_credential',
         null=False,
-        blank=False
+        blank=False,
     )
     device = models.ForeignKey(
-        DeviceModel,
-        verbose_name=_('Device'),
-        on_delete=models.PROTECT,
-        related_name='issued_credentials'
+        DeviceModel, verbose_name=_('Device'), on_delete=models.PROTECT, related_name='issued_credentials'
     )
     domain = models.ForeignKey(
-        DomainModel,
-        verbose_name=_('Domain'),
-        on_delete=models.PROTECT,
-        related_name='issued_credentials'
+        DomainModel, verbose_name=_('Domain'), on_delete=models.PROTECT, related_name='issued_credentials'
     )
 
     created_at = models.DateTimeField(verbose_name=_('Created'), auto_now_add=True)
 
     def __str__(self) -> str:
-        return f'IssuedCredentialModel()'
+        """Returns a human-readable string representation."""
+        return f'IssuedCredentialModel(common_name={common_name})'
 
 
 class RemoteDeviceCredentialDownloadModel(models.Model):
     """Model to associate a credential model with an OTP and token for unauthenticated remoted download."""
+
     BROWSER_MAX_OTP_ATTEMPTS = 3
     TOKEN_VALIDITY = datetime.timedelta(minutes=3)
 
@@ -204,20 +194,31 @@ class RemoteDeviceCredentialDownloadModel(models.Model):
         """Return a string representation of the model."""
         return f'RemoteDeviceCredentialDownloadModel(credential={self.issued_credential_model.id})'
 
-    def save(self, *args: dict, **kwargs: dict) -> None:
+    def save(self, *args: Any, **kwargs: Any) -> None:
         """Generates a new random OTP on initial save of the model."""
         if not self.otp:
             self.otp = secrets.token_urlsafe(8)
         super().save(*args, **kwargs)
 
     def get_otp_display(self) -> str:
-        """Return the OTP in the format 'credential_id.otp' for display within the admin view."""
+        """Return the OTP in the format 'credential_id.otp' for display within the admin view.
+
+        Returns:
+            The str to display.
+        """
         if not self.otp or self.otp == '-':
             return 'OTP no longer valid'
         return f'{self.issued_credential_model.id}.{self.otp}'
 
     def check_otp(self, otp: str) -> bool:
-        """Check if the provided OTP matches the stored OTP."""
+        """Check if the provided OTP matches the stored OTP.
+
+        Args:
+            otp: The OTP to check.
+
+        Returns:
+            True if the OTP is valid, False otherwise.
+        """
         if not self.otp or self.otp == '-':
             return False
         matches = otp == self.otp
@@ -249,7 +250,14 @@ class RemoteDeviceCredentialDownloadModel(models.Model):
         return True
 
     def check_token(self, token: str) -> bool:
-        """Check if the provided token matches the stored token and whether it is still valid."""
+        """Check if the provided token matches the stored token and whether it is still valid.
+
+        Args:
+            token: The token to check.
+
+        Returns:
+            True if the token is valid, false otherwise.
+        """
         if not self.download_token or not self.token_created_at:
             return False
         if timezone.now() - self.token_created_at > self.TOKEN_VALIDITY:

--- a/trustpoint/devices/models.py
+++ b/trustpoint/devices/models.py
@@ -147,6 +147,9 @@ class IssuedCredentialModel(models.Model):
         GENERIC = 1, _('Generic')
         TLS_CLIENT = 2, _('TLS-Client')
         TLS_SERVER = 3, _('TLS-Server')
+        OPCUA_CLIENT = 4, _('OpcUa-Client')
+        OPCUA_SERVER = 5, _('OpcUa-Server')
+
 
 
     id = models.AutoField(primary_key=True)

--- a/trustpoint/devices/models.py
+++ b/trustpoint/devices/models.py
@@ -10,13 +10,13 @@ from typing import TYPE_CHECKING
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
+from django_stubs_ext.db.models import TypedModelMeta
 from pki.models.credential import CredentialModel
 from pki.models.domain import DomainModel
 from pki.models.truststore import TruststoreModel
 from pyasn1_modules.rfc3280 import common_name  # type: ignore[import-untyped]
 from trustpoint_core import oid  # type: ignore[import-untyped]
 from util.field import UniqueNameValidator
-from django_stubs_ext.db.models import TypedModelMeta
 
 if TYPE_CHECKING:
     from typing import Any
@@ -34,9 +34,6 @@ class DeviceModel(models.Model):
     """The DeviceModel."""
 
     objects: models.Manager[DeviceModel]
-
-    class Meta(TypedModelMeta):
-        """Meta class configuration."""
 
     id = models.AutoField(primary_key=True)
     unique_name = models.CharField(
@@ -109,6 +106,9 @@ class DeviceModel(models.Model):
 
     created_at = models.DateTimeField(verbose_name=_('Created'), auto_now_add=True)
 
+    class Meta(TypedModelMeta):
+        """Meta class configuration."""
+
     def __str__(self) -> str:
         """Returns a human-readable string representation."""
         return f'DeviceModel(unique_name={self.unique_name})'
@@ -135,9 +135,6 @@ class IssuedCredentialModel(models.Model):
     """Model for all credentials and certificates that have been issued or requested by the Trustpoint."""
 
     objects: models.Manager[IssuedCredentialModel]
-
-    class Meta(TypedModelMeta):
-        """Meta class configuration."""
 
     class IssuedCredentialType(models.IntegerChoices):
         """The type of the credential."""
@@ -179,6 +176,9 @@ class IssuedCredentialModel(models.Model):
 
     created_at = models.DateTimeField(verbose_name=_('Created'), auto_now_add=True)
 
+    class Meta(TypedModelMeta):
+        """Meta class configuration."""
+
     def __str__(self) -> str:
         """Returns a human-readable string representation."""
         return f'IssuedCredentialModel(common_name={common_name})'
@@ -189,9 +189,6 @@ class RemoteDeviceCredentialDownloadModel(models.Model):
 
     objects: models.Manager[RemoteDeviceCredentialDownloadModel]
 
-    class Meta(TypedModelMeta):
-        """Meta class configuration."""
-
     BROWSER_MAX_OTP_ATTEMPTS = 3
     TOKEN_VALIDITY = datetime.timedelta(minutes=3)
 
@@ -201,6 +198,9 @@ class RemoteDeviceCredentialDownloadModel(models.Model):
     attempts = models.IntegerField(_('Attempts'), default=0)
     download_token = models.CharField(_('Download Token'), max_length=64, default='')
     token_created_at = models.DateTimeField(_('Token Created'), null=True)
+
+    class Meta(TypedModelMeta):
+        """Meta class configuration."""
 
     def __str__(self) -> str:
         """Return a string representation of the model."""

--- a/trustpoint/devices/revocation.py
+++ b/trustpoint/devices/revocation.py
@@ -12,7 +12,7 @@ class DeviceCredentialRevocation:
 
     @staticmethod
     def revoke_certificate(issued_credential_id: int, reason: str) -> tuple[bool, str]:
-        """Revokes a certificate given an ID of an IssuedCredentialModel instance"""
+        """Revokes a certificate given an ID of an IssuedCredentialModel instance."""
         try:
             issued_credential = IssuedCredentialModel.objects.get(id=issued_credential_id)
         except IssuedCredentialModel.DoesNotExist:

--- a/trustpoint/devices/revocation.py
+++ b/trustpoint/devices/revocation.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from devices.models import IssuedCredentialModel
 from pki.models.certificate import RevokedCertificateModel
+
+from devices.models import IssuedCredentialModel
 
 
 class DeviceCredentialRevocation:
@@ -26,8 +27,6 @@ class DeviceCredentialRevocation:
             return False, 'The certificate is already revoked.'
 
         RevokedCertificateModel.objects.create(
-            certificate=primary_cert,
-            revocation_reason=reason,
-            ca = issued_credential.domain.issuing_ca
+            certificate=primary_cert, revocation_reason=reason, ca=issued_credential.domain.issuing_ca
         )
         return True, 'Certificate successfully revoked.'

--- a/trustpoint/devices/tests.py
+++ b/trustpoint/devices/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/trustpoint/devices/tests/__init__.py
+++ b/trustpoint/devices/tests/__init__.py
@@ -1,0 +1,1 @@
+"""This package contains the pytest unittests for the devices application."""

--- a/trustpoint/devices/tests/conftest.py
+++ b/trustpoint/devices/tests/conftest.py
@@ -15,6 +15,7 @@ def enable_db_access_for_all_tests(db: None) -> None:
 
 @pytest.fixture
 def mock_models() -> dict:
+    """Creates mock models."""
     return create_mock_models()
 
 

--- a/trustpoint/devices/tests/conftest.py
+++ b/trustpoint/devices/tests/conftest.py
@@ -12,21 +12,20 @@ from devices.models import DeviceModel, RemoteDeviceCredentialDownloadModel
 def enable_db_access_for_all_tests(db: None) -> None:
     """Fixture to enable database access for all tests."""
 
+
 @pytest.fixture
 def mock_models() -> dict:
     return create_mock_models()
 
+
 def create_mock_models() -> dict:
     """Fixture to create mock CA, domain, device, and credential models for testing."""
     root_1, root_1_key = CertificateGenerator.create_root_ca('Test Root CA')
-    issuing_1, issuing_1_key = CertificateGenerator.create_issuing_ca(
-                                    root_1_key, 'Root CA', 'Issuing CA A')
+    issuing_1, issuing_1_key = CertificateGenerator.create_issuing_ca(root_1_key, 'Root CA', 'Issuing CA A')
 
     CertificateGenerator.save_issuing_ca(
-        issuing_ca_cert=issuing_1,
-        private_key=issuing_1_key,
-        chain=[root_1],
-        unique_name='test_local_ca')
+        issuing_ca_cert=issuing_1, private_key=issuing_1_key, chain=[root_1], unique_name='test_local_ca'
+    )
 
     mock_ca = IssuingCaModel.objects.get(unique_name='test_local_ca')
 
@@ -38,7 +37,7 @@ def create_mock_models() -> dict:
         serial_number='1234567890',
         domain=mock_domain,
         onboarding_protocol=DeviceModel.OnboardingProtocol.NO_ONBOARDING,
-        onboarding_status=DeviceModel.OnboardingStatus.PENDING
+        onboarding_status=DeviceModel.OnboardingStatus.PENDING,
     )
     mock_device.save()
 
@@ -46,8 +45,7 @@ def create_mock_models() -> dict:
     mock_issued_credential = credential_issuer.issue_domain_credential()
 
     mock_remote_credential_download = RemoteDeviceCredentialDownloadModel(
-        issued_credential_model=mock_issued_credential,
-        device = mock_device
+        issued_credential_model=mock_issued_credential, device=mock_device
     )
 
     return {
@@ -55,5 +53,5 @@ def create_mock_models() -> dict:
         'domain': mock_domain,
         'ca': mock_ca,
         'issued_credential': mock_issued_credential,
-        'remote_credential_download': mock_remote_credential_download
+        'remote_credential_download': mock_remote_credential_download,
     }

--- a/trustpoint/devices/tests/test_credential_download.py
+++ b/trustpoint/devices/tests/test_credential_download.py
@@ -8,7 +8,7 @@ import pytest
 from devices.models import RemoteDeviceCredentialDownloadModel
 
 
-def test_otp_generation(mock_models : dict) -> None:
+def test_otp_generation(mock_models: dict) -> None:
     """Test that a valid OTP is generated on save."""
     remote_credential_download_model = mock_models['remote_credential_download']
     assert remote_credential_download_model.otp == ''
@@ -16,7 +16,7 @@ def test_otp_generation(mock_models : dict) -> None:
     assert len(remote_credential_download_model.otp) == len(secrets.token_urlsafe(8))
 
 
-def test_token_invalidation(mock_models : dict) -> None:
+def test_token_invalidation(mock_models: dict) -> None:
     """Test that a download token is no longer valid after the token validity period."""
     rcd = mock_models['remote_credential_download']
     # no token present at initialization
@@ -32,7 +32,7 @@ def test_token_invalidation(mock_models : dict) -> None:
         RemoteDeviceCredentialDownloadModel.objects.get(id=rcd.id)
 
 
-def test_otp_use_once(mock_models : dict) -> None:
+def test_otp_use_once(mock_models: dict) -> None:
     """Test that an OTP can only be used once."""
     rcd = mock_models['remote_credential_download']
     rcd.save()
@@ -41,7 +41,8 @@ def test_otp_use_once(mock_models : dict) -> None:
     assert not rcd.check_otp(otp)
     assert len(rcd.otp) < 2  # noqa: PLR2004
 
-def test_otp_max_attempts(mock_models : dict) -> None:
+
+def test_otp_max_attempts(mock_models: dict) -> None:
     """Test that the OTP is invalidated after too many incorrect attempts."""
     rcd = mock_models['remote_credential_download']
     rcd.save()

--- a/trustpoint/devices/urls.py
+++ b/trustpoint/devices/urls.py
@@ -7,19 +7,16 @@ from . import views
 app_name = 'devices'
 
 urlpatterns = [
-
     # Main Pages
     path('', views.DeviceTableView.as_view(), name='devices'),
     path('add/', views.CreateDeviceView.as_view(), name='add'),
     path('details/<int:pk>/', views.DeviceDetailsView.as_view(), name='details'),
-
     # Certificate Lifecycle Management
     path(
         'certificate-lifecycle-management/<int:pk>/',
         views.DeviceCertificateLifecycleManagementSummaryView.as_view(),
         name='certificate_lifecycle_management',
     ),
-
     # Certificate Lifecycle Management - Credential Issuance
     path(
         'certificate-lifecycle-management/<int:pk>/issue-tls-client-credential/',
@@ -41,7 +38,6 @@ urlpatterns = [
         views.DeviceIssueOpcUaServerCredential.as_view(),
         name='certificate_lifecycle_management-issue_opcua_server_credential',
     ),
-
     # Certificate Lifecycle Management - Help Pages
     path('help/dispatch/<int:pk>/', views.HelpDispatchView.as_view(), name='help_dispatch'),
     path(
@@ -64,7 +60,6 @@ urlpatterns = [
         views.OnboardingIdevidRegistrationHelpView.as_view(),
         name='help-onboarding_cmp-idevid-registration',
     ),
-
     # Certificate Lifecycle Management - Downloads
     path('download/<int:pk>/', views.DownloadPageDispatcherView.as_view(), name='download'),
     path('certificate/download/<int:pk>/', views.CertificateDownloadView.as_view(), name='certificate-download'),
@@ -75,7 +70,6 @@ urlpatterns = [
         'credential-download/browser/<int:pk>/', views.DeviceBrowserOnboardingOTPView.as_view(), name='browser_otp_view'
     ),
     path('browser/', views.DeviceOnboardingBrowserLoginView.as_view(), name='browser_login'),
-
     # Revoke Views
     path('browser/', views.DeviceOnboardingBrowserLoginView.as_view(), name='browser_login'),
     path(
@@ -83,23 +77,15 @@ urlpatterns = [
         views.DeviceBrowserCredentialDownloadView.as_view(),
         name='browser_domain_credential_download',
     ),
-
     path(
         'credential-download/browser/<int:pk>/cancel',
         views.DeviceBrowserOnboardingCancelView.as_view(),
         name='browser_cancel',
     ),
-
-
-
-
-
-
     path(
         'certificate-lifecycle-management/<int:pk>/revoke/<int:credential_pk>/',
         views.DeviceCredentialRevocationView.as_view(),
         name='credential_revocation',
     ),
     path('revoke/<int:pk>/', views.DeviceRevocationView.as_view(), name='device_revocation'),
-
 ]

--- a/trustpoint/devices/urls.py
+++ b/trustpoint/devices/urls.py
@@ -7,34 +7,20 @@ from . import views
 app_name = 'devices'
 
 urlpatterns = [
+
+    # Main Pages
     path('', views.DeviceTableView.as_view(), name='devices'),
     path('add/', views.CreateDeviceView.as_view(), name='add'),
     path('details/<int:pk>/', views.DeviceDetailsView.as_view(), name='details'),
-    path('configure/<int:pk>/', views.DeviceConfigureView.as_view(), name='config'),
-    path('browser/', views.DeviceOnboardingBrowserLoginView.as_view(), name='browser_login'),
-    path(
-        'browser/credential-download/<int:pk>/',
-        views.DeviceBrowserCredentialDownloadView.as_view(),
-        name='browser_domain_credential_download',
-    ),
-    path(
-        'credential-download/browser/<int:pk>/', views.DeviceBrowserOnboardingOTPView.as_view(), name='browser_otp_view'
-    ),
-    path(
-        'credential-download/browser/<int:pk>/cancel',
-        views.DeviceBrowserOnboardingCancelView.as_view(),
-        name='browser_cancel',
-    ),
-    path('download/<int:pk>/', views.DownloadPageDispatcherView.as_view(), name='download'),
-    path(
-        'credential/download/<int:pk>/', views.DeviceManualCredentialDownloadView.as_view(), name='credential-download'
-    ),
-    path('certificate/download/<int:pk>/', views.CertificateDownloadView.as_view(), name='certificate-download'),
+
+    # Certificate Lifecycle Management
     path(
         'certificate-lifecycle-management/<int:pk>/',
         views.DeviceCertificateLifecycleManagementSummaryView.as_view(),
         name='certificate_lifecycle_management',
     ),
+
+    # Certificate Lifecycle Management - Credential Issuance
     path(
         'certificate-lifecycle-management/<int:pk>/issue-tls-client-credential/',
         views.DeviceIssueTlsClientCredential.as_view(),
@@ -55,12 +41,8 @@ urlpatterns = [
         views.DeviceIssueOpcUaServerCredential.as_view(),
         name='certificate_lifecycle_management-issue_opcua_server_credential',
     ),
-    path(
-        'certificate-lifecycle-management/<int:pk>/revoke/<int:credential_pk>/',
-        views.DeviceCredentialRevocationView.as_view(),
-        name='credential_revocation',
-    ),
-    path('revoke/<int:pk>/', views.DeviceRevocationView.as_view(), name='device_revocation'),
+
+    # Certificate Lifecycle Management - Help Pages
     path('help/dispatch/<int:pk>/', views.HelpDispatchView.as_view(), name='help_dispatch'),
     path(
         'help/no-onboarding/cmp-shared-secret/<int:pk>/',
@@ -82,4 +64,42 @@ urlpatterns = [
         views.OnboardingIdevidRegistrationHelpView.as_view(),
         name='help-onboarding_cmp-idevid-registration',
     ),
+
+    # Certificate Lifecycle Management - Downloads
+    path('download/<int:pk>/', views.DownloadPageDispatcherView.as_view(), name='download'),
+    path('certificate/download/<int:pk>/', views.CertificateDownloadView.as_view(), name='certificate-download'),
+    path(
+        'credential/download/<int:pk>/', views.DeviceManualCredentialDownloadView.as_view(), name='credential-download'
+    ),
+    path(
+        'credential-download/browser/<int:pk>/', views.DeviceBrowserOnboardingOTPView.as_view(), name='browser_otp_view'
+    ),
+    path('browser/', views.DeviceOnboardingBrowserLoginView.as_view(), name='browser_login'),
+
+    # Revoke Views
+    path('browser/', views.DeviceOnboardingBrowserLoginView.as_view(), name='browser_login'),
+    path(
+        'browser/credential-download/<int:pk>/',
+        views.DeviceBrowserCredentialDownloadView.as_view(),
+        name='browser_domain_credential_download',
+    ),
+
+    path(
+        'credential-download/browser/<int:pk>/cancel',
+        views.DeviceBrowserOnboardingCancelView.as_view(),
+        name='browser_cancel',
+    ),
+
+
+
+
+
+
+    path(
+        'certificate-lifecycle-management/<int:pk>/revoke/<int:credential_pk>/',
+        views.DeviceCredentialRevocationView.as_view(),
+        name='credential_revocation',
+    ),
+    path('revoke/<int:pk>/', views.DeviceRevocationView.as_view(), name='device_revocation'),
+
 ]

--- a/trustpoint/devices/urls.py
+++ b/trustpoint/devices/urls.py
@@ -1,6 +1,6 @@
 """URL configuration for the devices' application."""
 
-from django.urls import path  # type: ignore[import-untyped]
+from django.urls import path
 
 from . import views
 
@@ -12,78 +12,74 @@ urlpatterns = [
     path('details/<int:pk>/', views.DeviceDetailsView.as_view(), name='details'),
     path('configure/<int:pk>/', views.DeviceConfigureView.as_view(), name='config'),
     path('browser/', views.DeviceOnboardingBrowserLoginView.as_view(), name='browser_login'),
-    path('browser/credential-download/<int:pk>/',
-         views.DeviceBrowserCredentialDownloadView.as_view(),
-         name='browser_domain_credential_download'),
     path(
-        'credential-download/browser/<int:pk>/',
-        views.DeviceBrowserOnboardingOTPView.as_view(),
-        name='browser_otp_view'),
+        'browser/credential-download/<int:pk>/',
+        views.DeviceBrowserCredentialDownloadView.as_view(),
+        name='browser_domain_credential_download',
+    ),
+    path(
+        'credential-download/browser/<int:pk>/', views.DeviceBrowserOnboardingOTPView.as_view(), name='browser_otp_view'
+    ),
     path(
         'credential-download/browser/<int:pk>/cancel',
         views.DeviceBrowserOnboardingCancelView.as_view(),
-        name='browser_cancel'),
-    path(
-        'download/<int:pk>/',
-        views.DownloadPageDispatcherView.as_view(),
-        name='download'
+        name='browser_cancel',
     ),
+    path('download/<int:pk>/', views.DownloadPageDispatcherView.as_view(), name='download'),
     path(
-        'credential/download/<int:pk>/',
-        views.DeviceManualCredentialDownloadView.as_view(),
-        name='credential-download'
+        'credential/download/<int:pk>/', views.DeviceManualCredentialDownloadView.as_view(), name='credential-download'
     ),
-    path(
-        'certificate/download/<int:pk>/',
-        views.CertificateDownloadView.as_view(),
-        name='certificate-download'
-    ),
+    path('certificate/download/<int:pk>/', views.CertificateDownloadView.as_view(), name='certificate-download'),
     path(
         'certificate-lifecycle-management/<int:pk>/',
         views.DeviceCertificateLifecycleManagementSummaryView.as_view(),
-        name='certificate_lifecycle_management'),
+        name='certificate_lifecycle_management',
+    ),
     path(
         'certificate-lifecycle-management/<int:pk>/issue-tls-client-credential/',
         views.DeviceIssueTlsClientCredential.as_view(),
-        name='certificate_lifecycle_management-issue_tls_client_credential'),
+        name='certificate_lifecycle_management-issue_tls_client_credential',
+    ),
     path(
         'certificate-lifecycle-management/<int:pk>/issue-tls-server-credential/',
         views.DeviceIssueTlsServerCredential.as_view(),
-        name='certificate_lifecycle_management-issue_tls_server_credential'),
+        name='certificate_lifecycle_management-issue_tls_server_credential',
+    ),
     path(
         'certificate-lifecycle-management/<int:pk>/issue-opcua-client-credential/',
         views.DeviceIssueOpcUaClientCredential.as_view(),
-        name='certificate_lifecycle_management-issue_opcua_client_credential'),
+        name='certificate_lifecycle_management-issue_opcua_client_credential',
+    ),
     path(
         'certificate-lifecycle-management/<int:pk>/issue-opcua-server-credential/',
         views.DeviceIssueOpcUaServerCredential.as_view(),
-        name='certificate_lifecycle_management-issue_opcua_server_credential'),
-
-    path('certificate-lifecycle-management/<int:pk>/revoke/<int:credential_pk>/',
-         views.DeviceCredentialRevocationView.as_view(),
-         name='credential_revocation'),
-    path('revoke/<int:pk>/',
-         views.DeviceRevocationView.as_view(),
-         name='device_revocation'),
-    path(
-        'help/dispatch/<int:pk>/',
-        views.HelpDispatchView.as_view(),
-        name='help_dispatch'
+        name='certificate_lifecycle_management-issue_opcua_server_credential',
     ),
+    path(
+        'certificate-lifecycle-management/<int:pk>/revoke/<int:credential_pk>/',
+        views.DeviceCredentialRevocationView.as_view(),
+        name='credential_revocation',
+    ),
+    path('revoke/<int:pk>/', views.DeviceRevocationView.as_view(), name='device_revocation'),
+    path('help/dispatch/<int:pk>/', views.HelpDispatchView.as_view(), name='help_dispatch'),
     path(
         'help/no-onboarding/cmp-shared-secret/<int:pk>/',
         views.NoOnboardingCmpSharedSecretHelpView.as_view(),
-        name='help_no-onboarding_cmp-shared-secret'),
+        name='help_no-onboarding_cmp-shared-secret',
+    ),
     path(
         'help/onboarding/cmp-shared-secret/<int:pk>/',
         views.OnboardingCmpSharedSecretHelpView.as_view(),
-        name='help-onboarding_cmp-shared-secret'),
+        name='help-onboarding_cmp-shared-secret',
+    ),
     path(
         'help/onboarding/cmp-idevid/<int:pk>/',
         views.OnboardingCmpIdevidHelpView.as_view(),
-        name='help-onboarding_cmp-idevid'),
+        name='help-onboarding_cmp-idevid',
+    ),
     path(
         'help/onboarding/cmp-idevid-registration/<int:pk>/',
         views.OnboardingIdevidRegistrationHelpView.as_view(),
-        name='help-onboarding_cmp-idevid-registration')
+        name='help-onboarding_cmp-idevid-registration',
+    ),
 ]

--- a/trustpoint/devices/urls.py
+++ b/trustpoint/devices/urls.py
@@ -50,6 +50,15 @@ urlpatterns = [
         'certificate-lifecycle-management/<int:pk>/issue-tls-server-credential/',
         views.DeviceIssueTlsServerCredential.as_view(),
         name='certificate_lifecycle_management-issue_tls_server_credential'),
+    path(
+        'certificate-lifecycle-management/<int:pk>/issue-opcua-client-credential/',
+        views.DeviceIssueOpcUaClientCredential.as_view(),
+        name='certificate_lifecycle_management-issue_opcua_client_credential'),
+    path(
+        'certificate-lifecycle-management/<int:pk>/issue-opcua-server-credential/',
+        views.DeviceIssueOpcUaServerCredential.as_view(),
+        name='certificate_lifecycle_management-issue_opcua_server_credential'),
+
     path('certificate-lifecycle-management/<int:pk>/revoke/<int:credential_pk>/',
          views.DeviceCredentialRevocationView.as_view(),
          name='credential_revocation'),

--- a/trustpoint/devices/views.py
+++ b/trustpoint/devices/views.py
@@ -515,9 +515,9 @@ class HelpDispatchView(DeviceContextMixin, SingleObjectMixin[DeviceModel], Redir
         del kwargs
 
         device: DeviceModel = self.get_object()
-        if not device.domain_credential_onboarding:
-            if device.pki_protocol == device.PkiProtocol.CMP_SHARED_SECRET.value:
-                return f'{reverse("devices:help_no-onboarding_cmp-shared-secret", kwargs={"pk": device.id})}'
+        if not device.domain_credential_onboarding and \
+                device.pki_protocol == device.PkiProtocol.CMP_SHARED_SECRET.value:
+            return f'{reverse("devices:help_no-onboarding_cmp-shared-secret", kwargs={"pk": device.id})}'
 
         if device.onboarding_protocol == device.OnboardingProtocol.CMP_SHARED_SECRET.value:
             return f'{reverse("devices:help-onboarding_cmp-shared-secret", kwargs={"pk": device.id})}'
@@ -579,7 +579,8 @@ class HelpDomainCredentialCmpContextView(DeviceContextMixin, DetailView[DeviceMo
                 f'-genkey -noout -out key.pem'
             )
         else:
-            raise ValueError('Unsupported public key algorithm')
+            err_msg = _('Unsupported public key algorithm')
+            raise ValueError(err_msg)
 
         context['domain_credential_key_gen_command'] = domain_credential_key_gen_command
         context['key_gen_command'] = key_gen_command
@@ -613,7 +614,6 @@ class NoOnboardingCmpSharedSecretHelpView(DeviceContextMixin, DetailView[DeviceM
         Returns:
             The context to render the page.
         """
-
         context = super().get_context_data(**kwargs)
         device: DeviceModel = self.object
 
@@ -625,7 +625,8 @@ class NoOnboardingCmpSharedSecretHelpView(DeviceContextMixin, DetailView[DeviceM
                 f'-genkey -noout -out key.pem'
             )
         else:
-            raise ValueError('Unsupported public key algorithm')
+            err_msg = _('Unsupported public key algorithm')
+            raise ValueError(err_msg)
         context['host'] = (
             self.request.META.get('REMOTE_ADDR', '127.0.0.1') + ':' + self.request.META.get('SERVER_PORT'),
             '443',
@@ -667,7 +668,6 @@ class OnboardingIdevidRegistrationHelpView(DeviceContextMixin, DetailView[DevIdR
         Returns:
             The context to render the page.
         """
-
         context = super().get_context_data(**kwargs)
         devid_registration: DevIdRegistration = self.object
 
@@ -763,7 +763,7 @@ class DeviceBaseCredentialDownloadView(
     is_browser_download = False
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
-        """Adds information about the credential to the context
+        """Adds information about the credential to the context.
 
         Args:
             **kwargs: Keyword arguments are passed to super().get_context_data(**kwargs).
@@ -802,8 +802,8 @@ class DeviceBaseCredentialDownloadView(
         context['issued_credential'] = issued_credential
         return context
 
-    # TODO(AlexHx8472): This needs to return a success url redirect and then download the file.
-    # TODO(AlexHx8472): The FileResponse must then be returned from a get or post method.
+    # TODO(AlexHx8472): This needs to return a success url redirect and then download the file. # noqa: FIX002
+    # TODO(AlexHx8472): The FileResponse must then be returned from a get or post method.       # noqa: FIX002
     def form_valid(self, form: CredentialDownloadForm) -> HttpResponse:
         """Processing the valid form data.
 
@@ -885,7 +885,6 @@ class DeviceBrowserOnboardingOTPView(DeviceContextMixin, DetailView[IssuedCreden
         Returns:
             The context to render the page.
         """
-
         credential = self.get_object()
         device = credential.device
         context = super().get_context_data(**kwargs)
@@ -927,7 +926,6 @@ class DeviceOnboardingBrowserLoginView(FormView[BrowserLoginForm]):
         Returns:
             The success url to redirect to after successful processing of the POST data following a form submit.
         """
-
         credential_id = cast(int, self.cleaned_data.get('credential_id'))
         credential_download = cast(RemoteDeviceCredentialDownloadModel, self.cleaned_data.get('credential_download'))
         token: str = credential_download.download_token
@@ -1019,6 +1017,9 @@ class DeviceBrowserOnboardingCancelView(DeviceContextMixin, SingleObjectMixin[Is
         Returns:
             The redirect URL.
         """
+        del args
+        del kwargs
+
         return str(reverse_lazy('devices:credential-download', kwargs={'pk': self.object.id}))
 
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
@@ -1116,7 +1117,6 @@ class DeviceCredentialRevocationView(
         Returns:
             The context to render the page.
         """
-
         context = super().get_context_data(**kwargs)
         context['credentials'] = [context['credential']]
         return context

--- a/trustpoint/devices/views.py
+++ b/trustpoint/devices/views.py
@@ -288,7 +288,7 @@ class DeviceCertificateLifecycleManagementSummaryView(DeviceContextMixin, Sortab
 #  ------------------------------ Certificate Lifecycle Management - Credential Issuance -------------------------------
 
 
-class DeviceIssueCredentialViewMixin(
+class DeviceIssueCredentialView(
     DeviceContextMixin,
     SingleObjectMixin[DeviceModel],
     FormView[CredentialFormClass],
@@ -365,7 +365,7 @@ class DeviceIssueCredentialViewMixin(
 
 
 class DeviceIssueTlsClientCredential(
-    DeviceIssueCredentialViewMixin[IssueTlsClientCredentialForm, LocalTlsClientCredentialIssuer]
+    DeviceIssueCredentialView[IssueTlsClientCredentialForm, LocalTlsClientCredentialIssuer]
 ):
     """View to issue a new TLS client credential."""
 
@@ -391,7 +391,7 @@ class DeviceIssueTlsClientCredential(
 
 
 class DeviceIssueTlsServerCredential(
-    DeviceIssueCredentialViewMixin[IssueTlsServerCredentialForm, LocalTlsServerCredentialIssuer]
+    DeviceIssueCredentialView[IssueTlsServerCredentialForm, LocalTlsServerCredentialIssuer]
 ):
     """View to issue a new TLS server credential."""
 
@@ -424,7 +424,7 @@ class DeviceIssueTlsServerCredential(
 
 
 class DeviceIssueOpcUaClientCredential(
-    DeviceIssueCredentialViewMixin[IssueOpcUaClientCredentialForm, OpcUaClientCredentialIssuer]
+    DeviceIssueCredentialView[IssueOpcUaClientCredentialForm, OpcUaClientCredentialIssuer]
 ):
     """View to issue a new OPC UA client credential."""
 
@@ -451,7 +451,7 @@ class DeviceIssueOpcUaClientCredential(
 
 
 class DeviceIssueOpcUaServerCredential(
-    DeviceIssueCredentialViewMixin[IssueOpcUaServerCredentialForm, OpcUaServerCredentialIssuer]
+    DeviceIssueCredentialView[IssueOpcUaServerCredentialForm, OpcUaServerCredentialIssuer]
 ):
     """View to issue a new OPC UA server credential."""
 

--- a/trustpoint/devices/views.py
+++ b/trustpoint/devices/views.py
@@ -71,6 +71,8 @@ else:
 CredentialFormClass = TypeVar('CredentialFormClass', bound='BaseCredentialForm')
 TlsCredentialIssuerClass = TypeVar('TlsCredentialIssuerClass', bound='BaseTlsCredentialIssuer')
 
+# TODO(AlexHx8472): Derived CBVs must only derive from one Django view which must be the last one.  # noqa: FIX002
+
 
 # --------------------------------------------------- Device Mixins ----------------------------------------------------
 

--- a/trustpoint/devices/views.py
+++ b/trustpoint/devices/views.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import datetime
 import io
-import ipaddress
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
@@ -14,22 +13,21 @@ from django.core.paginator import Paginator
 from django.db.models import Q
 from django.forms import BaseModelForm
 from django.http import FileResponse, Http404, HttpResponse, HttpResponseBase
-from django.shortcuts import redirect, render
+from django.shortcuts import redirect
 from django.urls import reverse, reverse_lazy
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
-from django.views.generic.base import RedirectView
+from django.views.generic.base import RedirectView, View
 from django.views.generic.detail import DetailView, SingleObjectMixin
 from django.views.generic.edit import CreateView, FormMixin, FormView
 from django.views.generic.list import ListView
 from pki.models.certificate import CertificateModel
 from pki.models.credential import CredentialModel
 from pki.models.devid_registration import DevIdRegistration
-from trustpoint_core import oid # type: ignore[import-untyped]
-from trustpoint_core.file_builder.enum import ArchiveFormat # type: ignore[import-untyped]
-from trustpoint_core.serializer import CredentialSerializer # type: ignore[import-untyped]
-from util.field import UniqueNameValidator
+from trustpoint_core import oid  # type: ignore[import-untyped]
+from trustpoint_core.file_builder.enum import ArchiveFormat  # type: ignore[import-untyped]
+from trustpoint_core.serializer import CredentialSerializer  # type: ignore[import-untyped]
 
 from devices.forms import (
     BrowserLoginForm,
@@ -50,62 +48,46 @@ from devices.issuer import (
 from devices.models import DeviceModel, IssuedCredentialModel, RemoteDeviceCredentialDownloadModel
 from devices.revocation import DeviceCredentialRevocation
 from trustpoint.settings import UIConfig
-from trustpoint.views.base import ListInDetailView, SortableTableMixin, TpLoginRequiredMixin
+from trustpoint.views.base import ListInDetailView, SortableTableMixin
 
 if TYPE_CHECKING:
+    import ipaddress
     from typing import Any, ClassVar
+
     from django.http.request import HttpRequest
     from django.utils.safestring import SafeString
-    _DispatchableType = FormView
+
+    # noinspection PyUnresolvedReferences
+    from devices.forms import BaseCredentialForm
+
+    # noinspection PyUnresolvedReferences
+    from devices.issuer import BaseTlsCredentialIssuer
+
+    _DispatchableType = View
+
 else:
     _DispatchableType = object
 
-F = TypeVar('F', bound='BaseCredentialForm')
-I = TypeVar('I', bound='BaseTlsCredentialIssuer')
+CredentialFormClass = TypeVar('CredentialFormClass', bound='BaseCredentialForm')
+TlsCredentialIssuerClass = TypeVar('TlsCredentialIssuerClass', bound='BaseTlsCredentialIssuer')
 
 
-class Detail404RedirectView(DetailView):
-    """A detail view that redirects to self.redirection_view on 404 and adds a message."""
-
-    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
-        """Overrides the get method to add a message and redirect to self.redirection_view on 404."""
-        try:
-            return super().get(request, *args, **kwargs)
-        except Http404:
-            redirection_view = 'devices:devices'
-            messages.error(self.request, f'{self.model.__name__} with ID {kwargs[self.pk_url_kwarg]} not found.')
-            return redirect(redirection_view)
+# --------------------------------------------------- Device Mixins ----------------------------------------------------
 
 
 class DeviceContextMixin:
-    """Mixin which adds context_data for the Devices -> Devices pages."""
+    """Mixin which adds data to the context for the devices application."""
 
     extra_context: ClassVar = {'page_category': 'devices', 'page_name': 'devices'}
 
 
-class DownloadTokenRequiredMixin(_DispatchableType):
-    """Mixin which checks the token included in the URL for browser download views."""
-
-    credential_download: RemoteDeviceCredentialDownloadModel
-
-    def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
-        """Checks the validity of the token included in the URL for browser download views."""
-        token = request.GET.get('token')
-        try:
-            self.credential_download = RemoteDeviceCredentialDownloadModel.objects.get(
-                issued_credential_model=kwargs.get('pk')
-            )
-        except RemoteDeviceCredentialDownloadModel.DoesNotExist:
-            messages.warning(request, 'Invalid download token.')
-            return redirect('devices:browser_login')
-        if not token or not self.credential_download.check_token(token):
-            messages.warning(request, 'Invalid download token.')
-            return redirect('devices:browser_login')
-        return super().dispatch(request, *args, **kwargs)
+# ----------------------------------------------------- Main Pages -----------------------------------------------------
 
 
-class DeviceTableView(DeviceContextMixin, TpLoginRequiredMixin, SortableTableMixin, ListView[DeviceModel]):
+class DeviceTableView(DeviceContextMixin, SortableTableMixin, ListView[DeviceModel]):
     """Device Table View."""
+
+    http_method_names = ('get',)
 
     model = DeviceModel
     template_name = 'devices/devices.html'
@@ -114,206 +96,81 @@ class DeviceTableView(DeviceContextMixin, TpLoginRequiredMixin, SortableTableMix
     default_sort_param = 'unique_name'
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
-        """Add the context data for the view and render additional table fields."""
+        """Adds the clm and revoke buttons to the context.
+
+        Args:
+            **kwargs: Keyword arguments passed to super().get_context_data.
+
+        Returns:
+            The context to use for rendering the devices page.
+        """
         context = super().get_context_data(**kwargs)
 
-        for device in context['page_obj']:
-            device.onboarding_button = self._render_onboarding_button(device)
-            device.clm_button = self._render_clm(device)
-            device.revoke_button = self._render_revoke(device)
+        for device in context['devices']:
+            device.clm_button = self._get_clm_button_html(device)
+            device.revoke_button = self._get_revoke_button_html(device)
 
         return context
 
     @staticmethod
-    def _render_onboarding_button(record: DeviceModel) -> SafeString | str:
-        """Creates the html hyperlink for the onboarding-view.
+    def _get_clm_button_html(record: DeviceModel) -> SafeString:
+        """Gets the HTML for the CLM button in the devices table.
 
         Args:
-            record (Device): The current record of the Device model.
+            record: The corresponding DeviceModel.
 
         Returns:
-            SafeString: The html hyperlink for the details-view.
+            The HTML of the hyperlink for the CLM button.
         """
-        if not record.domain:
-            return format_html('<span>{}</span>', _('No Domain configured.'))
-        if not record.domain.issuing_ca:
-            return format_html('<span>{}</span>', _('No Issuing CA configured.'))
-        return 'Hello'
-
-    @staticmethod
-    def _render_clm(record: DeviceModel) -> SafeString | str:
+        # noinspection PyDeprecation
         return format_html(
-            f'<a href="certificate-lifecycle-management/{record.pk}/" class="btn btn-primary tp-table-btn w-100">Manage</a>',
+            '<a href="certificate-lifecycle-management/{}/" class="btn btn-primary tp-table-btn w-100">Manage</a>',
+            record.pk,
         )
 
     @staticmethod
-    def _render_revoke(record: DeviceModel) -> SafeString | str:
-        # TODO(Air): This cursed query may be slow for a large number of devices.
-        if IssuedCredentialModel.objects.filter(
-            device=record, credential__primarycredentialcertificate__is_primary=True
-        ).exists():
-            return format_html(
-                '<a href="revoke/{}/" class="btn btn-danger tp-table-btn w-100">{}</a>', record.pk, _('Revoke')
-            )
+    def _get_revoke_button_html(record: DeviceModel) -> SafeString:
+        """Gets the HTML for the revoke button in the devices table.
 
+        Args:
+            record: The corresponding DeviceModel.
+
+        Returns:
+            the HTML of the hyperlink for the revoke button.
+        """
+        qs = IssuedCredentialModel.objects.filter(device=record)
+        for credential in qs:
+            if credential.credential.certificate.certificate_status == CertificateModel.CertificateStatus.OK:
+                # noinspection PyDeprecation
+                return format_html(
+                    '<a href="revoke/{}/" class="btn btn-danger tp-table-btn w-100">{}</a>', record.pk, _('Revoke')
+                )
+        # noinspection PyDeprecation
         return format_html('<a class="btn btn-danger tp-table-btn w-100 disabled">{}</a>', _('Revoke'))
 
 
-class CreateDeviceView(DeviceContextMixin, TpLoginRequiredMixin, CreateView[DeviceModel, BaseModelForm[DeviceModel]]):
+class CreateDeviceView(DeviceContextMixin, CreateView[DeviceModel, BaseModelForm[DeviceModel]]):
     """Device Create View."""
 
     http_method_names = ('get', 'post')
+
     model = DeviceModel
     form_class = CreateDeviceForm
     template_name = 'devices/add.html'
 
     def get_success_url(self) -> str:
+        """Gets the success url to redirect to after successful processing of the POST data following a form submit.
+
+        Returns:
+            The success url to redirect to after successful processing of the POST data following a form submit.
+        """
         if self.object is None:
-            err_msg = 'Failed to get DeviceModel object.'
+            err_msg = 'Unexpected error occurred. The object was likely not created and saved.'
             raise Http404(err_msg)
-        return reverse('devices:help_dispatch', kwargs={'pk': self.object.id})
-
-    @staticmethod
-    def clean_device_name(device_name: str) -> str:
-        """Validates the device name, i.e. checks if it is unique.
-
-        Args:
-            device_name: The desired name of the new device.
-
-        Returns:
-            The device name if it passed the checks.
-        """
-        UniqueNameValidator(device_name)
-        return device_name
-
-    def form_valid(self, form: BaseModelForm[DeviceModel]) -> HttpResponse:
-        """Processing the valid form data.
-
-        This will use the contained form data to issue a new TLS server credential.
-
-        Args:
-            form: The valid form including the cleaned data.
-
-        Returns:
-            If successful, this will start the file download. Otherwise, a Http404 will be raised and displayed.
-        """
-        return super().form_valid(form)
+        return str(reverse_lazy('devices:help_dispatch', kwargs={'pk': self.object.id}))
 
 
-class NoOnboardingCmpSharedSecretHelpView(DeviceContextMixin, TpLoginRequiredMixin, Detail404RedirectView):
-    model = DeviceModel
-    template_name = 'devices/help/no_onboarding/cmp_shared_secret.html'
-    context_object_name = 'device'
-
-    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
-        context = super().get_context_data()
-        device: DeviceModel = self.object
-
-        if device.public_key_info.public_key_algorithm_oid == oid.PublicKeyAlgorithmOid.RSA:
-            key_gen_command = f'openssl genrsa -out key.pem {device.public_key_info.key_size}'
-        elif device.public_key_info.public_key_algorithm_oid == oid.PublicKeyAlgorithmOid.ECC:
-            key_gen_command = (
-                f'openssl ecparam -name {device.public_key_info.named_curve.ossl_curve_name} '
-                f'-genkey -noout -out key.pem'
-            )
-        else:
-            raise ValueError('Unsupported public key algorithm')
-        context['host'] = (
-                self.request.META.get('REMOTE_ADDR', '127.0.0.1')
-                + ':'
-                + self.request.META.get('SERVER_PORT'), '443')
-        context['key_gen_command'] = key_gen_command
-        number_of_issued_device_certificates = len(IssuedCredentialModel.objects.filter(device=device))
-        context['tls_client_cn'] = f'Trustpoint-TLS-Client-Credential-{number_of_issued_device_certificates}'
-        context['tls_server_cn'] = f'Trustpoint-TLS-Server-Credential-{number_of_issued_device_certificates}'
-        return context
-
-
-class OnboardingCmpSharedSecretHelpView(DeviceContextMixin, TpLoginRequiredMixin, Detail404RedirectView):
-    model = DeviceModel
-    template_name = 'devices/help/onboarding/cmp_shared_secret.html'
-    context_object_name = 'device'
-
-    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
-        context = super().get_context_data()
-        device: DeviceModel = self.object
-
-        if device.public_key_info.public_key_algorithm_oid == oid.PublicKeyAlgorithmOid.RSA:
-            domain_credential_key_gen_command = (
-                f'openssl genrsa -out domain_credential_key.pem {device.public_key_info.key_size}'
-            )
-            key_gen_command = f'openssl genrsa -out key.pem {device.public_key_info.key_size}'
-        elif device.public_key_info.public_key_algorithm_oid == oid.PublicKeyAlgorithmOid.ECC:
-            domain_credential_key_gen_command = (
-                f'openssl ecparam -name {device.public_key_info.named_curve.ossl_curve_name} '
-                f'-genkey -noout -out domain_credential_key.pem'
-            )
-            key_gen_command = (
-                f'openssl ecparam -name {device.public_key_info.named_curve.ossl_curve_name} '
-                f'-genkey -noout -out key.pem'
-            )
-        else:
-            raise ValueError('Unsupported public key algorithm')
-        context['host'] = (
-                self.request.META.get('REMOTE_ADDR', '127.0.0.1')
-                + ':'
-                + self.request.META.get('SERVER_PORT', '443'))
-        context['domain_credential_key_gen_command'] = domain_credential_key_gen_command
-        context['key_gen_command'] = key_gen_command
-        context['issuing_ca_pem'] = (
-            device.domain.issuing_ca.credential.get_certificate()
-            .public_bytes(encoding=serialization.Encoding.PEM)
-            .decode()
-        )
-        number_of_issued_device_certificates = len(IssuedCredentialModel.objects.filter(device=device))
-        context['tls_client_cn'] = f'Trustpoint-TLS-Client-Credential-{number_of_issued_device_certificates}'
-        context['tls_server_cn'] = f'Trustpoint-TLS-Server-Credential-{number_of_issued_device_certificates}'
-        return context
-
-
-class OnboardingCmpIdevidHelpView(DeviceContextMixin, TpLoginRequiredMixin, Detail404RedirectView):
-    model = DeviceModel
-    template_name = 'devices/help/onboarding/cmp_idevid.html'
-    context_object_name = 'device'
-
-    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
-        context = super().get_context_data()
-        device: DeviceModel = self.object
-
-        if device.public_key_info.public_key_algorithm_oid == oid.PublicKeyAlgorithmOid.RSA:
-            domain_credential_key_gen_command = (
-                f'openssl genrsa -out domain_credential_key.pem {device.public_key_info.key_size}'
-            )
-            key_gen_command = f'openssl genrsa -out key.pem {device.public_key_info.key_size}'
-        elif device.public_key_info.public_key_algorithm_oid == oid.PublicKeyAlgorithmOid.ECC:
-            domain_credential_key_gen_command = (
-                f'openssl ecparam -name {device.public_key_info.named_curve.ossl_curve_name} '
-                f'-genkey -noout -out domain_credential_key.pem'
-            )
-            key_gen_command = (
-                f'openssl ecparam -name {device.public_key_info.named_curve.ossl_curve_name} '
-                f'-genkey -noout -out key.pem'
-            )
-        else:
-            raise ValueError('Unsupported public key algorithm')
-        context['host'] = (
-                self.request.META.get('REMOTE_ADDR', '127.0.0.1')
-                + ':'
-                + self.request.META.get('SERVER_PORT', '443'))
-        context['domain_credential_key_gen_command'] = domain_credential_key_gen_command
-        context['key_gen_command'] = key_gen_command
-        context['issuing_ca_pem'] = (
-            device.domain.issuing_ca.credential.get_certificate()
-            .public_bytes(encoding=serialization.Encoding.PEM)
-            .decode()
-        )
-        number_of_issued_device_certificates = len(IssuedCredentialModel.objects.filter(device=device))
-        context['tls_client_cn'] = f'Trustpoint-TLS-Client-Credential-{number_of_issued_device_certificates}'
-        context['tls_server_cn'] = f'Trustpoint-TLS-Server-Credential-{number_of_issued_device_certificates}'
-        return context
-
-
-class DeviceDetailsView(DeviceContextMixin, TpLoginRequiredMixin, Detail404RedirectView):
+class DeviceDetailsView(DeviceContextMixin, DetailView[DeviceModel]):
     """Device Details View."""
 
     http_method_names = ('get',)
@@ -324,21 +181,577 @@ class DeviceDetailsView(DeviceContextMixin, TpLoginRequiredMixin, Detail404Redir
     context_object_name = 'device'
 
 
-class DeviceConfigureView(DeviceContextMixin, TpLoginRequiredMixin, Detail404RedirectView):
-    """Device Configuration View."""
+# ------------------------------------------ Certificate Lifecycle Management ------------------------------------------
+
+
+class DeviceCertificateLifecycleManagementSummaryView(DeviceContextMixin, SortableTableMixin, ListInDetailView):
+    """This is the CLM summary view in the devices section."""
+
+    http_method_names = ('get',)
+
+    detail_model = DeviceModel
+    template_name = 'devices/credentials/certificate_lifecycle_management.html'
+    detail_context_object_name = 'device'
+    model = IssuedCredentialModel
+    context_object_name = 'issued_credentials'
+    default_sort_param = 'common_name'
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        """Adds the paginator and credential details to the context.
+
+        Args:
+            **kwargs: Keyword arguments passed to super().get_context_data.
+
+        Returns:
+            The context to use for rendering the clm summary page.
+        """
+        context = super().get_context_data(**kwargs)
+
+        device = self.get_object()
+        qs = super().get_queryset()  # inherited from SortableTableMixin, sorted query
+
+        domain_credentials = qs.filter(
+            Q(device=device)
+            & Q(issued_credential_type=IssuedCredentialModel.IssuedCredentialType.DOMAIN_CREDENTIAL.value)
+        )
+
+        application_credentials = qs.filter(
+            Q(device=device)
+            & Q(issued_credential_type=IssuedCredentialModel.IssuedCredentialType.APPLICATION_CREDENTIAL.value)
+        )
+
+        context['domain_credentials'] = domain_credentials
+        context['application_credentials'] = application_credentials
+
+        paginator_domain = Paginator(domain_credentials, UIConfig.paginate_by)
+        page_number_domain = self.request.GET.get('page', 1)
+        context['domain_credentials'] = paginator_domain.get_page(page_number_domain)
+        context['is_paginated'] = paginator_domain.num_pages > 1
+
+        paginator_application = Paginator(application_credentials, UIConfig.paginate_by)
+        page_number_application = self.request.GET.get('page-a', 1)
+        context['application_credentials'] = paginator_application.get_page(page_number_application)
+        context['is_paginated_a'] = paginator_application.num_pages > 1
+
+        for cred in context['domain_credentials']:
+            cred.expires_in = self._get_expires_in(cred)
+            cred.expiration_date = cast(datetime.datetime, cred.credential.certificate.not_valid_after)
+            cred.revoke = self._get_revoke_button_html(cred)
+
+        for cred in context['application_credentials']:
+            cred.expires_in = self._get_expires_in(cred)
+            cred.expiration_date = cast(datetime.datetime, cred.credential.certificate.not_valid_after)
+            cred.revoke = self._get_revoke_button_html(cred)
+
+        return context
+
+    @staticmethod
+    def _get_expires_in(record: IssuedCredentialModel) -> str:
+        """Gets the remaining time until the credential expires as human-readable string.
+
+        Args:
+            record: The corresponding IssuedCredentialModel.
+
+        Returns:
+            The remaining time until the credential expires as human-readable string.
+        """
+        if record.credential.certificate.certificate_status != CertificateModel.CertificateStatus.OK:
+            return str(record.credential.certificate.certificate_status.label)
+        now = datetime.datetime.now(datetime.UTC)
+        expire_timedelta = record.credential.certificate.not_valid_after - now
+        days = expire_timedelta.days
+        hours, remainder = divmod(expire_timedelta.seconds, 3600)
+        minutes, seconds = divmod(remainder, 60)
+        return f'{days} days, {hours}:{minutes:02d}:{seconds:02d}'
+
+    @staticmethod
+    def _get_revoke_button_html(record: IssuedCredentialModel) -> str:
+        """Gets the HTML for the revoke button in the devices table.
+
+        Args:
+            record: The corresponding DeviceModel.
+
+        Returns:
+            the HTML of the hyperlink for the revoke button.
+        """
+        if record.credential.certificate.certificate_status == CertificateModel.CertificateStatus.REVOKED:
+            # noinspection PyDeprecation
+            return format_html('<a class="btn btn-danger tp-table-btn w-100 disabled">{}</a>', _('Revoked'))
+        # noinspection PyDeprecation
+        return format_html(
+            '<a href="revoke/{}/" class="btn btn-danger tp-table-btn w-100">{}</a>', record.pk, _('Revoke')
+        )
+
+
+#  ------------------------------ Certificate Lifecycle Management - Credential Issuance -------------------------------
+
+
+class DeviceIssueCredentialViewMixin(
+    DeviceContextMixin,
+    DetailView[DeviceModel],
+    FormView[CredentialFormClass],
+    Generic[CredentialFormClass, TlsCredentialIssuerClass],
+):
+    """Base view to issue device credentials."""
+
+    http_method_names = ('get', 'post')
+
+    model = DeviceModel
+    context_object_name = 'device'
+    template_name = 'devices/credentials/issue_application_credential.html'
+    form_class: type[CredentialFormClass]
+    issuer_class: type[TlsCredentialIssuerClass]
+    friendly_name: str
+
+    def get_initial(self) -> dict[str, Any]:
+        """Gets the initial data for the corresponding form.
+
+        Returns:
+            The initial data for the corresponding form.
+        """
+        initial = super().get_initial()
+        device = self.get_object()
+        if self.issuer_class:
+            initial.update(self.issuer_class.get_fixed_values(device=device, domain=device.domain))
+        return initial
+
+    def get_form_kwargs(self) -> dict[str, Any]:
+        """This method ads the concerning device model to the form kwargs and returns them.
+
+        Returns:
+            The form kwargs including the concerning device model.
+        """
+        form_kwargs = super().get_form_kwargs()
+        form_kwargs.update({'device': self.get_object()})
+        return form_kwargs
+
+    def get_success_url(self) -> str:
+        """Gets the success url to redirect to after successful processing of the POST data following a form submit.
+
+        Returns:
+            The success url to redirect to after successful processing of the POST data following a form submit.
+        """
+        return cast(str, reverse_lazy('devices:certificate_lifecycle_management', kwargs={'pk': self.get_object().id}))
+
+    def form_valid(self, form: CredentialFormClass) -> HttpResponse:
+        """This method is executed if the form submit data was valid.
+
+        Args:
+            form: The form that was used to validate the data.
+
+        Returns:
+            The HTTP Response object after successful validation of the form data.
+        """
+        device = self.get_object()
+        credential = self.issue_credential(device=device, cleaned_data=form.cleaned_data)
+        messages.success(
+            self.request, f'Successfully issued {self.friendly_name} for device {credential.device.unique_name}'
+        )
+        return super().form_valid(form)
+
+    @abstractmethod
+    def issue_credential(self, device: DeviceModel, cleaned_data: dict[str, Any]) -> IssuedCredentialModel:
+        """Abstract method to issue a credential.
+
+        Args:
+            device: The device to be associated with the new credential.
+            cleaned_data: The validated form data.
+
+        Returns:
+            The IssuedCredentialModel object that was created and saved.
+        """
+
+
+class DeviceIssueTlsClientCredential(
+    DeviceIssueCredentialViewMixin[IssueTlsClientCredentialForm, LocalTlsClientCredentialIssuer]
+):
+    """View to issue a new TLS client credential."""
+
+    form_class = IssueTlsClientCredentialForm
+    issuer_class = LocalTlsClientCredentialIssuer
+    friendly_name = 'TLS client credential'
+
+    def issue_credential(self, device: DeviceModel, cleaned_data: dict[str, Any]) -> IssuedCredentialModel:
+        """Issues an TLS client credential.
+
+        Args:
+            device: The device to be associated with the new credential.
+            cleaned_data: The validated form data.
+
+        Returns:
+            The IssuedCredentialModel object that was created and saved.
+        """
+        common_name = cast(str, cleaned_data.get('common_name'))
+        validity = cast(int, cleaned_data.get('validity'))
+        issuer = self.issuer_class(device=device, domain=device.domain)
+
+        return issuer.issue_tls_client_credential(common_name=common_name, validity_days=validity)
+
+
+class DeviceIssueTlsServerCredential(
+    DeviceIssueCredentialViewMixin[IssueTlsServerCredentialForm, LocalTlsServerCredentialIssuer]
+):
+    """View to issue a new TLS server credential."""
+
+    form_class = IssueTlsServerCredentialForm
+    issuer_class = LocalTlsServerCredentialIssuer
+    friendly_name = 'TLS server credential'
+
+    def issue_credential(self, device: DeviceModel, cleaned_data: dict[str, Any]) -> IssuedCredentialModel:
+        """Issues an TLS server credential.
+
+        Args:
+            device: The device to be associated with the new credential.
+            cleaned_data: The validated form data.
+
+        Returns:
+            The IssuedCredentialModel object that was created and saved.
+        """
+        common_name = cast(str, cleaned_data.get('common_name'))
+        if not common_name:
+            raise Http404
+        issuer = self.issuer_class(device=device, domain=device.domain)
+        return issuer.issue_tls_server_credential(
+            common_name=common_name,
+            ipv4_addresses=cast('list[ipaddress.IPv4Address]', cleaned_data.get('ipv4_addresses')),
+            ipv6_addresses=cast('list[ipaddress.IPv6Address]', cleaned_data.get('ipv6_addresses')),
+            domain_names=cast(list[str], cleaned_data.get('domain_names')),
+            san_critical=False,
+            validity_days=cast(int, cleaned_data.get('validity')),
+        )
+
+
+class DeviceIssueOpcUaClientCredential(
+    DeviceIssueCredentialViewMixin[IssueOpcUaClientCredentialForm, OpcUaClientCredentialIssuer]
+):
+    """View to issue a new OPC UA client credential."""
+
+    form_class = IssueOpcUaClientCredentialForm
+    issuer_class = OpcUaClientCredentialIssuer
+    friendly_name = 'OPC UA client credential'
+
+    def issue_credential(self, device: DeviceModel, cleaned_data: dict[str, Any]) -> IssuedCredentialModel:
+        """Issues an OPC UA client credential.
+
+        Args:
+            device: The device to be associated with the new credential.
+            cleaned_data: The validated form data.
+
+        Returns:
+            The IssuedCredentialModel object that was created and saved.
+        """
+        issuer = self.issuer_class(device=device, domain=device.domain)
+        return issuer.issue_opcua_client_credential(
+            common_name=cast(str, cleaned_data.get('common_name')),
+            application_uri=cast(str, cleaned_data.get('application_uri')),
+            validity_days=cast(int, cleaned_data.get('validity')),
+        )
+
+
+class DeviceIssueOpcUaServerCredential(
+    DeviceIssueCredentialViewMixin[IssueOpcUaServerCredentialForm, OpcUaServerCredentialIssuer]
+):
+    """View to issue a new OPC UA server credential."""
+
+    form_class = IssueOpcUaServerCredentialForm
+    issuer_class = OpcUaServerCredentialIssuer
+    friendly_name = 'OPC UA server credential'
+
+    def issue_credential(self, device: DeviceModel, cleaned_data: dict[str, Any]) -> IssuedCredentialModel:
+        """Issues an OPC UA server credential.
+
+        Args:
+            device: The device to be associated with the new credential.
+            cleaned_data: The validated form data.
+
+        Returns:
+            The IssuedCredentialModel object that was created and saved.
+        """
+        common_name = cast(str, cleaned_data.get('common_name'))
+        if not common_name:
+            raise Http404
+        issuer = self.issuer_class(device=device, domain=device.domain)
+
+        ipv4_addresses: list[ipaddress.IPv4Address] = cleaned_data.get('ipv4_addresses', [])
+        ipv6_addresses: list[ipaddress.IPv6Address] = cleaned_data.get('ipv6_addresses', [])
+        domain_names: list[str] = cleaned_data.get('domain_names', [])
+        validity_days: int = cleaned_data.get('validity', 0)
+
+        return issuer.issue_opcua_server_credential(
+            common_name=common_name,
+            application_uri=cast(str, cleaned_data.get('application_uri')),
+            ipv4_addresses=ipv4_addresses,
+            ipv6_addresses=ipv6_addresses,
+            domain_names=domain_names,
+            validity_days=validity_days,
+        )
+
+
+#  ----------------------------------- Certificate Lifecycle Management - Help Pages -----------------------------------
+
+
+class HelpDispatchView(DeviceContextMixin, SingleObjectMixin[DeviceModel], RedirectView):
+    """Redirects to the required help pages depending on the onboarding protocol.
+
+    If no help page could be determined, it will redirect to the devices page.
+    """
+
+    http_method_names = ('get',)
+
+    model: type[DeviceModel] = DeviceModel
+    permanent = False
+
+    def get_redirect_url(self, *args: Any, **kwargs: Any) -> str:
+        """Gets the redirection URL for the required help page.
+
+        Args:
+            *args: Positional arguments are discarded.
+            **kwargs: Keyword arguments are discarded.
+
+        Returns:
+            The redirection URL.
+        """
+        del args
+        del kwargs
+
+        device: DeviceModel = self.get_object()
+        if not device.domain_credential_onboarding:
+            if device.pki_protocol == device.PkiProtocol.CMP_SHARED_SECRET.value:
+                return f'{reverse("devices:help_no-onboarding_cmp-shared-secret", kwargs={"pk": device.id})}'
+
+        if device.onboarding_protocol == device.OnboardingProtocol.CMP_SHARED_SECRET.value:
+            return f'{reverse("devices:help-onboarding_cmp-shared-secret", kwargs={"pk": device.id})}'
+
+        if device.onboarding_protocol == device.OnboardingProtocol.CMP_IDEVID.value:
+            return f'{reverse("devices:help-onboarding_cmp-idevid", kwargs={"pk": device.id})}'
+
+        return f'{reverse("devices:devices")}'
+
+
+class HelpDomainCredentialCmpContextView(DeviceContextMixin, DetailView[DeviceModel]):
+    """Base view for CMP help views concerning the domain credential, not intended to be used directly."""
 
     http_method_names = ('get',)
 
     model = DeviceModel
-    success_url = reverse_lazy('devices:devices')
-    template_name = 'devices/configure.html'
     context_object_name = 'device'
 
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        """Adds information about the required OpenSSL commands to the context.
 
-class DeviceBaseCredentialDownloadView(DeviceContextMixin, Detail404RedirectView, FormView[CredentialDownloadForm]):
+        Args:
+            **kwargs: Keyword arguments passed to super().get_context_data.
+
+        Returns:
+            The context to render the page.
+        """
+        context = super().get_context_data(**kwargs)
+        device: DeviceModel = self.object
+        context['host'] = (
+            self.request.META.get('REMOTE_ADDR', '127.0.0.1') + ':' + self.request.META.get('SERVER_PORT', '443')
+        )
+        context.update(self._get_domain_credential_cmp_context(device=device))
+        return context
+
+    @staticmethod
+    def _get_domain_credential_cmp_context(device: DeviceModel) -> dict[str, Any]:
+        """Provides the context for cmp commands using client based authentication.
+
+        Args:
+            device: The corresponding device model.
+
+        Returns:
+            The required context.
+        """
+        context = {}
+        if device.public_key_info.public_key_algorithm_oid == oid.PublicKeyAlgorithmOid.RSA:
+            domain_credential_key_gen_command = (
+                f'openssl genrsa -out domain_credential_key.pem {device.public_key_info.key_size}'
+            )
+            key_gen_command = f'openssl genrsa -out key.pem {device.public_key_info.key_size}'
+        elif device.public_key_info.public_key_algorithm_oid == oid.PublicKeyAlgorithmOid.ECC:
+            domain_credential_key_gen_command = (
+                f'openssl ecparam -name {device.public_key_info.named_curve.ossl_curve_name} '
+                f'-genkey -noout -out domain_credential_key.pem'
+            )
+            key_gen_command = (
+                f'openssl ecparam -name {device.public_key_info.named_curve.ossl_curve_name} '
+                f'-genkey -noout -out key.pem'
+            )
+        else:
+            raise ValueError('Unsupported public key algorithm')
+
+        context['domain_credential_key_gen_command'] = domain_credential_key_gen_command
+        context['key_gen_command'] = key_gen_command
+        context['issuing_ca_pem'] = (
+            device.domain.issuing_ca.credential.get_certificate()
+            .public_bytes(encoding=serialization.Encoding.PEM)
+            .decode()
+        )
+        number_of_issued_device_certificates = len(IssuedCredentialModel.objects.filter(device=device))
+        context['tls_client_cn'] = f'Trustpoint-TLS-Client-Credential-{number_of_issued_device_certificates}'
+        context['tls_server_cn'] = f'Trustpoint-TLS-Server-Credential-{number_of_issued_device_certificates}'
+
+        return context
+
+
+class NoOnboardingCmpSharedSecretHelpView(DeviceContextMixin, DetailView[DeviceModel]):
+    """Help view for the case of no onboarding using CMP shared-secret."""
+
+    http_method_names = ('get',)
+
+    model = DeviceModel
+    template_name = 'devices/help/no_onboarding/cmp_shared_secret.html'
+    context_object_name = 'device'
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        """Adds information about the required OpenSSL commands to the context.
+
+        Args:
+            **kwargs: Keyword arguments passed to super().get_context_data.
+
+        Returns:
+            The context to render the page.
+        """
+
+        context = super().get_context_data(**kwargs)
+        device: DeviceModel = self.object
+
+        if device.public_key_info.public_key_algorithm_oid == oid.PublicKeyAlgorithmOid.RSA:
+            key_gen_command = f'openssl genrsa -out key.pem {device.public_key_info.key_size}'
+        elif device.public_key_info.public_key_algorithm_oid == oid.PublicKeyAlgorithmOid.ECC:
+            key_gen_command = (
+                f'openssl ecparam -name {device.public_key_info.named_curve.ossl_curve_name} '
+                f'-genkey -noout -out key.pem'
+            )
+        else:
+            raise ValueError('Unsupported public key algorithm')
+        context['host'] = (
+            self.request.META.get('REMOTE_ADDR', '127.0.0.1') + ':' + self.request.META.get('SERVER_PORT'),
+            '443',
+        )
+        context['key_gen_command'] = key_gen_command
+        number_of_issued_device_certificates = len(IssuedCredentialModel.objects.filter(device=device))
+        context['tls_client_cn'] = f'Trustpoint-TLS-Client-Credential-{number_of_issued_device_certificates}'
+        context['tls_server_cn'] = f'Trustpoint-TLS-Server-Credential-{number_of_issued_device_certificates}'
+        return context
+
+
+class OnboardingCmpSharedSecretHelpView(HelpDomainCredentialCmpContextView):
+    """Help view for the onboarding cmp-shared secret case."""
+
+    template_name = 'devices/help/onboarding/cmp_shared_secret.html'
+
+
+class OnboardingCmpIdevidHelpView(HelpDomainCredentialCmpContextView):
+    """Help view for the onboarding IDeviD case."""
+
+    template_name = 'devices/help/onboarding/cmp_idevid.html'
+
+
+class OnboardingIdevidRegistrationHelpView(DeviceContextMixin, DetailView[DevIdRegistration]):
+    """Help view for the IDevID Registration, which displays the required OpenSSL commands."""
+
+    http_method_names = ('get',)
+
+    model = DevIdRegistration
+    template_name = 'devices/help/onboarding/cmp_idevid_registration.html'
+    context_object_name = 'devid_registration'
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        """Adds information about the required OpenSSL commands to the context.
+
+        Args:
+            **kwargs: Keyword arguments passed to super().get_context_data.
+
+        Returns:
+            The context to render the page.
+        """
+
+        context = super().get_context_data(**kwargs)
+        devid_registration: DevIdRegistration = self.object
+
+        if devid_registration.domain.public_key_info.public_key_algorithm_oid == oid.PublicKeyAlgorithmOid.RSA:
+            domain_credential_key_gen_command = (
+                f'openssl genrsa -out domain_credential_key.pem {devid_registration.domain.public_key_info.key_size}'
+            )
+            key_gen_command = f'openssl genrsa -out key.pem {devid_registration.domain.public_key_info.key_size}'
+        elif devid_registration.domain.public_key_info.public_key_algorithm_oid == oid.PublicKeyAlgorithmOid.ECC:
+            domain_credential_key_gen_command = (
+                f'openssl ecparam -name {devid_registration.domain.public_key_info.named_curve.ossl_curve_name} '
+                f'-genkey -noout -out domain_credential_key.pem'
+            )
+            key_gen_command = (
+                f'openssl ecparam -name {devid_registration.domain.public_key_info.named_curve.ossl_curve_name} '
+                f'-genkey -noout -out key.pem'
+            )
+        else:
+            err_msg = 'Unsupported public key algorithm'
+            raise ValueError(err_msg)
+        context['host'] = (
+            self.request.META.get('REMOTE_ADDR', '127.0.0.1') + ':' + self.request.META.get('SERVER_PORT', '443')
+        )
+        context['domain_credential_key_gen_command'] = domain_credential_key_gen_command
+        context['key_gen_command'] = key_gen_command
+        context['issuing_ca_pem'] = (
+            devid_registration.domain.issuing_ca.credential.get_certificate()
+            .public_bytes(encoding=serialization.Encoding.PEM)
+            .decode()
+        )
+        number_of_issued_device_certificates = 0
+        context['tls_client_cn'] = f'Trustpoint-TLS-Client-Credential-{number_of_issued_device_certificates}'
+        context['tls_server_cn'] = f'Trustpoint-TLS-Server-Credential-{number_of_issued_device_certificates}'
+        context['public_key_info'] = devid_registration.domain.public_key_info
+        context['domain'] = devid_registration.domain
+        return context
+
+
+#  ----------------------------------- Certificate Lifecycle Management - Downloads ------------------------------------
+
+
+class DownloadPageDispatcherView(DeviceContextMixin, SingleObjectMixin[IssuedCredentialModel], RedirectView):
+    """Redirects depending on the type of credential, that is if a private key is available or not."""
+
+    http_method_names = ('get',)
+
+    model: type[IssuedCredentialModel] = IssuedCredentialModel
+    permanent = False
+
+    def get_redirect_url(self, *args: Any, **kwargs: Any) -> str:
+        """Gets the redirection URL depending on the type credential, that is if a private key is available or not.
+
+        Args:
+            *args: Positional arguments are discarded.
+            **kwargs: Keyword arguments are discarded.
+
+        Returns:
+            The redirect URL.
+        """
+        del args
+        del kwargs
+
+        issued_credential: IssuedCredentialModel = self.get_object()
+        if issued_credential.credential.private_key:
+            return f'{reverse("devices:credential-download", kwargs={"pk": issued_credential.id})}'
+        return f'{reverse("devices:certificate-download", kwargs={"pk": issued_credential.id})}'
+
+
+class CertificateDownloadView(DeviceContextMixin, DetailView[IssuedCredentialModel]):
+    """View for downloading certificates."""
+
+    http_method_names = ('get',)
+
+    model: type[IssuedCredentialModel] = IssuedCredentialModel
+    template_name = 'devices/credentials/certificate_download.html'
+    context_object_name = 'issued_credential'
+
+
+class DeviceBaseCredentialDownloadView(
+    DeviceContextMixin, DetailView[IssuedCredentialModel], FormView[CredentialDownloadForm]
+):
     """View to download a password protected application credential in the desired format.
 
-    Inherited by the domain and application credential download views.
+    Inherited by the domain and application credential download views. It is not intended for direct use.
     """
 
     http_method_names = ('get', 'post')
@@ -350,7 +763,7 @@ class DeviceBaseCredentialDownloadView(DeviceContextMixin, Detail404RedirectView
     is_browser_download = False
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
-        """Gets the context data depending on the credential.
+        """Adds information about the credential to the context
 
         Args:
             **kwargs: Keyword arguments are passed to super().get_context_data(**kwargs).
@@ -359,7 +772,7 @@ class DeviceBaseCredentialDownloadView(DeviceContextMixin, Detail404RedirectView
             The context data for the view.
         """
         context = super().get_context_data(**kwargs)
-        issued_credential = self.get_object()
+        issued_credential = self.object
         credential = issued_credential.credential
 
         if credential.credential_type != CredentialModel.CredentialTypeChoice.ISSUED_CREDENTIAL:  # sanity check
@@ -389,20 +802,8 @@ class DeviceBaseCredentialDownloadView(DeviceContextMixin, Detail404RedirectView
         context['issued_credential'] = issued_credential
         return context
 
-    def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
-        """Processing of all POST requests, i.e. the expected form data.
-
-        Args:
-            request: The POST request to process.
-            *args: Any positional arguments are passed to super().get().
-            **kwargs: Any keyword arguments are passed to super().get().
-
-        Returns:
-            The HttpResponse to display the view.
-        """
-        self.object = self.get_object()
-        return FormView.post(self, request, *args, **kwargs)
-
+    # TODO(AlexHx8472): This needs to return a success url redirect and then download the file.
+    # TODO(AlexHx8472): The FileResponse must then be returned from a get or post method.
     def form_valid(self, form: CredentialDownloadForm) -> HttpResponse:
         """Processing the valid form data.
 
@@ -414,8 +815,7 @@ class DeviceBaseCredentialDownloadView(DeviceContextMixin, Detail404RedirectView
         Returns:
             If successful, this will start the file download. Otherwise, a Http404 will be raised and displayed.
         """
-        self.object = self.get_object()
-
+        issued_credential_model = self.get_object()
         password = form.cleaned_data['password'].encode()
 
         try:
@@ -424,10 +824,10 @@ class DeviceBaseCredentialDownloadView(DeviceContextMixin, Detail404RedirectView
             err_msg = _('Unknown file format.')
             raise Http404(err_msg) from ValueError
 
-        credential_model = self.get_object().credential
+        credential_model = issued_credential_model.credential
         credential_serializer = credential_model.get_credential_serializer()
         credential_purpose = IssuedCredentialModel.IssuedCredentialPurpose(
-            self.get_object().issued_credential_purpose
+            issued_credential_model.issued_credential_purpose
         ).label
         credential_type_name = credential_purpose.replace(' ', '-').lower().replace('-credential', '')
 
@@ -463,10 +863,101 @@ class DeviceBaseCredentialDownloadView(DeviceContextMixin, Detail404RedirectView
 
 
 class DeviceManualCredentialDownloadView(DeviceBaseCredentialDownloadView):
-    """View to download a password protected domain or application credential in the desired format.
+    """View to download a password protected domain or application credential in the desired format."""
 
-    This CBV does intentionally not require the authentication mixin.
-    """
+
+class DeviceBrowserOnboardingOTPView(DeviceContextMixin, DetailView[IssuedCredentialModel]):
+    """View to display the OTP for remote credential download (aka. browser onboarding)."""
+
+    http_method_names = ('get',)
+
+    model = IssuedCredentialModel
+    template_name = 'devices/credentials/onboarding/browser/otp_view.html'
+    redirection_view = 'devices:devices'
+    context_object_name = 'credential'
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        """Adds information about the credential and otp for the browser download process.
+
+        Args:
+            **kwargs: Keyword arguments passed to super().get_context_data.
+
+        Returns:
+            The context to render the page.
+        """
+
+        credential = self.get_object()
+        device = credential.device
+        context = super().get_context_data(**kwargs)
+
+        try:
+            cdm = RemoteDeviceCredentialDownloadModel.objects.get(issued_credential_model=credential, device=device)
+            cdm.delete()
+        except RemoteDeviceCredentialDownloadModel.DoesNotExist:
+            pass
+
+        cdm = RemoteDeviceCredentialDownloadModel(issued_credential_model=credential, device=device)
+        cdm.save()
+
+        context.update(
+            {
+                'device_name': device.unique_name,
+                'device_id': device.id,
+                'credential_id': credential.id,
+                'otp': cdm.get_otp_display(),
+                'download_url': self.request.build_absolute_uri(reverse('devices:browser_login')),
+            }
+        )
+        return context
+
+
+class DeviceOnboardingBrowserLoginView(FormView[BrowserLoginForm]):
+    """View to handle certificate download requests."""
+
+    http_method_names = ('get', 'post')
+
+    template_name = 'devices/credentials/onboarding/browser/login.html'
+    form_class = BrowserLoginForm
+
+    cleaned_data: dict[str, Any] | None = None
+
+    def get_success_url(self) -> str:
+        credential_id: int = self.cleaned_data.get('credential_id')
+        credential_download: RemoteDeviceCredentialDownloadModel = self.cleaned_data.get('credential_download')
+        token: str = credential_download.download_token
+        return (
+            f'{reverse_lazy("devices:browser_domain_credential_download", kwargs={"pk": credential_id})}'
+            f'?token={token}'
+        )
+
+    def form_invalid(self, form: BrowserLoginForm) -> HttpResponse:
+        messages.error(self.request, _('The provided password is not valid.'))
+        return super().form_invalid(form)
+
+    def form_valid(self, form: BrowserLoginForm) -> HttpResponse:
+        self.cleaned_data = form.cleaned_data
+        return super().form_valid(form)
+
+
+class DownloadTokenRequiredMixin(_DispatchableType):
+    """Mixin which checks the token included in the URL for browser download views."""
+
+    credential_download: RemoteDeviceCredentialDownloadModel
+
+    def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
+        """Checks the validity of the token included in the URL for browser download views."""
+        token = request.GET.get('token')
+        try:
+            self.credential_download = RemoteDeviceCredentialDownloadModel.objects.get(
+                issued_credential_model=kwargs.get('pk')
+            )
+        except RemoteDeviceCredentialDownloadModel.DoesNotExist:
+            messages.warning(request, 'Invalid download token.')
+            return redirect('devices:browser_login')
+        if not token or not self.credential_download.check_token(token):
+            messages.warning(request, 'Invalid download token.')
+            return redirect('devices:browser_login')
+        return super().dispatch(request, *args, **kwargs)
 
 
 class DeviceBrowserCredentialDownloadView(DownloadTokenRequiredMixin, DeviceBaseCredentialDownloadView):
@@ -474,278 +965,10 @@ class DeviceBrowserCredentialDownloadView(DownloadTokenRequiredMixin, DeviceBase
 
     This CBV does intentionally not require the authentication mixin.
     """
-
     is_browser_download = True
 
 
-class DeviceIssueCredentialView(
-    DeviceContextMixin, TpLoginRequiredMixin, DetailView[DeviceModel], FormView[F], Generic[F, I]
-):
-    """Base view to issue device credentials."""
-
-    http_method_names = ('get', 'post')
-    model = DeviceModel
-    context_object_name = 'device'
-    template_name = 'devices/credentials/issue_application_credential.html'
-    form_class: type[F]
-    issuer_class: type[I]
-    friendly_name = type[str]
-
-    def get_initial(self) -> dict[str, Any]:
-        """Gets the initial data for the form."""
-        initial = super().get_initial()
-        device = self.get_object()
-        if self.issuer_class:
-            initial.update(self.issuer_class.get_fixed_values(device=device, domain=device.domain))
-        return initial
-
-    def get_form_kwargs(self) -> dict[str, Any]:
-        """Pass device instance to the form."""
-        form_kwargs = super().get_form_kwargs()
-        form_kwargs.update({'device': self.get_object()})
-        return form_kwargs
-
-    def get_success_url(self) -> str:
-        """Redirect URL after successful form submission."""
-        return cast(str, reverse_lazy('devices:certificate_lifecycle_management', kwargs={'pk': self.get_object().id}))
-
-    def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
-        """Handles POST requests."""
-        self.object = self.get_object()
-        return super().post(request, *args, **kwargs)
-
-    def form_valid(self, form: F) -> HttpResponse:
-        """Issues the credential and shows success message."""
-        device = self.get_object()
-        credential = self.issue_credential(device=device, cleaned_data=form.cleaned_data)
-        messages.success(
-            self.request, f'Successfully issued {self.friendly_name} for device {credential.device.unique_name}'
-        )
-        return super().form_valid(form)
-
-    @abstractmethod
-    def issue_credential(self, device: DeviceModel, cleaned_data: dict[str, Any]) -> IssuedCredentialModel:
-        """To be implemented by subclasses."""
-
-
-class DeviceIssueTlsClientCredential(
-    DeviceIssueCredentialView[IssueTlsClientCredentialForm, LocalTlsClientCredentialIssuer]
-):
-    """View to issue a new TLS client credential."""
-
-    form_class = IssueTlsClientCredentialForm
-    issuer_class = LocalTlsClientCredentialIssuer
-    friendly_name = 'TLS client credential'
-
-    def issue_credential(self, device: DeviceModel, cleaned_data: dict[str, Any]) -> IssuedCredentialModel:
-        """Issues an TLS client credential.
-
-        Args:
-            device (DeviceModel): The device for which the credential is issued.
-            cleaned_data (dict[str, Any]): The validated form data.
-
-        Returns:
-            IssuedCredentialModel: The issued TLS client credential.
-        """
-        common_name = cast(str, cleaned_data.get('common_name'))
-        validity = cast(int, cleaned_data.get('validity'))
-        issuer = self.issuer_class(device=device, domain=device.domain)
-
-        return issuer.issue_tls_client_credential(common_name=common_name, validity_days=validity)
-
-
-class DeviceIssueTlsServerCredential(
-    DeviceIssueCredentialView[IssueTlsServerCredentialForm, LocalTlsServerCredentialIssuer]
-):
-    """View to issue a new TLS server credential."""
-
-    form_class = IssueTlsServerCredentialForm
-    issuer_class = LocalTlsServerCredentialIssuer
-    friendly_name = 'TLS server credential'
-
-    def issue_credential(self, device: DeviceModel, cleaned_data: dict[str, Any]) -> IssuedCredentialModel:
-        """Issues an TLS server credential.
-
-        Args:
-            device (DeviceModel): The device for which the credential is issued.
-            cleaned_data (dict[str, Any]): The validated form data.
-
-        Returns:
-            IssuedCredentialModel: The issued TLS server credential.
-        """
-        common_name = cast(str, cleaned_data.get('common_name'))
-        if not common_name:
-            raise Http404
-        issuer = self.issuer_class(device=device, domain=device.domain)
-        return issuer.issue_tls_server_credential(
-            common_name=common_name,
-            ipv4_addresses=cast('list[ipaddress.IPv4Address]', cleaned_data.get('ipv4_addresses')),
-            ipv6_addresses=cast('list[ipaddress.IPv6Address]', cleaned_data.get('ipv6_addresses')),
-            domain_names=cast(list[str], cleaned_data.get('domain_names')),
-            san_critical=False,
-            validity_days=cast(int, cleaned_data.get('validity')),
-        )
-
-
-class DeviceIssueOpcUaClientCredential(
-    DeviceIssueCredentialView[IssueOpcUaClientCredentialForm, OpcUaClientCredentialIssuer]
-):
-    """View to issue a new OPC UA client credential."""
-
-    form_class = IssueOpcUaClientCredentialForm
-    issuer_class = OpcUaClientCredentialIssuer
-    friendly_name = 'OPC UA client credential'
-
-    def issue_credential(self, device: DeviceModel, cleaned_data: dict[str, Any]) -> IssuedCredentialModel:
-        """Issues an OPC UA client credential.
-
-        Args:
-            device (DeviceModel): The device for which the credential is issued.
-            cleaned_data (dict[str, Any]): The validated form data.
-
-        Returns:
-            IssuedCredentialModel: The issued OPC UA client credential.
-        """
-        issuer = self.issuer_class(device=device, domain=device.domain)
-        return issuer.issue_opcua_client_credential(
-            common_name=cast(str, cleaned_data.get('common_name')),
-            application_uri=cast(str, cleaned_data.get('application_uri')),
-            validity_days=cast(int, cleaned_data.get('validity')),
-        )
-
-
-class DeviceIssueOpcUaServerCredential(
-    DeviceIssueCredentialView[IssueOpcUaServerCredentialForm, OpcUaServerCredentialIssuer]
-):
-    """View to issue a new OPC UA server credential."""
-
-    form_class = IssueOpcUaServerCredentialForm
-    issuer_class = OpcUaServerCredentialIssuer
-    friendly_name = 'OPC UA server credential'
-
-    def issue_credential(self, device: DeviceModel, cleaned_data: dict[str, Any]) -> IssuedCredentialModel:
-        """Issues an OPC UA server credential.
-
-        Args:
-            device (DeviceModel): The device for which the credential is issued.
-            cleaned_data (dict[str, Any]): The validated form data.
-
-        Returns:
-            IssuedCredentialModel: The issued OPC UA server credential.
-        """
-        common_name = cast(str, cleaned_data.get('common_name'))
-        if not common_name:
-            raise Http404
-        issuer = self.issuer_class(device=device, domain=device.domain)
-
-        ipv4_addresses: list[ipaddress.IPv4Address] = cleaned_data.get('ipv4_addresses', [])
-        ipv6_addresses: list[ipaddress.IPv6Address] = cleaned_data.get('ipv6_addresses', [])
-        domain_names: list[str] = cleaned_data.get('domain_names', [])
-        validity_days: int = cleaned_data.get('validity', 0)
-
-        return issuer.issue_opcua_server_credential(
-            common_name=common_name,
-            application_uri=cast(str, cleaned_data.get('application_uri')),
-            ipv4_addresses=ipv4_addresses,
-            ipv6_addresses=ipv6_addresses,
-            domain_names=domain_names,
-            validity_days=validity_days
-        )
-
-
-class DeviceCertificateLifecycleManagementSummaryView(
-    DeviceContextMixin, TpLoginRequiredMixin, SortableTableMixin, ListInDetailView
-):
-    """This is the CLM summary view in the devices section."""
-
-    http_method_names = ('get',)
-
-    detail_model = DeviceModel
-    template_name = 'devices/credentials/certificate_lifecycle_management.html'
-    detail_context_object_name = 'device'
-    model = IssuedCredentialModel
-    context_object_name = 'issued_credentials'
-    default_sort_param = 'common_name'
-
-    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
-        context = super().get_context_data(**kwargs)
-
-        device = self.get_object()
-        qs = super().get_queryset()  # inherited from SortableTableMixin, sorted query
-
-        domain_credentials = qs.filter(
-            Q(device=device)
-            & Q(issued_credential_type=IssuedCredentialModel.IssuedCredentialType.DOMAIN_CREDENTIAL.value)
-        )
-
-        application_credentials = qs.filter(
-            Q(device=device)
-            & Q(issued_credential_type=IssuedCredentialModel.IssuedCredentialType.APPLICATION_CREDENTIAL.value)
-        )
-
-        context['domain_credentials'] = domain_credentials
-        context['application_credentials'] = application_credentials
-
-        paginator_domain = Paginator(domain_credentials, UIConfig.paginate_by)
-        page_number_domain = self.request.GET.get('page', 1)
-        context['domain_credentials'] = paginator_domain.get_page(page_number_domain)
-        context['is_paginated'] = paginator_domain.num_pages > 1
-
-        paginator_application = Paginator(application_credentials, UIConfig.paginate_by)
-        page_number_application = self.request.GET.get('page-a', 1)
-        context['application_credentials'] = paginator_application.get_page(page_number_application)
-        context['is_paginated_a'] = paginator_application.num_pages > 1
-
-        for cred in context['domain_credentials']:
-            cred.expires_in = self._render_expires_in(cred)
-            cred.expiration_date = self._render_expiration_date(cred)
-            cred.revoke = self._render_revoke(cred)
-
-        for cred in context['application_credentials']:
-            cred.expires_in = self._render_expires_in(cred)
-            cred.expiration_date = self._render_expiration_date(cred)
-            cred.revoke = self._render_revoke(cred)
-
-        return context
-
-    @staticmethod
-    def _render_expiration_date(record: IssuedCredentialModel) -> datetime.datetime:
-        return cast(datetime.datetime, record.credential.certificate.not_valid_after)
-
-    @staticmethod
-    def _render_expires_in(record: IssuedCredentialModel) -> str | SafeString:
-        if record.credential.certificate.certificate_status != CertificateModel.CertificateStatus.OK:
-            return str(record.credential.certificate.certificate_status.label)
-        now = datetime.datetime.now(datetime.UTC)
-        expire_timedelta = record.credential.certificate.not_valid_after - now
-        days = expire_timedelta.days
-        hours, remainder = divmod(expire_timedelta.seconds, 3600)
-        minutes, seconds = divmod(remainder, 60)
-        return format_html(f'{days} days, {hours}:{minutes:02d}:{seconds:02d}')
-
-    @staticmethod
-    def _render_revoke(record: IssuedCredentialModel) -> SafeString:
-        """Creates the html hyperlink for the revoke-view.
-
-        Args:
-            record: The current record of the Device model.
-
-        Returns:
-            SafeString: The html hyperlink for the revoke-view.
-        """
-        if record.credential.certificate.certificate_status == CertificateModel.CertificateStatus.REVOKED:
-            return format_html('<a class="btn btn-danger tp-table-btn w-100 disabled">{}</a>', _('Revoked'))
-
-        return format_html(
-            '<a href="revoke/{}/" class="btn btn-danger tp-table-btn w-100">{}</a>', record.pk, _('Revoke')
-        )
-
-
-class DeviceRevocationView(
-    DeviceContextMixin,
-    TpLoginRequiredMixin,
-    FormMixin[CredentialRevocationForm],
-    ListView[DeviceModel]):
+class DeviceRevocationView(DeviceContextMixin, FormMixin[CredentialRevocationForm], ListView[DeviceModel]):
     """Revokes all active credentials for a given device."""
 
     http_method_names = ('get', 'post')
@@ -757,18 +980,8 @@ class DeviceRevocationView(
     success_url = reverse_lazy('devices:devices')
     device: DeviceModel
 
-    # TODO(AlexHx8472, Air): Fix get_queryset / view.
-
-    def post(self, *args: Any, **kwargs: Any) -> HttpResponse:
-        form = self.get_form()
-        if form.is_valid():
-            return self.form_valid(form)
-
-        return self.form_invalid(form)
-
     def form_valid(self, form: CredentialRevocationForm) -> HttpResponse:
         """Handles revocation upon a POST request containing a valid form."""
-        # Revoke all active credentials for the device
         n_revoked = 0
         credentials = self.get_queryset()
         for credential in credentials:
@@ -794,9 +1007,9 @@ class DeviceRevocationView(
 
 class DeviceCredentialRevocationView(
     DeviceContextMixin,
-    TpLoginRequiredMixin,
-    Detail404RedirectView,
-    FormView[CredentialRevocationForm]):
+    DetailView[IssuedCredentialModel],
+    FormView[CredentialRevocationForm],
+):
     """Revokes a specific issued credential."""
 
     http_method_names = ('get', 'post')
@@ -831,50 +1044,22 @@ class DeviceCredentialRevocationView(
         return super().form_valid(form)
 
 
-class DeviceBrowserOnboardingOTPView(DeviceContextMixin, TpLoginRequiredMixin, Detail404RedirectView, RedirectView):
-    """View to display the OTP for remote credential download (aka. browser onboarding)."""
-
-    model = IssuedCredentialModel
-    template_name = 'devices/credentials/onboarding/browser/otp_view.html'
-    redirection_view = 'devices:devices'
-    context_object_name = 'credential'
-
-    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:  # noqa: ARG002
-        """Renders a template view for displaying the OTP."""
-        credential = self.get_object()
-        device = credential.device
-        try:  # remove a potential previous download model for this credential
-            cdm = RemoteDeviceCredentialDownloadModel.objects.get(issued_credential_model=credential, device=device)
-            cdm.delete()
-        except RemoteDeviceCredentialDownloadModel.DoesNotExist:
-            pass
-        cdm = RemoteDeviceCredentialDownloadModel(issued_credential_model=credential, device=device)
-        cdm.save()
-
-        context = {
-            'device_name': device.unique_name,
-            'device_id': device.id,
-            'credential_id': credential.id,
-            'otp': cdm.get_otp_display(),
-            'download_url': request.build_absolute_uri(reverse('devices:browser_login')),
-        }
-
-        return render(request, self.template_name, context)
 
 
-class DeviceBrowserOnboardingCancelView(DeviceContextMixin, TpLoginRequiredMixin, Detail404RedirectView, RedirectView):
+
+class DeviceBrowserOnboardingCancelView(DeviceContextMixin, DetailView[IssuedCredentialModel], RedirectView):
     """View to cancel the browser onboarding process and delete the associated RemoteDeviceCredentialDownloadModel."""
 
     model = IssuedCredentialModel
     redirection_view = 'devices:credential-download'
     context_object_name = 'credential'
 
-    def get_redirect_url(self, *args: Any, **kwargs: Any) -> str:  # noqa: ARG002
+    def get_redirect_url(self, *args: Any, **kwargs: Any) -> str:
         """Returns the URL to redirect to after the browser onboarding process was canceled."""
         pk = self.kwargs.get('pk')
         return reverse(self.redirection_view, kwargs={'pk': pk})
 
-    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:  # noqa: ARG002
+    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         """Cancels the browser onboarding process and deletes the associated RemoteDeviceCredentialDownloadModel."""
         credential = self.get_object()
         device = credential.device
@@ -888,123 +1073,10 @@ class DeviceBrowserOnboardingCancelView(DeviceContextMixin, TpLoginRequiredMixin
         return redirect(self.get_redirect_url())
 
 
-class DeviceOnboardingBrowserLoginView(FormView[BrowserLoginForm]):
-    """View to handle certificate download requests."""
-
-    template_name = 'devices/credentials/onboarding/browser/login.html'
-    form_class = BrowserLoginForm
-
-    def fail_redirect(self) -> HttpResponse:
-        """On login failure, redirect back to the login page with an error message."""
-        messages.error(self.request, _('The provided password is not valid.'))
-        return redirect(self.request.path)
-
-    def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:  # noqa: ARG002
-        """Handles POST request for browser login form submission."""
-        form = BrowserLoginForm(request.POST)
-        if not form.is_valid():
-            return self.fail_redirect()
-
-        cred_id = form.cleaned_data['cred_id']
-        otp = form.cleaned_data['otp']
-        try:
-
-            credential_download = RemoteDeviceCredentialDownloadModel.objects.get(issued_credential_model=cred_id)
-        except RemoteDeviceCredentialDownloadModel.DoesNotExist:
-            return self.fail_redirect()
-
-        if not credential_download.check_otp(otp):
-            return self.fail_redirect()
-
-        token = credential_download.download_token
-        url = f'{reverse("devices:browser_domain_credential_download", kwargs={"pk": cred_id})}?token={token}'
-        return redirect(url)
 
 
-class HelpDispatchView(DeviceContextMixin, TpLoginRequiredMixin, SingleObjectMixin[DeviceModel], RedirectView):
-    model: type[DeviceModel] = DeviceModel
-    permanent = False
-
-    def get_redirect_url(self, *args: Any, **kwargs: Any) -> str:
-        device: DeviceModel = self.get_object()
-        if not device.domain_credential_onboarding:
-            if device.pki_protocol == device.PkiProtocol.CMP_SHARED_SECRET.value:
-                return f'{reverse("devices:help_no-onboarding_cmp-shared-secret", kwargs={"pk": device.id})}'
-
-        if device.onboarding_protocol == device.OnboardingProtocol.CMP_SHARED_SECRET.value:
-            return f'{reverse("devices:help-onboarding_cmp-shared-secret", kwargs={"pk": device.id})}'
-
-        if device.onboarding_protocol == device.OnboardingProtocol.CMP_IDEVID.value:
-            return f'{reverse("devices:help-onboarding_cmp-idevid", kwargs={"pk": device.id})}'
-
-        return f'{reverse("devices:devices")}'
 
 
-class DownloadPageDispatcherView(
-    DeviceContextMixin,
-    TpLoginRequiredMixin,
-    SingleObjectMixin[IssuedCredentialModel],
-    RedirectView):
-    model: type[IssuedCredentialModel] = IssuedCredentialModel
-    permanent = False
-
-    def get_redirect_url(self, *args: Any, **kwargs: Any) -> str:
-        issued_credential: IssuedCredentialModel = self.get_object()
-        if issued_credential.credential.private_key:
-            return f'{reverse("devices:credential-download", kwargs={"pk": issued_credential.id})}'
-        return f'{reverse("devices:certificate-download", kwargs={"pk": issued_credential.id})}'
 
 
-class CertificateDownloadView(DeviceContextMixin, TpLoginRequiredMixin, DetailView[IssuedCredentialModel]):
-    http_method_names = ('get',)
 
-    model: type[IssuedCredentialModel] = IssuedCredentialModel
-    template_name = 'devices/credentials/certificate_download.html'
-    context_object_name = 'issued_credential'
-
-
-class OnboardingIdevidRegistrationHelpView(
-    DeviceContextMixin, TpLoginRequiredMixin, Detail404RedirectView
-):
-    model = DevIdRegistration
-    template_name = 'devices/help/onboarding/cmp_idevid_registration.html'
-    context_object_name = 'devid_registration'
-
-    def get_context_data(self, **_: Any) -> dict[str, Any]:
-        context = super().get_context_data()
-        devid_registration: DevIdRegistration = self.object
-
-        if devid_registration.domain.public_key_info.public_key_algorithm_oid == oid.PublicKeyAlgorithmOid.RSA:
-            domain_credential_key_gen_command = (
-                f'openssl genrsa -out domain_credential_key.pem {devid_registration.domain.public_key_info.key_size}'
-            )
-            key_gen_command = f'openssl genrsa -out key.pem {devid_registration.domain.public_key_info.key_size}'
-        elif devid_registration.domain.public_key_info.public_key_algorithm_oid == oid.PublicKeyAlgorithmOid.ECC:
-            domain_credential_key_gen_command = (
-                f'openssl ecparam -name {devid_registration.domain.public_key_info.named_curve.ossl_curve_name} '
-                f'-genkey -noout -out domain_credential_key.pem'
-            )
-            key_gen_command = (
-                f'openssl ecparam -name {devid_registration.domain.public_key_info.named_curve.ossl_curve_name} '
-                f'-genkey -noout -out key.pem'
-            )
-        else:
-            err_msg = 'Unsupported public key algorithm'
-            raise ValueError(err_msg)
-        context['host'] = (
-                self.request.META.get('REMOTE_ADDR', '127.0.0.1')
-                + ':'
-                + self.request.META.get('SERVER_PORT', '443'))
-        context['domain_credential_key_gen_command'] = domain_credential_key_gen_command
-        context['key_gen_command'] = key_gen_command
-        context['issuing_ca_pem'] = (
-            devid_registration.domain.issuing_ca.credential.get_certificate()
-            .public_bytes(encoding=serialization.Encoding.PEM)
-            .decode()
-        )
-        number_of_issued_device_certificates = 0
-        context['tls_client_cn'] = f'Trustpoint-TLS-Client-Credential-{number_of_issued_device_certificates}'
-        context['tls_server_cn'] = f'Trustpoint-TLS-Server-Credential-{number_of_issued_device_certificates}'
-        context['public_key_info'] = devid_registration.domain.public_key_info
-        context['domain'] = devid_registration.domain
-        return context

--- a/trustpoint/devices/widgets.py
+++ b/trustpoint/devices/widgets.py
@@ -1,13 +1,46 @@
+"""This module contains widgets used in the devices app."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
 from django import forms
 
+
 class DisableSelectOptionsWidget(forms.Select):
+    """Allows to disable options within a select input."""
 
-    def __init__(self, disabled_values=None, *args, **kwargs) -> None:
+    disabled_values: list[str]
+
+    def __init__(self, disabled_values: list[str] | None = None, *args: Any, **kwargs: Any) -> None:
+        """Initializes the DisableSelectOptionsWidget.
+
+        Args:
+            disabled_values: The values to disable.
+            *args: Positional arguments passed to forms.Select.
+            **kwargs: Keyword arguments passed to forms.Select.
+        """
         super().__init__(*args, **kwargs)
-        self.disabled_values = disabled_values
+        if disabled_values is None:
+            self.disabled_values = []
+        else:
+            self.disabled_values = disabled_values
 
-    def create_option(self, name, value, label, selected, index, subindex=None, attrs=None) -> dict:
-        option_dict = super().create_option(name, value, label, selected, index, subindex, attrs)
+    def create_option(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        """Creates the options in the select and disables the desired ones.
+
+        Args:
+            *args: Positional arguments passed to forms.Select.create_option.
+            **kwargs: Positional arguments passed to forms.Select.create_option.
+
+        Returns:
+            The option dictionary.
+        """
+        value = kwargs.get('value')
+        option_dict = super().create_option(*args, **kwargs)
         if value in self.disabled_values:
             option_dict['attrs'].setdefault('disabled', 'disabled')
 

--- a/trustpoint/devices/widgets.py
+++ b/trustpoint/devices/widgets.py
@@ -29,18 +29,19 @@ class DisableSelectOptionsWidget(forms.Select):
         else:
             self.disabled_values = disabled_values
 
-    def create_option(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    def create_option(self, name: str, value: Any, *args: Any, **kwargs: Any) -> dict[str, Any]:
         """Creates the options in the select and disables the desired ones.
 
         Args:
+            name: The name of the option.
+            value: The value of the option.
             *args: Positional arguments passed to forms.Select.create_option.
             **kwargs: Positional arguments passed to forms.Select.create_option.
 
         Returns:
             The option dictionary.
         """
-        value = kwargs.get('value')
-        option_dict = super().create_option(*args, **kwargs)
+        option_dict = super().create_option(name, value, *args, **kwargs)
         if value in self.disabled_values:
             option_dict['attrs'].setdefault('disabled', 'disabled')
 

--- a/trustpoint/features/environment.py
+++ b/trustpoint/features/environment.py
@@ -10,6 +10,7 @@ from behave import given, runner, step, then, when
 # Function to wrap steps and enforce failure on any exception
 def fail_on_exception(func: Callable) -> Callable:
     """Wrapper that ensures uncaught exceptions fail the scenario and are logged to the HTML report."""
+
     @functools.wraps(func)
     def wrapper(context: runner.Context, *args: tuple, **kwargs: dict) -> Callable:
         try:
@@ -20,7 +21,9 @@ def fail_on_exception(func: Callable) -> Callable:
             traceback.print_exc()  # Print full traceback for debugging
             exc_msg = f'Step failed due to exception: {e}'
             raise AssertionError(exc_msg) from e
+
     return wrapper
+
 
 # Monkey-patch Behave's step decorators to automatically wrap all steps
 original_step = step
@@ -28,29 +31,42 @@ original_given = given
 original_when = when
 original_then = then
 
+
 def patched_step(*args: tuple, **kwargs: dict) -> Callable:
     """Monkey-patched step decorator that wraps the step function to fail on any exception."""
+
     def decorator(func: Callable) -> Callable:
         return original_step(*args, **kwargs)(fail_on_exception(func))
+
     return decorator
+
 
 def patched_given(*args: tuple, **kwargs: dict) -> Callable:
     """Monkey-patched given decorator that wraps the step function to fail on any exception."""
+
     def decorator(func: Callable) -> Callable:
         return original_given(*args, **kwargs)(fail_on_exception(func))
+
     return decorator
+
 
 def patched_when(*args: tuple, **kwargs: dict) -> Callable:
     """Monkey-patched when decorator that wraps the step function to fail on any exception."""
+
     def decorator(func: Callable) -> Callable:
         return original_when(*args, **kwargs)(fail_on_exception(func))
+
     return decorator
+
 
 def patched_then(*args: tuple, **kwargs: dict) -> Callable:
     """Monkey-patched then decorator that wraps the step function to fail on any exception."""
+
     def decorator(func: Callable) -> Callable:
         return original_then(*args, **kwargs)(fail_on_exception(func))
+
     return decorator
+
 
 # Override Behave's step registration functions
 step = patched_step

--- a/trustpoint/features/steps/r_006_steps.py
+++ b/trustpoint/features/steps/r_006_steps.py
@@ -1,4 +1,4 @@
-"""Python steps file for R_006.""" # noqa: INP001
+"""Python steps file for R_006."""  # noqa: INP001
 
 from behave import runner, then, when
 

--- a/trustpoint/features/steps/r_013_steps.py
+++ b/trustpoint/features/steps/r_013_steps.py
@@ -122,9 +122,9 @@ def step_then_they_will_receive_page_to_select_the_format(context: runner.Contex
     Args:
         context (runner.Context): Behave context.
     """
-    assert 'value="PEM_ZIP"' in context.otp_post_view_response.decode(), \
+    assert 'value="PEM_ZIP"' in context.otp_post_view_response.decode(), (
         'Page does not contain "Download as ZIP (PEM)" button'
-
+    )
 
 
 @given('an incorrect one-time password')
@@ -144,8 +144,9 @@ def step_then_they_will_receive_a_warning(context: runner.Context) -> None:
     Args:
         context (runner.Context): Behave context.
     """
-    assert 'The provided password is not valid.' in context.otp_post_view_response.decode(), \
+    assert 'The provided password is not valid.' in context.otp_post_view_response.decode(), (
         'Page does not contain OTP error message'
+    )
 
 
 @given('the user is on the credential download page')
@@ -176,11 +177,13 @@ def step_given_the_download_is_not_yet_expired(context: runner.Context) -> None:
         context (runner.Context): Behave context.
     """
     assert context.download_token is not None, 'Download token not in context'
-    assert not RemoteDeviceCredentialDownloadModel.objects.get(id=context.download_id).check_token('dummy_token'), \
+    assert not RemoteDeviceCredentialDownloadModel.objects.get(id=context.download_id).check_token('dummy_token'), (
         'Dummy token should not be valid'
+    )
 
-    assert RemoteDeviceCredentialDownloadModel.objects.get(id=context.download_id).check_token(context.download_token),\
-        'Actual token from URL should be valid'
+    assert RemoteDeviceCredentialDownloadModel.objects.get(id=context.download_id).check_token(
+        context.download_token
+    ), 'Actual token from URL should be valid'
 
 
 @when('the user enters a password to encrypt the credential private key')
@@ -201,11 +204,7 @@ def step_when_user_selects_a_file(context: runner.Context) -> None:
         context (runner.Context): Behave context.
     """
     url = f'/devices/browser/credential-download/{context.download_id}/?token={context.download_token}'
-    post_data = {
-        'password': context.test_password,
-        'confirm_password': context.test_password,
-        'file_format': 'PEM_ZIP'
-    }
+    post_data = {'password': context.test_password, 'confirm_password': context.test_password, 'file_format': 'PEM_ZIP'}
     download_response = context.unauthenticated_user_client.post(url, post_data)
     assert download_response.status_code == HTTP_OK, 'Non-OK response code'
     context.download_response = download_response

--- a/trustpoint/features/steps/r_104_steps.py
+++ b/trustpoint/features/steps/r_104_steps.py
@@ -1,6 +1,5 @@
 """Python steps file for R_104."""  # noqa: INP001
 
-
 from behave import given, runner, then, when
 
 

--- a/trustpoint/home/admin.py
+++ b/trustpoint/home/admin.py
@@ -1,4 +1,5 @@
 """Registers models with the Django admin site to manage the application's data."""
+
 from django.contrib import admin
 
 # Register your models here.

--- a/trustpoint/home/apps.py
+++ b/trustpoint/home/apps.py
@@ -5,5 +5,6 @@ from django.apps import AppConfig
 
 class HomeConfig(AppConfig):
     """Configures the Home application, including its name and other settings for Django."""
+
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'home'

--- a/trustpoint/home/filters.py
+++ b/trustpoint/home/filters.py
@@ -3,9 +3,9 @@
 from datetime import timedelta
 from typing import ClassVar
 
-import django_filters  # type: ignore[import-untyped]
-from django.db.models import QuerySet  # type: ignore[import-untyped]
-from django.utils import timezone  # type: ignore[import-untyped]
+import django_filters
+from django.db.models import QuerySet
+from django.utils import timezone
 
 from home.models import NotificationModel
 

--- a/trustpoint/home/models.py
+++ b/trustpoint/home/models.py
@@ -240,13 +240,9 @@ class NotificationModel(models.Model):
             )
             return message_dict.get(self, default)
 
-    notification_type = models.CharField(
-        max_length=3, choices=NotificationTypes, default=NotificationTypes.INFO
-    )
+    notification_type = models.CharField(max_length=3, choices=NotificationTypes, default=NotificationTypes.INFO)
 
-    notification_source = models.CharField(
-        max_length=1, choices=NotificationSource, default=NotificationSource.SYSTEM
-    )
+    notification_source = models.CharField(max_length=1, choices=NotificationSource, default=NotificationSource.SYSTEM)
 
     message_type = models.CharField(
         max_length=32, choices=NotificationMessageType, default=NotificationMessageType.CUSTOM
@@ -255,28 +251,20 @@ class NotificationModel(models.Model):
     message_data = models.JSONField(blank=True, default=dict)
 
     domain = models.ForeignKey(
-        DomainModel,
-        on_delete=models.SET_NULL,
-        blank=True, null=True,
-        related_name='notifications')
+        DomainModel, on_delete=models.SET_NULL, blank=True, null=True, related_name='notifications'
+    )
 
     certificate = models.ForeignKey(
         CertificateModel, on_delete=models.SET_NULL, blank=True, null=True, related_name='notifications'
     )
 
     device = models.ForeignKey(
-        DeviceModel,
-        on_delete=models.SET_NULL,
-        blank=True,
-        null=True,
-        related_name='notifications')
+        DeviceModel, on_delete=models.SET_NULL, blank=True, null=True, related_name='notifications'
+    )
 
     issuing_ca = models.ForeignKey(
-        IssuingCaModel,
-        on_delete=models.SET_NULL,
-        blank=True,
-        null=True,
-        related_name='notifications')
+        IssuingCaModel, on_delete=models.SET_NULL, blank=True, null=True, related_name='notifications'
+    )
 
     event = models.CharField(max_length=255, blank=True, null=True)
 

--- a/trustpoint/home/views.py
+++ b/trustpoint/home/views.py
@@ -303,9 +303,7 @@ class DashboardChartsAndCountsView(TpLoginRequiredMixin, TemplateView):
         cert_counts_by_status = []
         try:
             cert_status_qr = (
-                CertificateModel.objects.annotate(
-                    issue_date=TruncDate('not_valid_before')
-                )
+                CertificateModel.objects.annotate(issue_date=TruncDate('not_valid_before'))
                 .values('issue_date', 'certificate_status')
                 .annotate(cert_count=Count('id'))
                 .order_by('issue_date', 'certificate_status')
@@ -467,7 +465,7 @@ class DashboardChartsAndCountsView(TpLoginRequiredMixin, TemplateView):
             # )
 
             # Use a union query to combine results
-            #cert_domain_qr = cert_app_counts.union(cert_domain_counts)
+            # cert_domain_qr = cert_app_counts.union(cert_domain_counts)
 
             #   # Convert the queryset to a list
             cert_counts_by_domain = list(cert_counts_domain_qr)
@@ -482,16 +480,12 @@ class DashboardChartsAndCountsView(TpLoginRequiredMixin, TemplateView):
         }
         try:
             cert_template_qr = (
-                IssuedCredentialModel.objects.filter(
-                    credential__certificates__created_at__gt=start_date
-                )
+                IssuedCredentialModel.objects.filter(credential__certificates__created_at__gt=start_date)
                 .values(cert_type=F('issued_credential_purpose'))
                 .annotate(count=Count('credential__certificates'))
             )
             # Mapping from short code to human-readable name
-            template_mapping = {
-                key: str(value) for key, value in IssuedCredentialModel.IssuedCredentialPurpose.choices
-            }
+            template_mapping = {key: str(value) for key, value in IssuedCredentialModel.IssuedCredentialPurpose.choices}
             cert_counts_by_template = {template_mapping[item['cert_type']]: item['count'] for item in cert_template_qr}
         except Exception:
             self._logger.exception('Error occurred in certificate count by template query')

--- a/trustpoint/manage.py
+++ b/trustpoint/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/trustpoint/md-report.md
+++ b/trustpoint/md-report.md
@@ -1,0 +1,4 @@
+|                       filepath                       | passed | SUBTOTAL |
+| ---------------------------------------------------- | -----: | -------: |
+| trustpoint/devices/tests/test_credential_download.py |      4 |        4 |
+| TOTAL                                                |      4 |        4 |

--- a/trustpoint/md-report.md
+++ b/trustpoint/md-report.md
@@ -1,4 +1,0 @@
-|                       filepath                       | passed | SUBTOTAL |
-| ---------------------------------------------------- | -----: | -------: |
-| trustpoint/devices/tests/test_credential_download.py |      4 |        4 |
-| TOTAL                                                |      4 |        4 |

--- a/trustpoint/pki/admin.py
+++ b/trustpoint/pki/admin.py
@@ -12,38 +12,30 @@ class CertificateModelAdmin(admin.ModelAdmin):
         'sha256_fingerprint',
         'common_name',
         'certificate_status',
-
         'signature_algorithm_oid',
         'signature_algorithm',
         'signature_algorithm_padding_scheme',
         'signature_value',
-
         'version',
         'serial_number',
-
         'issuer_public_bytes',
         'issuer',
-
         'not_valid_before',
         'not_valid_after',
-
         'subject_public_bytes',
         'subject',
-
         'spki_algorithm_oid',
         'spki_algorithm',
         'spki_key_size',
         'spki_ec_curve_oid',
         'spki_ec_curve',
-
         'cert_pem',
         'public_key_pem',
         'is_self_signed',
-
         'key_usage_extension',
         'subject_alternative_name_extension',
         'issuer_alternative_name_extension',
-        'basic_constraints_extension'
+        'basic_constraints_extension',
     )
 
 

--- a/trustpoint/pki/apps.py
+++ b/trustpoint/pki/apps.py
@@ -8,5 +8,5 @@ class PkiConfig(AppConfig):
     def ready(self) -> None:
         from pki.signals.issuing_ca import (
             delete_related_credential_certificate_chain_order_records,
-            delete_related_credential_record
+            delete_related_credential_record,
         )

--- a/trustpoint/pki/auto_gen_pki.py
+++ b/trustpoint/pki/auto_gen_pki.py
@@ -47,8 +47,9 @@ class AutoGenPki:
 
             # Re-use any existing root CA for the auto-generated PKI and current key type
             try:
-                root_ca = IssuingCaModel.objects.get(unique_name=root_ca_name,
-                                                     issuing_ca_type=IssuingCaModel.IssuingCaTypeChoice.AUTOGEN_ROOT)
+                root_ca = IssuingCaModel.objects.get(
+                    unique_name=root_ca_name, issuing_ca_type=IssuingCaModel.IssuingCaTypeChoice.AUTOGEN_ROOT
+                )
                 root_cert = root_ca.credential.get_certificate()
                 root_1_key = root_ca.credential.get_private_key()
             except IssuingCaModel.DoesNotExist:
@@ -61,7 +62,7 @@ class AutoGenPki:
                     private_key=root_1_key,
                     chain=[],
                     unique_name=root_ca_name,
-                    ca_type=IssuingCaModel.IssuingCaTypeChoice.AUTOGEN_ROOT
+                    ca_type=IssuingCaModel.IssuingCaTypeChoice.AUTOGEN_ROOT,
                 )
 
             # Create new issuing CA
@@ -79,7 +80,7 @@ class AutoGenPki:
                 private_key=issuing_1_key,
                 chain=[root_cert],
                 unique_name=UNIQUE_NAME,
-                ca_type=IssuingCaModel.IssuingCaTypeChoice.AUTOGEN
+                ca_type=IssuingCaModel.IssuingCaTypeChoice.AUTOGEN,
             )
 
             # Link to domain
@@ -100,8 +101,7 @@ class AutoGenPki:
             issuing_ca = cls.get_auto_gen_pki()
             if not issuing_ca:
                 log.error(
-                    'Issuing CA for auto-generated PKI does not exist - '
-                    'auto-generated PKI possibly not fully disabled'
+                    'Issuing CA for auto-generated PKI does not exist - auto-generated PKI possibly not fully disabled'
                 )
                 return
 
@@ -127,12 +127,12 @@ class AutoGenPki:
             try:
                 root_ca = IssuingCaModel.objects.get(
                     credential__primarycredentialcertificate__certificate__subject_public_bytes=subject_public_bytes,
-                    issuing_ca_type=IssuingCaModel.IssuingCaTypeChoice.AUTOGEN_ROOT
+                    issuing_ca_type=IssuingCaModel.IssuingCaTypeChoice.AUTOGEN_ROOT,
                 )
                 root_ca.revoke_all_issued_certificates(reason=RevokedCertificateModel.ReasonCode.CESSATION)
             except IssuingCaModel.DoesNotExist:
                 exc_msg = 'Root CA for auto-generated PKI Issuing CA not found - cannot revoke the CA certificate'
-                log.error(exc_msg) # noqa: TRY400
+                log.error(exc_msg)  # noqa: TRY400
                 return
 
             # Hide the AutoGenPKI domain from the UI

--- a/trustpoint/pki/management/commands/add_domains_and_devices.py
+++ b/trustpoint/pki/management/commands/add_domains_and_devices.py
@@ -149,7 +149,7 @@ class Command(BaseCommand):
                         onboarding_protocol == DeviceModel.OnboardingProtocol.CMP_SHARED_SECRET.value
                         or pki_protocol == DeviceModel.PkiProtocol.CMP_SHARED_SECRET.value
                     )
-                    else None
+                    else ''
                 )
 
                 idevid_trust_store = (

--- a/trustpoint/pki/management/commands/add_domains_and_devices.py
+++ b/trustpoint/pki/management/commands/add_domains_and_devices.py
@@ -18,64 +18,63 @@ class Command(BaseCommand):
         call_command('import_idevid_truststores')
 
         data = {
-            "arburg": [
-                "ALLROUNDER-Injection-Molding-Machine",
-                "freeformer-3D-Printer",
-                "SELOGICA-Control-System",
-                "MULTILIFT-Robotic-Systems",
-                "ARBIDRIVE-Servo-Motor",
-                "ALS_Arburg-Leitrechner-System"
+            'arburg': [
+                'ALLROUNDER-Injection-Molding-Machine',
+                'freeformer-3D-Printer',
+                'SELOGICA-Control-System',
+                'MULTILIFT-Robotic-Systems',
+                'ARBIDRIVE-Servo-Motor',
+                'ALS_Arburg-Leitrechner-System',
             ],
-            "homag": [
-                "CENTATEQ-CNC-Processing-Center",
-                "EDGETEQ-Edge-Banding-Machine",
-                "powerTouch-Control",
-                "intelliGuide-Assist-System",
-                "DRILLTEQ-Drilling-and-Dowel-Insertion-Machine",
-                "STORETEQ-Storage-System"
+            'homag': [
+                'CENTATEQ-CNC-Processing-Center',
+                'EDGETEQ-Edge-Banding-Machine',
+                'powerTouch-Control',
+                'intelliGuide-Assist-System',
+                'DRILLTEQ-Drilling-and-Dowel-Insertion-Machine',
+                'STORETEQ-Storage-System',
             ],
-            "belden": [
-                "Hirschmann-Industrial-Ethernet-Switches",
-                "Lumberg-Automation-Connectors",
-                "GarrettCom-Magnum-Routers",
-                "TROMPETER-Coaxial-Connectors",
-                "Belden-I_O-Modules"
+            'belden': [
+                'Hirschmann-Industrial-Ethernet-Switches',
+                'Lumberg-Automation-Connectors',
+                'GarrettCom-Magnum-Routers',
+                'TROMPETER-Coaxial-Connectors',
+                'Belden-I_O-Modules',
             ],
-            "siemens": [
-                "SIMATIC-PLC",
-                "SINAMICS-Drive-Systems",
-                "SIRIUS-Control-Devices",
-                "SIMOTICS-Electric-Motors",
-                "SIMATIC-HMI-Panels",
-                "SITOP-Power-Supplies"
+            'siemens': [
+                'SIMATIC-PLC',
+                'SINAMICS-Drive-Systems',
+                'SIRIUS-Control-Devices',
+                'SIMOTICS-Electric-Motors',
+                'SIMATIC-HMI-Panels',
+                'SITOP-Power-Supplies',
             ],
-            "phoenix_contact": [
-                "CLIPLINE-Terminal-Blocks",
-                "QUINT-Power-Supplies",
-                "PLCnext-Control",
-                "TERMITRAB-Surge-Protection",
-                "CONTACTRON-Motor-Starters",
-                "ME-PLC_Modular-Controller"
+            'phoenix_contact': [
+                'CLIPLINE-Terminal-Blocks',
+                'QUINT-Power-Supplies',
+                'PLCnext-Control',
+                'TERMITRAB-Surge-Protection',
+                'CONTACTRON-Motor-Starters',
+                'ME-PLC_Modular-Controller',
             ],
-            "schmalz": [
-                "Vacuum-Generators",
-                "Vacuum-Grippers",
-                "Vacuum-Clamping-Systems",
-                "Suction-Pads",
-                "Vacuum-Layer-Grippers",
-                "Vacuum-Ejectors"
-            ]
+            'schmalz': [
+                'Vacuum-Generators',
+                'Vacuum-Grippers',
+                'Vacuum-Clamping-Systems',
+                'Suction-Pads',
+                'Vacuum-Layer-Grippers',
+                'Vacuum-Ejectors',
+            ],
         }
 
         domain_ca_truststore_map = {
-            "arburg": ("issuing-ca-a", "idevid-truststore-RSA-2048"),
-            "homag": ("issuing-ca-b", "idevid-truststore-RSA-3072"),
-            "belden": ("issuing-ca-c", "idevid-truststore-RSA-4096"),
-            "siemens": ("issuing-ca-d", "idevid-truststore-EC-256"),
-            "phoenix_contact": ("issuing-ca-e", "idevid-truststore-EC-283"),
-            "schmalz": ("issuing-ca-f", "idevid-truststore-EC-570"),
+            'arburg': ('issuing-ca-a', 'idevid-truststore-RSA-2048'),
+            'homag': ('issuing-ca-b', 'idevid-truststore-RSA-3072'),
+            'belden': ('issuing-ca-c', 'idevid-truststore-RSA-4096'),
+            'siemens': ('issuing-ca-d', 'idevid-truststore-EC-256'),
+            'phoenix_contact': ('issuing-ca-e', 'idevid-truststore-EC-283'),
+            'schmalz': ('issuing-ca-f', 'idevid-truststore-EC-570'),
         }
-
 
         onboarding_protocols = [
             DeviceModel.OnboardingProtocol.NO_ONBOARDING.value,
@@ -83,7 +82,7 @@ class Command(BaseCommand):
             DeviceModel.OnboardingProtocol.CMP_SHARED_SECRET.value,
         ]
 
-        print("Starting the process of adding domains and devices...\n")
+        print('Starting the process of adding domains and devices...\n')
 
         for domain_name, devices in data.items():
             issuing_ca_name, truststore_name = domain_ca_truststore_map[domain_name]
@@ -96,15 +95,15 @@ class Command(BaseCommand):
             domain.save()
 
             if created:
-                print(f"Created new domain: {domain_name}")
+                print(f'Created new domain: {domain_name}')
             else:
-                print(f"Domain already exists: {domain_name}")
+                print(f'Domain already exists: {domain_name}')
 
             devid_reg, devid_created = DevIdRegistration.objects.get_or_create(
-                unique_name=f"devid-reg-{domain_name}",
+                unique_name=f'devid-reg-{domain_name}',
                 domain=domain,
                 truststore=truststore,
-                serial_number_pattern="^.*$",
+                serial_number_pattern='^.*$',
             )
 
             if devid_created:
@@ -112,7 +111,7 @@ class Command(BaseCommand):
             else:
                 print(f"DevIdRegistration already exists for domain '{domain_name}'")
 
-            print(f"Domain({domain_name}, Issuing CA: {domain.issuing_ca})")
+            print(f'Domain({domain_name}, Issuing CA: {domain.issuing_ca})')
 
             for device_name in devices:
                 onboarding_protocol = random.choice(onboarding_protocols)
@@ -120,31 +119,42 @@ class Command(BaseCommand):
                 serial_number = ''.join(random.choices(string.ascii_uppercase + string.digits, k=12))
 
                 print(f"Creating device '{device_name}' in domain '{domain_name}' with:")
-                print(f"  - Serial Number: {serial_number}")
-                print(f"  - Onboarding Protocol: {onboarding_protocol}")
+                print(f'  - Serial Number: {serial_number}')
+                print(f'  - Onboarding Protocol: {onboarding_protocol}')
 
-                onboarding_status = DeviceModel.OnboardingStatus.NO_ONBOARDING \
-                    if onboarding_protocol == DeviceModel.OnboardingProtocol.NO_ONBOARDING \
+                onboarding_status = (
+                    DeviceModel.OnboardingStatus.NO_ONBOARDING
+                    if onboarding_protocol == DeviceModel.OnboardingProtocol.NO_ONBOARDING
                     else DeviceModel.OnboardingStatus.PENDING
+                )
 
-                domain_credential_onboarding = False \
-                    if onboarding_protocol == DeviceModel.OnboardingProtocol.NO_ONBOARDING \
-                    else True
+                domain_credential_onboarding = (
+                    False if onboarding_protocol == DeviceModel.OnboardingProtocol.NO_ONBOARDING else True
+                )
 
-                pki_protocol = DeviceModel.PkiProtocol.CMP_CLIENT_CERTIFICATE.value \
-                    if (onboarding_protocol == DeviceModel.OnboardingProtocol.CMP_IDEVID or
-                        onboarding_protocol == DeviceModel.OnboardingProtocol.CMP_SHARED_SECRET) \
-                    else random.choice([DeviceModel.PkiProtocol.MANUAL.value,
-                                        DeviceModel.PkiProtocol.CMP_SHARED_SECRET.value])
+                pki_protocol = (
+                    DeviceModel.PkiProtocol.CMP_CLIENT_CERTIFICATE.value
+                    if (
+                        onboarding_protocol == DeviceModel.OnboardingProtocol.CMP_IDEVID
+                        or onboarding_protocol == DeviceModel.OnboardingProtocol.CMP_SHARED_SECRET
+                    )
+                    else random.choice(
+                        [DeviceModel.PkiProtocol.MANUAL.value, DeviceModel.PkiProtocol.CMP_SHARED_SECRET.value]
+                    )
+                )
 
-                cmp_shared_secret = secrets.token_urlsafe(16) \
-                    if (onboarding_protocol == DeviceModel.OnboardingProtocol.CMP_SHARED_SECRET.value or
-                        pki_protocol == DeviceModel.PkiProtocol.CMP_SHARED_SECRET.value) \
+                cmp_shared_secret = (
+                    secrets.token_urlsafe(16)
+                    if (
+                        onboarding_protocol == DeviceModel.OnboardingProtocol.CMP_SHARED_SECRET.value
+                        or pki_protocol == DeviceModel.PkiProtocol.CMP_SHARED_SECRET.value
+                    )
                     else None
+                )
 
-                idevid_trust_store = truststore \
-                    if onboarding_protocol == DeviceModel.OnboardingProtocol.CMP_IDEVID.value \
-                    else None
+                idevid_trust_store = (
+                    truststore if onboarding_protocol == DeviceModel.OnboardingProtocol.CMP_IDEVID.value else None
+                )
 
                 dev = DeviceModel(
                     unique_name=device_name,
@@ -162,12 +172,12 @@ class Command(BaseCommand):
                     dev.save()
                     if dev.pk:
                         print(f"Creating device '{dev.unique_name}' (ID {dev.pk}) in domain '{dev.domain}' with:")
-                        print(f"  - Serial Number: {dev.serial_number}")
-                        print(f"  - Onboarding Protocol: {dev.onboarding_protocol}")
-                        print(f"  - PKI Protocol: {dev.pki_protocol}")
+                        print(f'  - Serial Number: {dev.serial_number}')
+                        print(f'  - Onboarding Protocol: {dev.onboarding_protocol}')
+                        print(f'  - PKI Protocol: {dev.pki_protocol}')
                     else:
                         print(f"Device '{device_name}' was not saved correctly.")
                 except Exception as e:
                     print(f"Failed to create device '{device_name}': {e}")
 
-        print("\nProcess completed. All domains and devices have been added.")
+        print('\nProcess completed. All domains and devices have been added.')

--- a/trustpoint/pki/management/commands/add_domains_and_devices_certs.py
+++ b/trustpoint/pki/management/commands/add_domains_and_devices_certs.py
@@ -15,7 +15,6 @@ class Command(BaseCommand):
     help = 'Add domains, associated device names with random onboarding protocol and serial \
     number, and their certificates. make sure you have certificates added in the CertificateModel'
 
-
     def handle(self, *args, **kwargs):
         call_command('create_multiple_test_issuing_cas')
 
@@ -27,57 +26,56 @@ class Command(BaseCommand):
         onboarding_protocols = [Device.OnboardingProtocol.TP_CLIENT.value, Device.OnboardingProtocol.MANUAL.value]
 
         data = {
-            "arburg": [
-                "ALLROUNDER-Injection-Molding-Machine",
-                "freeformer-3D-Printer",
-                "SELOGICA-Control-System",
-                "MULTILIFT-Robotic-Systems",
-                "ARBIDRIVE-Servo-Motor",
-                "ALS_Arburg-Leitrechner-System"
+            'arburg': [
+                'ALLROUNDER-Injection-Molding-Machine',
+                'freeformer-3D-Printer',
+                'SELOGICA-Control-System',
+                'MULTILIFT-Robotic-Systems',
+                'ARBIDRIVE-Servo-Motor',
+                'ALS_Arburg-Leitrechner-System',
             ],
-            "homag": [
-                "CENTATEQ-CNC-Processing-Center",
-                "EDGETEQ-Edge-Banding-Machine",
-                "powerTouch-Control",
-                "intelliGuide-Assist-System",
-                "DRILLTEQ-Drilling-and-Dowel-Insertion-Machine",
-                "STORETEQ-Storage-System"
+            'homag': [
+                'CENTATEQ-CNC-Processing-Center',
+                'EDGETEQ-Edge-Banding-Machine',
+                'powerTouch-Control',
+                'intelliGuide-Assist-System',
+                'DRILLTEQ-Drilling-and-Dowel-Insertion-Machine',
+                'STORETEQ-Storage-System',
             ],
-            "belden": [
-                "Hirschmann-Industrial-Ethernet-Switches",
-                "Lumberg-Automation-Connectors",
-                "GarrettCom-Magnum-Routers",
-                "TROMPETER-Coaxial-Connectors",
-                "Belden-I_O-Modules"
+            'belden': [
+                'Hirschmann-Industrial-Ethernet-Switches',
+                'Lumberg-Automation-Connectors',
+                'GarrettCom-Magnum-Routers',
+                'TROMPETER-Coaxial-Connectors',
+                'Belden-I_O-Modules',
             ],
-            "siemens": [
-                "SIMATIC-PLC",
-                "SINAMICS-Drive-Systems",
-                "SIRIUS-Control-Devices",
-                "SIMOTICS-Electric-Motors",
-                "SIMATIC-HMI-Panels",
-                "SITOP-Power-Supplies"
+            'siemens': [
+                'SIMATIC-PLC',
+                'SINAMICS-Drive-Systems',
+                'SIRIUS-Control-Devices',
+                'SIMOTICS-Electric-Motors',
+                'SIMATIC-HMI-Panels',
+                'SITOP-Power-Supplies',
             ],
-            "phoenix_contact": [
-                "CLIPLINE-Terminal-Blocks",
-                "QUINT-Power-Supplies",
-                "PLCnext-Control",
-                "TERMITRAB-Surge-Protection",
-                "CONTACTRON-Motor-Starters",
-                "ME-PLC_Modular-Controller"
+            'phoenix_contact': [
+                'CLIPLINE-Terminal-Blocks',
+                'QUINT-Power-Supplies',
+                'PLCnext-Control',
+                'TERMITRAB-Surge-Protection',
+                'CONTACTRON-Motor-Starters',
+                'ME-PLC_Modular-Controller',
             ],
-            "schmalz": [
-                "Vacuum-Generators",
-                "Vacuum-Grippers",
-                "Vacuum-Clamping-Systems",
-                "Suction-Pads",
-                "Vacuum-Layer-Grippers",
-                "Vacuum-Ejectors"
-            ]
+            'schmalz': [
+                'Vacuum-Generators',
+                'Vacuum-Grippers',
+                'Vacuum-Clamping-Systems',
+                'Suction-Pads',
+                'Vacuum-Layer-Grippers',
+                'Vacuum-Ejectors',
+            ],
         }
 
-
-        print("Starting the process of adding domains and devices...\n")
+        print('Starting the process of adding domains and devices...\n')
         index = 0
         for domain_name, devices in data.items():
             issuing_ca = random.choice(['issuing-ca-a', 'issuing-ca-b', 'issuing-ca-c'])
@@ -86,11 +84,11 @@ class Command(BaseCommand):
             domain.save()
 
             if created:
-                print(f"Created new domain: {domain_name}")
+                print(f'Created new domain: {domain_name}')
             else:
-                print(f"Domain already exists: {domain_name}")
+                print(f'Domain already exists: {domain_name}')
 
-            print(f"Domain({domain_name}, Issuing CA: {domain.issuing_ca})")
+            print(f'Domain({domain_name}, Issuing CA: {domain.issuing_ca})')
 
             for device_name in devices:
                 onboarding_protocol = random.choice(onboarding_protocols)
@@ -98,29 +96,29 @@ class Command(BaseCommand):
                 serial_number = ''.join(random.choices(string.ascii_uppercase + string.digits, k=12))
 
                 print(f"Creating device '{device_name}' in domain '{domain_name}' with:")
-                print(f"  - Serial Number: {serial_number}")
-                print(f"  - Onboarding Protocol: {onboarding_protocol}")
+                print(f'  - Serial Number: {serial_number}')
+                print(f'  - Onboarding Protocol: {onboarding_protocol}')
 
                 dev = Device(
                     device_name=device_name,
                     device_serial_number=serial_number,
                     onboarding_protocol=onboarding_protocol,
                     domain=domain,
-                    device_onboarding_status=random.choice(device_onboarding_statuses)
+                    device_onboarding_status=random.choice(device_onboarding_statuses),
                 )
 
                 dev.save()
                 print(f"Device '{device_name}' created successfully.\n")
 
                 issued_dev_cert = IssuedDeviceCertificateModel(
-                  device = dev,
-                  certificate=certificate_list[index],
-                  certificate_type=random.choice(certificate_types),
-                  domain=domain,
-                  template_name=random.choice(template_names),
-                  protocol=onboarding_protocol
+                    device=dev,
+                    certificate=certificate_list[index],
+                    certificate_type=random.choice(certificate_types),
+                    domain=domain,
+                    template_name=random.choice(template_names),
+                    protocol=onboarding_protocol,
                 )
                 issued_dev_cert.save()
-                index = index +1 
+                index = index + 1
                 print(f"IssuedDeviceCertificateModel '{device_name}' created successfully.\n")
-        print("\nProcess completed. All domains, devices and certificates have been added.")
+        print('\nProcess completed. All domains, devices and certificates have been added.')

--- a/trustpoint/pki/management/commands/base_commands.py
+++ b/trustpoint/pki/management/commands/base_commands.py
@@ -1,6 +1,5 @@
 """Something."""
 
-
 from __future__ import annotations
 
 from pathlib import Path
@@ -29,12 +28,8 @@ class CertificateCreationCommandMixin(CertificateGenerator):
 
     @classmethod
     def store_issuing_ca(
-            cls,
-            issuing_ca_cert: x509.Certificate,
-            chain: list[x509.Certificate],
-            private_key: PrivateKey,
-            filename: str) -> None:
-
+        cls, issuing_ca_cert: x509.Certificate, chain: list[x509.Certificate], private_key: PrivateKey, filename: str
+    ) -> None:
         tests_data_path = Path(__file__).parent.parent.parent.parent.parent / Path('tests/data/issuing_cas')
         issuing_ca_path = tests_data_path / Path(filename)
         # shutil.rmtree(tests_data_path, ignore_errors=True)
@@ -46,14 +41,14 @@ class CertificateCreationCommandMixin(CertificateGenerator):
             key=private_key,
             cert=issuing_ca_cert,
             cas=chain,
-            encryption_algorithm=BestAvailableEncryption(b"testing321"))
+            encryption_algorithm=BestAvailableEncryption(b'testing321'),
+        )
 
         with open(issuing_ca_path, 'wb') as f:
             f.write(p12)
 
         print(f'Issuing CA: {issuing_ca_path}')
         print('Issuing CA - Password: testing321\n')
-
 
     @staticmethod
     def store_ee_certs(certs: dict[str, x509.Certificate]) -> None:
@@ -72,10 +67,13 @@ class CertificateCreationCommandMixin(CertificateGenerator):
         for name, key in keys.items():
             key_path = tests_data_path / Path(f'{name}.pem')
             with open(key_path, 'wb') as f:
-                f.write(key.private_bytes(
-                    encoding=Encoding.PEM,
-                    format=PrivateFormat.TraditionalOpenSSL,
-                    encryption_algorithm=NoEncryption()))
+                f.write(
+                    key.private_bytes(
+                        encoding=Encoding.PEM,
+                        format=PrivateFormat.TraditionalOpenSSL,
+                        encryption_algorithm=NoEncryption(),
+                    )
+                )
             print(f'Stored EE certificate: {key_path}')
 
     @staticmethod
@@ -93,15 +91,18 @@ class CertificateCreationCommandMixin(CertificateGenerator):
                 key_size=2048,
             )
             builder = x509.CertificateSigningRequestBuilder()
-            builder = builder.subject_name(x509.Name([
-                x509.NameAttribute(NameOID.COMMON_NAME, f'CSR Cert {i}'),
-            ]))
+            builder = builder.subject_name(
+                x509.Name(
+                    [
+                        x509.NameAttribute(NameOID.COMMON_NAME, f'CSR Cert {i}'),
+                    ]
+                )
+            )
             builder = builder.add_extension(
-                x509.BasicConstraints(ca=False, path_length=None), critical=True,
+                x509.BasicConstraints(ca=False, path_length=None),
+                critical=True,
             )
-            csr = builder.sign(
-                private_key, hashes.SHA256()
-            )
+            csr = builder.sign(private_key, hashes.SHA256())
 
             with open(tests_data_path / Path(f'csr{i}.pem'), 'wb') as f:
                 f.write(csr.public_bytes(encoding=Encoding.PEM))

--- a/trustpoint/pki/management/commands/create_and_validate_test_certs.py
+++ b/trustpoint/pki/management/commands/create_and_validate_test_certs.py
@@ -1,6 +1,5 @@
 """Something."""
 
-
 from __future__ import annotations
 
 import datetime
@@ -26,18 +25,16 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
     help = 'Removes all migrations, deletes db and runs makemigrations and migrate afterwards.'
 
     def _create_cert_chain(self, algorithm: KeyAlgorithm, path: Path) -> None:
-
         pem_root_cert, root_cert, root_private_key = self._create_certificate(
-            common_name=f'{algorithm.value}-root-ca',
-            algorithm=algorithm,
-            path=path)
+            common_name=f'{algorithm.value}-root-ca', algorithm=algorithm, path=path
+        )
 
         pem_issuing_cert, issuing_cert, issuing_private = self._create_certificate(
             common_name=f'{algorithm.value}-issuing-ca',
             algorithm=algorithm,
             path=path,
             issuer=root_cert,
-            issuer_priv_key=root_private_key
+            issuer_priv_key=root_private_key,
         )
 
         pem_ee_cert, ee_cert, ee_key = self._create_certificate(
@@ -45,7 +42,7 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
             algorithm=algorithm,
             path=path,
             issuer=issuing_cert,
-            issuer_priv_key=issuing_private
+            issuer_priv_key=issuing_private,
         )
 
         p12 = pkcs12.serialize_key_and_certificates(
@@ -53,7 +50,7 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
             key=ee_key,
             cert=ee_cert,
             cas=[root_cert, issuing_cert],
-            encryption_algorithm=BestAvailableEncryption(b"password")
+            encryption_algorithm=BestAvailableEncryption(b'password'),
         )
 
         with open(path / f'{algorithm.value}.p12', 'wb') as f:
@@ -65,27 +62,35 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
 
     @classmethod
     def _create_certificate(
-            cls,
-            common_name: str,
-            algorithm: KeyAlgorithm,
-            path: Path,
-            issuer: None | x509.Certificate = None,
-            issuer_priv_key: None | rsa.RSAPrivateKey | ec.EllipticCurvePrivateKey = None,
-            validity_days: int = 365) -> tuple[str, x509.Certificate, rsa.RSAPrivateKey | ec.EllipticCurvePrivateKey]:
-        
+        cls,
+        common_name: str,
+        algorithm: KeyAlgorithm,
+        path: Path,
+        issuer: None | x509.Certificate = None,
+        issuer_priv_key: None | rsa.RSAPrivateKey | ec.EllipticCurvePrivateKey = None,
+        validity_days: int = 365,
+    ) -> tuple[str, x509.Certificate, rsa.RSAPrivateKey | ec.EllipticCurvePrivateKey]:
         kg = KeyGenerator(algorithm)
         private_key = kg.generate_key()
 
         one_day = datetime.timedelta(1, 0, 0)
         public_key = private_key.public_key()
         builder = x509.CertificateBuilder()
-        builder = builder.subject_name(x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, common_name),
-        ]))
+        builder = builder.subject_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+                ]
+            )
+        )
         if issuer is None:
-            builder = builder.issuer_name(x509.Name([
-                x509.NameAttribute(NameOID.COMMON_NAME, common_name),
-            ]))
+            builder = builder.issuer_name(
+                x509.Name(
+                    [
+                        x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+                    ]
+                )
+            )
         else:
             builder = builder.issuer_name(issuer.subject)
         builder = builder.not_valid_before(datetime.datetime.today() - one_day)
@@ -104,9 +109,7 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
             ca = False
             path_length = None
 
-        builder = builder.add_extension(
-            x509.BasicConstraints(ca=ca, path_length=path_length), critical=True
-        )
+        builder = builder.add_extension(x509.BasicConstraints(ca=ca, path_length=path_length), critical=True)
 
         builder = builder.add_extension(
             x509.KeyUsage(
@@ -118,9 +121,9 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
                 key_cert_sign=True,
                 crl_sign=True,
                 encipher_only=True,
-                decipher_only=True
+                decipher_only=True,
             ),
-            critical=True
+            critical=True,
         )
 
         some_arbitrary_der_as_hex = (
@@ -142,16 +145,17 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
                     x509.IPAddress(ipaddress.IPv6Network('2001:db8:1234::/48')),
                     x509.RegisteredID(x509.ObjectIdentifier('2.5.4.3')),
                     x509.OtherName(type_id=x509.ObjectIdentifier('2.5.4.3'), value=some_arbitrary_der),
-
                     x509.DirectoryName(
-                        x509.Name([
-                            x509.NameAttribute(NameOID.COMMON_NAME, 'Trustpoint Model Test'),
-                            x509.NameAttribute(NameOID.ORGANIZATION_NAME, 'Trustpoint')
-                        ])
-                    )
+                        x509.Name(
+                            [
+                                x509.NameAttribute(NameOID.COMMON_NAME, 'Trustpoint Model Test'),
+                                x509.NameAttribute(NameOID.ORGANIZATION_NAME, 'Trustpoint'),
+                            ]
+                        )
+                    ),
                 ]
             ),
-            critical=False
+            critical=False,
         )
 
         builder = builder.add_extension(
@@ -166,31 +170,34 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
                     x509.IPAddress(ipaddress.IPv6Network('2001:db8:1234::/48')),
                     x509.RegisteredID(x509.ObjectIdentifier('2.5.4.3')),
                     x509.OtherName(type_id=x509.ObjectIdentifier('2.5.4.3'), value=some_arbitrary_der),
-
                     x509.DirectoryName(
-                        x509.Name([
-                            x509.NameAttribute(NameOID.COMMON_NAME, 'Subject Trustpoint Model Test'),
-                            x509.NameAttribute(NameOID.ORGANIZATION_NAME, 'Subject Trustpoint')
-                        ])
-                    )
+                        x509.Name(
+                            [
+                                x509.NameAttribute(NameOID.COMMON_NAME, 'Subject Trustpoint Model Test'),
+                                x509.NameAttribute(NameOID.ORGANIZATION_NAME, 'Subject Trustpoint'),
+                            ]
+                        )
+                    ),
                 ]
             ),
-            critical=False
+            critical=False,
         )
 
         if issuer_priv_key is None:
             certificate = builder.sign(
-                private_key=private_key, algorithm=hashes.SHA256(),
+                private_key=private_key,
+                algorithm=hashes.SHA256(),
             )
         else:
             certificate = builder.sign(
-                private_key=issuer_priv_key, algorithm=hashes.SHA256(),
+                private_key=issuer_priv_key,
+                algorithm=hashes.SHA256(),
             )
 
         pem_priv_key = private_key.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption()
+            encryption_algorithm=serialization.NoEncryption(),
         )
 
         pem_cert = certificate.public_bytes(serialization.Encoding.PEM)

--- a/trustpoint/pki/management/commands/create_multiple_test_issuing_cas.py
+++ b/trustpoint/pki/management/commands/create_multiple_test_issuing_cas.py
@@ -19,95 +19,113 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
         rsa2_root_ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
         rsa2_issuing_ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
         rsa2_root, _ = self.create_root_ca(
-            'Root-CA RSA-2048-SHA256', private_key=rsa2_root_ca_key, hash_algorithm=hashes.SHA256())
+            'Root-CA RSA-2048-SHA256', private_key=rsa2_root_ca_key, hash_algorithm=hashes.SHA256()
+        )
         rsa2_issuing_ca, rsa2_issuing_ca_key = self.create_issuing_ca(
             issuer_private_key=rsa2_root_ca_key,
             private_key=rsa2_issuing_ca_key,
             issuer_cn='Root-CA RSA-2048-SHA256',
             subject_cn='Issuing CA A',
-            hash_algorithm=hashes.SHA256())
+            hash_algorithm=hashes.SHA256(),
+        )
         self.save_issuing_ca(
             issuing_ca_cert=rsa2_issuing_ca,
             private_key=rsa2_issuing_ca_key,
             chain=[rsa2_root],
-            unique_name='issuing-ca-a')
+            unique_name='issuing-ca-a',
+        )
 
         rsa3_root_ca_key = rsa.generate_private_key(public_exponent=65537, key_size=3072)
         rsa3_issuing_ca_key = rsa.generate_private_key(public_exponent=65537, key_size=3072)
         rsa3_root, _ = self.create_root_ca(
-            'Root-CA RSA-3072-SHA256', private_key=rsa3_root_ca_key, hash_algorithm=hashes.SHA256())
+            'Root-CA RSA-3072-SHA256', private_key=rsa3_root_ca_key, hash_algorithm=hashes.SHA256()
+        )
         rsa3_issuing_ca, rsa3_issuing_ca_key = self.create_issuing_ca(
             issuer_private_key=rsa2_root_ca_key,
             private_key=rsa3_issuing_ca_key,
             issuer_cn='Root-CA RSA-3072-SHA256',
             subject_cn='Issuing CA B',
-            hash_algorithm=hashes.SHA256())
+            hash_algorithm=hashes.SHA256(),
+        )
         self.save_issuing_ca(
             issuing_ca_cert=rsa3_issuing_ca,
             private_key=rsa3_issuing_ca_key,
             chain=[rsa3_root],
-            unique_name='issuing-ca-b')
+            unique_name='issuing-ca-b',
+        )
 
         rsa4_root_ca_key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
         rsa4_issuing_ca_key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
         rsa4_root, _ = self.create_root_ca(
-            'Root-CA RSA-4096-SHA256', private_key=rsa4_root_ca_key, hash_algorithm=hashes.SHA512())
+            'Root-CA RSA-4096-SHA256', private_key=rsa4_root_ca_key, hash_algorithm=hashes.SHA512()
+        )
         rsa4_issuing_ca, rsa4_issuing_ca_key = self.create_issuing_ca(
             issuer_private_key=rsa4_root_ca_key,
             private_key=rsa4_issuing_ca_key,
             issuer_cn='Root-CA RSA-4096-SHA256',
             subject_cn='Issuing CA C',
-            hash_algorithm=hashes.SHA512())
+            hash_algorithm=hashes.SHA512(),
+        )
         self.save_issuing_ca(
             issuing_ca_cert=rsa4_issuing_ca,
             private_key=rsa4_issuing_ca_key,
             chain=[rsa4_root],
-            unique_name='issuing-ca-c')
+            unique_name='issuing-ca-c',
+        )
 
         ecc1_root_ca_key = ec.generate_private_key(curve=ec.SECP256R1())
         ecc1_issuing_ca_key = ec.generate_private_key(curve=ec.SECP256R1())
         ecc1_root, _ = self.create_root_ca(
-            'Root-CA SECP256R1-SHA256', private_key=ecc1_root_ca_key, hash_algorithm=hashes.SHA256())
+            'Root-CA SECP256R1-SHA256', private_key=ecc1_root_ca_key, hash_algorithm=hashes.SHA256()
+        )
         ecc1_issuing_ca, ecc1_issuing_ca_key = self.create_issuing_ca(
             issuer_private_key=ecc1_root_ca_key,
             private_key=ecc1_issuing_ca_key,
             issuer_cn='Root-CA SECP256R1-SHA256',
             subject_cn='Issuing CA D',
-            hash_algorithm=hashes.SHA256())
+            hash_algorithm=hashes.SHA256(),
+        )
         self.save_issuing_ca(
             issuing_ca_cert=ecc1_issuing_ca,
             private_key=ecc1_issuing_ca_key,
             chain=[ecc1_root],
-            unique_name='issuing-ca-d')
+            unique_name='issuing-ca-d',
+        )
 
         ecc2_root_ca_key = ec.generate_private_key(curve=ec.SECT283R1())
         ecc2_issuing_ca_key = ec.generate_private_key(curve=ec.SECT283R1())
         ecc2_root, _ = self.create_root_ca(
-            'Root-CA SECT283R1-SHA256', private_key=ecc2_root_ca_key, hash_algorithm=hashes.SHA256())
+            'Root-CA SECT283R1-SHA256', private_key=ecc2_root_ca_key, hash_algorithm=hashes.SHA256()
+        )
         ecc2_issuing_ca, ecc2_issuing_ca_key = self.create_issuing_ca(
             issuer_private_key=ecc2_root_ca_key,
             private_key=ecc2_issuing_ca_key,
             issuer_cn='Root-CA SECT283R1-SHA256',
             subject_cn='Issuing CA E',
-            hash_algorithm=hashes.SHA256())
+            hash_algorithm=hashes.SHA256(),
+        )
         self.save_issuing_ca(
             issuing_ca_cert=ecc2_issuing_ca,
             private_key=ecc2_issuing_ca_key,
             chain=[ecc2_root],
-            unique_name='issuing-ca-e')
+            unique_name='issuing-ca-e',
+        )
 
         ecc3_root_ca_key = ec.generate_private_key(curve=ec.SECT571R1())
         ecc3_issuing_ca_key = ec.generate_private_key(curve=ec.SECT571R1())
         ecc3_root, _ = self.create_root_ca(
-            'Root-CA SECT571R1-SHA256', private_key=ecc3_root_ca_key, hash_algorithm=hashes.SHA3_512())
+            'Root-CA SECT571R1-SHA256', private_key=ecc3_root_ca_key, hash_algorithm=hashes.SHA3_512()
+        )
         ecc3_issuing_ca, ecc3_issuing_ca_key = self.create_issuing_ca(
             issuer_private_key=ecc3_root_ca_key,
             private_key=ecc3_issuing_ca_key,
             issuer_cn='Root-CA SECT571R1-SHA256',
             subject_cn='Issuing CA F',
-            hash_algorithm=hashes.SHA3_512())
+            hash_algorithm=hashes.SHA3_512(),
+        )
         self.save_issuing_ca(
             issuing_ca_cert=ecc3_issuing_ca,
             private_key=ecc3_issuing_ca_key,
             chain=[ecc3_root],
-            unique_name='issuing-ca-f')
+            unique_name='issuing-ca-f',
+        )

--- a/trustpoint/pki/management/commands/create_test_cross_signed.py
+++ b/trustpoint/pki/management/commands/create_test_cross_signed.py
@@ -1,6 +1,5 @@
 """Something."""
 
-
 from __future__ import annotations
 
 import datetime
@@ -19,14 +18,13 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
     """Django management command for adding issuing CA test data."""
 
     help = 'Removes all migrations, deletes db and runs makemigrations and migrate afterwards.'
-    def handle(self, *args, **kwargs) -> None:
 
+    def handle(self, *args, **kwargs) -> None:
         root_1, root_1_key = self.create_root_ca('Root CA A')
         root_2, root_2_key = self.create_root_ca('Root CA B')
 
         issuing_1, issuing_1_key = self.create_issuing_ca(root_1_key, 'Root CA A', 'Issuing CA')
-        issuing_2, issuing_2_key = self.create_issuing_ca(
-            root_2_key, 'Root CA B', 'Issuing CA', issuing_1_key)
+        issuing_2, issuing_2_key = self.create_issuing_ca(root_2_key, 'Root CA B', 'Issuing CA', issuing_1_key)
 
         ee_1, _ = self.create_ee(issuing_1_key, 'Issuing CA', 'EE A1')
         ee_2, _ = self.create_ee(issuing_1_key, 'Issuing CA', 'EE A2')
@@ -41,4 +39,3 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
         CertificateModel.save_certificate(ee_2)
         CertificateModel.save_certificate(ee_3)
         CertificateModel.save_certificate(ee_4)
-

--- a/trustpoint/pki/management/commands/create_test_issuing_ca.py
+++ b/trustpoint/pki/management/commands/create_test_issuing_ca.py
@@ -1,6 +1,5 @@
 """Something."""
 
-
 from __future__ import annotations
 
 import random
@@ -31,7 +30,7 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
             key_cert_sign=False,
             crl_sign=False,
             decipher_only=False,
-            encipher_only=False
+            encipher_only=False,
         )
 
         root_1, root_1_key = self.create_root_ca('root_ca')
@@ -51,7 +50,7 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
                 issuer_cn='issuing_ca',
                 subject_cn=f'EE {i}',
                 key_usage_extension=key_usage_extension,
-                validity_days=validity_days
+                validity_days=validity_days,
             )
             ee_certs[f'ee{i}'] = ee
             ee_keys[f'key{i}'] = key

--- a/trustpoint/pki/management/commands/create_test_long_chain_p12.py
+++ b/trustpoint/pki/management/commands/create_test_long_chain_p12.py
@@ -1,6 +1,5 @@
 """Something."""
 
-
 from __future__ import annotations
 
 from pathlib import Path
@@ -18,19 +17,13 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
     help = 'Removes all migrations, deletes db and runs makemigrations and migrate afterwards.'
 
     def handle(self, *args, **kwargs) -> None:
-
         root_1, root_1_key = self.create_root_ca('Root CA A')
 
-        issuing_1, issuing_1_key = self.create_issuing_ca(
-            root_1_key, 'Root CA A', 'Intermediate CA A')
-        issuing_2, issuing_2_key = self.create_issuing_ca(
-            issuing_1_key, 'Intermediate CA A', 'Intermediate CA B')
-        issuing_3, issuing_3_key = self.create_issuing_ca(
-            issuing_2_key, 'Intermediate CA B', 'Intermediate CA C')
-        issuing_4, issuing_4_key = self.create_issuing_ca(
-            issuing_3_key, 'Intermediate CA C', 'Intermediate CA D')
-        issuing_5, issuing_5_key = self.create_issuing_ca(
-            issuing_4_key, 'Intermediate CA D', 'Issuing CA')
+        issuing_1, issuing_1_key = self.create_issuing_ca(root_1_key, 'Root CA A', 'Intermediate CA A')
+        issuing_2, issuing_2_key = self.create_issuing_ca(issuing_1_key, 'Intermediate CA A', 'Intermediate CA B')
+        issuing_3, issuing_3_key = self.create_issuing_ca(issuing_2_key, 'Intermediate CA B', 'Intermediate CA C')
+        issuing_4, issuing_4_key = self.create_issuing_ca(issuing_3_key, 'Intermediate CA C', 'Intermediate CA D')
+        issuing_5, issuing_5_key = self.create_issuing_ca(issuing_4_key, 'Intermediate CA D', 'Issuing CA')
 
         ee_1, ee_key = self.create_ee(issuing_5_key, 'Issuing CA', 'EE A1')
 
@@ -39,7 +32,7 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
             issuing_5_key,
             issuing_5,
             [root_1, issuing_1, issuing_2, issuing_3, issuing_4],
-            encryption_algorithm=BestAvailableEncryption(b'testing321')
+            encryption_algorithm=BestAvailableEncryption(b'testing321'),
         )
 
         with open(Path(__file__).parent.parent.parent / 'p12.p12', 'wb') as f:
@@ -51,5 +44,3 @@ class Command(CertificateCreationCommandMixin, BaseCommand):
         CertificateModel.save_certificate(issuing_4)
         CertificateModel.save_certificate(issuing_5)
         CertificateModel.save_certificate(ee_1)
-
-

--- a/trustpoint/pki/management/commands/create_test_ts.py
+++ b/trustpoint/pki/management/commands/create_test_ts.py
@@ -1,6 +1,5 @@
 """A."""
 
-
 from __future__ import annotations
 
 from itertools import product
@@ -13,6 +12,7 @@ from pki.models import CertificateModel
 from .base_commands import CertificateCreationCommandMixin
 from django.core.management.base import BaseCommand
 from . import Algorithm
+
 
 class Command(CertificateCreationCommandMixin, BaseCommand):
     """Django management command for adding issuing CA test data."""

--- a/trustpoint/pki/management/commands/create_tls_certs.py
+++ b/trustpoint/pki/management/commands/create_tls_certs.py
@@ -1,6 +1,5 @@
 """Something."""
 
-
 from __future__ import annotations
 
 import ipaddress
@@ -19,7 +18,7 @@ PublicKey = Union[rsa.RSAPublicKey, ec.EllipticCurvePublicKey, ed448.Ed448Public
 PrivateKey = Union[rsa.RSAPrivateKey, ec.EllipticCurvePrivateKey, ed448.Ed448PrivateKey, ed25519.Ed25519PrivateKey]
 
 BASE_PATH = Path(__file__).parent.parent.parent.parent.parent / 'tests/data/x509/'
-SERVER_CERT_PATH =  BASE_PATH / 'https_server.crt'
+SERVER_CERT_PATH = BASE_PATH / 'https_server.crt'
 SERVER_KEY_PATH = BASE_PATH / 'https_server.pem'
 
 
@@ -31,7 +30,7 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs) -> None:
         one_day = datetime.timedelta(1, 0, 0)
         ipv4_addresses = subprocess.check_output('hostname -I', shell=True).decode().strip()
-        #ipv4_addresses = '10.10.0.5 10.10.4.89'
+        # ipv4_addresses = '10.10.0.5 10.10.4.89'
         ipv4_addresses = ipv4_addresses.split(' ')
         ipv4_addresses.append('127.0.0.1')
         basic_constraints_extension = x509.BasicConstraints(ca=False, path_length=None)
@@ -44,7 +43,7 @@ class Command(BaseCommand):
             key_cert_sign=False,
             crl_sign=False,
             decipher_only=False,
-            encipher_only=False
+            encipher_only=False,
         )
         extended_key_usage_extension = x509.ExtendedKeyUsage([x509.oid.ExtendedKeyUsageOID.SERVER_AUTH])
         subject_alt_name_content = [x509.DNSName('localhost'), x509.DNSName('trustpoint.local')]
@@ -52,11 +51,13 @@ class Command(BaseCommand):
             subject_alt_name_content.append(x509.IPAddress(ipaddress.IPv4Address(ipv4)))
         subject_alternative_names_extension = x509.SubjectAlternativeName(subject_alt_name_content)
 
-        subject = x509.Name([
-            x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, 'Trustpoint TLS Server Certificate'),
-            x509.NameAttribute(x509.oid.NameOID.COUNTRY_NAME, 'DE'),
-            x509.NameAttribute(x509.oid.NameOID.ORGANIZATION_NAME, 'Trustpoint Project')
-        ])
+        subject = x509.Name(
+            [
+                x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, 'Trustpoint TLS Server Certificate'),
+                x509.NameAttribute(x509.oid.NameOID.COUNTRY_NAME, 'DE'),
+                x509.NameAttribute(x509.oid.NameOID.ORGANIZATION_NAME, 'Trustpoint Project'),
+            ]
+        )
         issuer = subject
 
         private_key = rsa.generate_private_key(
@@ -84,6 +85,6 @@ class Command(BaseCommand):
             private_key.private_bytes(
                 encoding=serialization.Encoding.PEM,
                 format=serialization.PrivateFormat.TraditionalOpenSSL,
-                encryption_algorithm=serialization.NoEncryption()
+                encryption_algorithm=serialization.NoEncryption(),
             ).decode()
         )

--- a/trustpoint/pki/management/commands/import_idevid_truststores.py
+++ b/trustpoint/pki/management/commands/import_idevid_truststores.py
@@ -21,13 +21,15 @@ class Command(BaseCommand):
     }
 
     def handle(self, *args, **kwargs):
-        base_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../tests/data/idevid_hierarchies"))
+        base_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), '../../../../tests/data/idevid_hierarchies')
+        )
 
         for relative_path, unique_name in self.TRUSTSTORE_RELATIVE_PATHS.items():
             pem_path = os.path.join(base_path, relative_path)
 
             if not os.path.exists(pem_path):
-                self.stderr.write(self.style.ERROR(f"File not found: {pem_path}"))
+                self.stderr.write(self.style.ERROR(f'File not found: {pem_path}'))
                 continue
 
             try:
@@ -37,20 +39,18 @@ class Command(BaseCommand):
                 certificates = x509.load_pem_x509_certificates(pem_content)
 
                 self._save_trust_store(
-                    unique_name=f"idevid-truststore-{unique_name}",
+                    unique_name=f'idevid-truststore-{unique_name}',
                     intended_usage=TruststoreModel.IntendedUsage.IDEVID,
-                    certificates=certificates
+                    certificates=certificates,
                 )
 
-                self.stdout.write(self.style.SUCCESS(f"Imported Truststore: {unique_name}"))
+                self.stdout.write(self.style.SUCCESS(f'Imported Truststore: {unique_name}'))
             except Exception as e:
-                self.stderr.write(self.style.ERROR(f"Failed to import {pem_path}: {e}"))
+                self.stderr.write(self.style.ERROR(f'Failed to import {pem_path}: {e}'))
 
     @staticmethod
     def _save_trust_store(
-        unique_name: str,
-        intended_usage: TruststoreModel.IntendedUsage,
-        certificates: list[x509.Certificate]
+        unique_name: str, intended_usage: TruststoreModel.IntendedUsage, certificates: list[x509.Certificate]
     ) -> TruststoreModel:
         saved_certs = []
 
@@ -61,17 +61,10 @@ class Command(BaseCommand):
             except CertificateModel.DoesNotExist:
                 saved_certs.append(CertificateModel.save_certificate(certificate))
 
-        trust_store_model = TruststoreModel(
-            unique_name=unique_name,
-            intended_usage=intended_usage
-        )
+        trust_store_model = TruststoreModel(unique_name=unique_name, intended_usage=intended_usage)
         trust_store_model.save()
 
         for number, certificate in enumerate(saved_certs):
-            TruststoreOrderModel.objects.create(
-                order=number,
-                certificate=certificate,
-                trust_store=trust_store_model
-            )
+            TruststoreOrderModel.objects.create(order=number, certificate=certificate, trust_store=trust_store_model)
 
         return trust_store_model

--- a/trustpoint/pki/management/commands/reset_db.py
+++ b/trustpoint/pki/management/commands/reset_db.py
@@ -11,92 +11,92 @@ from django.conf import settings
 
 class Command(BaseCommand):
     help = (
-        "Resets the database by deleting all migrations, dropping "
-        "the database, then running makemigrations and migrate. "
-        "Creates a superuser unless --no-user is provided."
+        'Resets the database by deleting all migrations, dropping '
+        'the database, then running makemigrations and migrate. '
+        'Creates a superuser unless --no-user is provided.'
     )
 
     def add_arguments(self, parser: CommandParser) -> None:
-        parser.add_argument("--force", action="store_true", help="Force database reset without prompt.")
-        parser.add_argument("--no-user", action="store_true", help="Skip superuser creation.")
+        parser.add_argument('--force', action='store_true', help='Force database reset without prompt.')
+        parser.add_argument('--no-user', action='store_true', help='Skip superuser creation.')
 
     def handle(self, *args, **options) -> None:
         # Confirm database reset
-        if not options.get("force"):
-            self.stdout.write("WARNING: This will delete the database and all migration files.")
-            answer = input("Are you sure you want to continue? (y/N): ").strip().lower()
-            if answer not in ("y", 'yes'):
-                self.stdout.write("Aborted.")
+        if not options.get('force'):
+            self.stdout.write('WARNING: This will delete the database and all migration files.')
+            answer = input('Are you sure you want to continue? (y/N): ').strip().lower()
+            if answer not in ('y', 'yes'):
+                self.stdout.write('Aborted.')
                 return
 
         # Remove migration files
-        self.stdout.write("Removing migration files...")
+        self.stdout.write('Removing migration files...')
         base_path = Path(__file__).resolve().parent.parent.parent.parent
         for root, dirs, files in os.walk(base_path):
-            if "migrations" in root:
+            if 'migrations' in root:
                 for file in files:
-                    if (file.endswith(".py") and file != "__init__.py") or file.endswith(".pyc"):
+                    if (file.endswith('.py') and file != '__init__.py') or file.endswith('.pyc'):
                         try:
                             os.remove(Path(root) / file)
                         except Exception as e:
-                            self.stderr.write(f"Error removing {file}: {e}")
+                            self.stderr.write(f'Error removing {file}: {e}')
 
         # Reset database depending on engine
-        engine = settings.DATABASES["default"]["ENGINE"]
-        if engine == "django.db.backends.sqlite3":
+        engine = settings.DATABASES['default']['ENGINE']
+        if engine == 'django.db.backends.sqlite3':
             self._reset_sqlite(base_path)
-        elif engine == "django.db.backends.postgresql":
+        elif engine == 'django.db.backends.postgresql':
             self._reset_postgresql()
         else:
-            self.stderr.write(f"Database engine {engine} is not supported by this command.")
+            self.stderr.write(f'Database engine {engine} is not supported by this command.')
             return
 
         # Run migrations
-        self.stdout.write("Running makemigrations...")
-        call_command("makemigrations")
-        self.stdout.write("Running migrate...")
-        call_command("migrate")
+        self.stdout.write('Running makemigrations...')
+        call_command('makemigrations')
+        self.stdout.write('Running migrate...')
+        call_command('migrate')
 
         # Create superuser if needed
-        if not options.get("no_user"):
-            self.stdout.write("Creating superuser...")
-            call_command("createsuperuser", interactive=False, username="admin", email="")
-            user = User.objects.get(username="admin")
-            user.set_password("testing321")
+        if not options.get('no_user'):
+            self.stdout.write('Creating superuser...')
+            call_command('createsuperuser', interactive=False, username='admin', email='')
+            user = User.objects.get(username='admin')
+            user.set_password('testing321')
             user.save()
-            self.stdout.write("Superuser created:")
-            self.stdout.write("  Username: admin")
-            self.stdout.write("  Password: testing321")
+            self.stdout.write('Superuser created:')
+            self.stdout.write('  Username: admin')
+            self.stdout.write('  Password: testing321')
 
-        self.stdout.write("Database reset complete.")
+        self.stdout.write('Database reset complete.')
 
     def _reset_sqlite(self, base_path: Path) -> None:
         """Deletes the SQLite database file."""
-        db_path = base_path / "db.sqlite3"
+        db_path = base_path / 'db.sqlite3'
         if db_path.exists():
             try:
                 os.remove(db_path)
-                self.stdout.write("SQLite database file deleted.")
+                self.stdout.write('SQLite database file deleted.')
             except Exception as e:
-                self.stderr.write(f"Error deleting SQLite database file: {e}")
+                self.stderr.write(f'Error deleting SQLite database file: {e}')
         else:
-            self.stdout.write("No SQLite database file found.")
+            self.stdout.write('No SQLite database file found.')
 
     def _reset_postgresql(self) -> None:
         """Drops and recreates the PostgreSQL database."""
-        db_config = settings.DATABASES["default"]
-        db_name = db_config["NAME"]
-        db_user = db_config["USER"]
-        db_password = db_config["PASSWORD"]
-        db_host = db_config["HOST"]
-        db_port = db_config["PORT"]
+        db_config = settings.DATABASES['default']
+        db_name = db_config['NAME']
+        db_user = db_config['USER']
+        db_password = db_config['PASSWORD']
+        db_host = db_config['HOST']
+        db_port = db_config['PORT']
 
         self.stdout.write(f"Resetting PostgreSQL database '{db_name}'...")
 
         try:
             # Connect to the default 'postgres' database to issue drop/create commands
             conn = psycopg.connect(
-                dbname="postgres",
+                dbname='postgres',
                 user=db_user,
                 password=db_password,
                 host=db_host,
@@ -106,7 +106,7 @@ class Command(BaseCommand):
             cur = conn.cursor()
 
             # Terminate existing connections to the target database
-            self.stdout.write("Terminating existing connections...")
+            self.stdout.write('Terminating existing connections...')
             cur.execute(
                 f"""
                 SELECT pg_terminate_backend(pid)
@@ -118,16 +118,16 @@ class Command(BaseCommand):
             )
 
             # Drop the database if it exists
-            self.stdout.write("Dropping database...")
-            cur.execute(f"DROP DATABASE IF EXISTS {db_name};")
+            self.stdout.write('Dropping database...')
+            cur.execute(f'DROP DATABASE IF EXISTS {db_name};')
 
             # Recreate the database owned by the specified user
-            self.stdout.write("Creating database...")
-            cur.execute(f"CREATE DATABASE {db_name} OWNER {db_user};")
+            self.stdout.write('Creating database...')
+            cur.execute(f'CREATE DATABASE {db_name} OWNER {db_user};')
 
             cur.close()
             conn.close()
-            self.stdout.write("PostgreSQL database reset successfully.")
+            self.stdout.write('PostgreSQL database reset successfully.')
 
         except Exception as e:
-            self.stderr.write(f"Error resetting PostgreSQL database: {e}")
+            self.stderr.write(f'Error resetting PostgreSQL database: {e}')

--- a/trustpoint/pki/models/__init__.py
+++ b/trustpoint/pki/models/__init__.py
@@ -13,7 +13,7 @@ from .extension import (
     BasicConstraintsExtension,
     KeyUsageExtension,
     IssuerAlternativeNameExtension,
-    SubjectAlternativeNameExtension
+    SubjectAlternativeNameExtension,
 )
 from .certificate import CertificateModel, RevokedCertificateModel
 from .issuing_ca import IssuingCaModel

--- a/trustpoint/pki/models/certificate.py
+++ b/trustpoint/pki/models/certificate.py
@@ -1,4 +1,5 @@
 """Module that contains the CertificateModel."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -20,7 +21,7 @@ from trustpoint_core.oid import (
     AlgorithmIdentifier,
     NamedCurve,
     SignatureSuite,
-    PublicKeyInfo
+    PublicKeyInfo,
 )
 from trustpoint_core.serializer import CertificateSerializer, PublicKeySerializer
 
@@ -47,14 +48,13 @@ from trustpoint.views.base import LoggerMixin
 
 if TYPE_CHECKING:
     from typing import Union
+
     PrivateKey = Union[rsa.RSAPrivateKey, ec.EllipticCurvePrivateKey, ed448.Ed448PrivateKey, ed25519.Ed25519PrivateKey]
     PublicKey = Union[rsa.RSAPublicKey, ec.EllipticCurvePublicKey, ed448.Ed448PublicKey, ed25519.Ed25519PublicKey]
 
 
-__all__ = [
-    'CertificateModel',
-    'RevokedCertificateModel'
-]
+__all__ = ['CertificateModel', 'RevokedCertificateModel']
+
 
 class CertificateModel(LoggerMixin, models.Model):
     """X509 Certificate Model.
@@ -69,6 +69,7 @@ class CertificateModel(LoggerMixin, models.Model):
 
     class CertificateStatus(models.TextChoices):
         """CertificateModel status"""
+
         OK = 'OK', _('OK')
         REVOKED = 'REV', _('Revoked')
         EXPIRED = 'EXP', _('Expired')
@@ -78,11 +79,13 @@ class CertificateModel(LoggerMixin, models.Model):
 
     class Version(models.IntegerChoices):
         """X509 RFC 5280 - Certificate Version."""
+
         # We only allow version 3 or later if any are available in the future.
         V3 = 2, _('Version 3')
 
     SignatureAlgorithmOidChoices = models.TextChoices(
-        'SIGNATURE_ALGORITHM_OID', [(x.dotted_string, x.dotted_string) for x in AlgorithmIdentifier])
+        'SIGNATURE_ALGORITHM_OID', [(x.dotted_string, x.dotted_string) for x in AlgorithmIdentifier]
+    )
 
     PublicKeyAlgorithmOidChoices = models.TextChoices(
         'PUBLIC_KEY_ALGORITHM_OID', [(x.dotted_string, x.dotted_string) for x in PublicKeyAlgorithmOid]
@@ -106,9 +109,9 @@ class CertificateModel(LoggerMixin, models.Model):
     def certificate_status(self) -> CertificateStatus:
         if RevokedCertificateModel.objects.filter(certificate=self).exists():
             return self.CertificateStatus.REVOKED
-        elif datetime.datetime.now(datetime. UTC) < self.not_valid_before:
+        elif datetime.datetime.now(datetime.UTC) < self.not_valid_before:
             return self.CertificateStatus.NOT_YET_VALID
-        elif datetime.datetime.now(datetime. UTC) > self.not_valid_after:
+        elif datetime.datetime.now(datetime.UTC) > self.not_valid_after:
             return self.CertificateStatus.EXPIRED
         return self.CertificateStatus.OK
 
@@ -118,21 +121,15 @@ class CertificateModel(LoggerMixin, models.Model):
     # TODO: This information is already available through the subject relation
     # TODO: Property would not be sortable.
     # TODO: We may want to resolve this later by modifying the queryset within the view
-    common_name = models.CharField(
-        verbose_name=_('Common Name'),
-        max_length=256,
-        default=''
-    )
+    common_name = models.CharField(verbose_name=_('Common Name'), max_length=256, default='')
     sha256_fingerprint = models.CharField(verbose_name=_('Fingerprint (SHA256)'), max_length=256, editable=False)
 
     # ------------------------------------------ Certificate Fields (Header) -------------------------------------------
 
     # OID of the signature algorithm -> dotted_string in DB
     signature_algorithm_oid = models.CharField(
-        _('Signature Algorithm OID'),
-        max_length=256,
-        editable=False,
-        choices=SignatureAlgorithmOidChoices)
+        _('Signature Algorithm OID'), max_length=256, editable=False, choices=SignatureAlgorithmOidChoices
+    )
 
     # Name of the signature algorithm
     @property
@@ -162,10 +159,8 @@ class CertificateModel(LoggerMixin, models.Model):
     serial_number = models.CharField(verbose_name=_('Serial Number'), max_length=256, editable=False)
 
     issuer = models.ManyToManyField(
-        AttributeTypeAndValue,
-        verbose_name=_('Issuer'),
-        related_name='issuer',
-        editable=False)
+        AttributeTypeAndValue, verbose_name=_('Issuer'), related_name='issuer', editable=False
+    )
 
     # The DER encoded issuer as hex string. Without prefix, all uppercase, no whitespace / trimmed.
     issuer_public_bytes = models.CharField(verbose_name=_('Issuer Public Bytes'), max_length=2048, editable=False)
@@ -179,26 +174,19 @@ class CertificateModel(LoggerMixin, models.Model):
     # However, this suffices for our use-case.
     # Do not use these to compare certificate subjects. Use issuer_public_bytes for this.
     subject = models.ManyToManyField(
-        AttributeTypeAndValue,
-        verbose_name=_('Subject'),
-        related_name='subject',
-        editable=False)
+        AttributeTypeAndValue, verbose_name=_('Subject'), related_name='subject', editable=False
+    )
 
     # The DER encoded subject as hex string. Without prefix, all uppercase, no whitespace / trimmed.
     subject_public_bytes = models.CharField(verbose_name=_('Subject Public Bytes'), max_length=2048, editable=False)
 
     # Subject Public Key Info - Algorithm OID
     spki_algorithm_oid = models.CharField(
-        _('Public Key Algorithm OID'),
-        max_length=256,
-        editable=False,
-        choices=PublicKeyAlgorithmOidChoices)
+        _('Public Key Algorithm OID'), max_length=256, editable=False, choices=PublicKeyAlgorithmOidChoices
+    )
 
     # Subject Public Key Info - Algorithm Name
-    spki_algorithm = models.CharField(
-        verbose_name=_('Public Key Algorithm'),
-        max_length=256,
-        editable=False)
+    spki_algorithm = models.CharField(verbose_name=_('Public Key Algorithm'), max_length=256, editable=False)
 
     # Subject Public Key Info - Key Size
     spki_key_size = models.PositiveIntegerField(_('Public Key Size'), editable=False)
@@ -209,14 +197,13 @@ class CertificateModel(LoggerMixin, models.Model):
         max_length=256,
         editable=False,
         choices=PublicKeyEcCurveOidChoices,
-        default=None)
+        default=None,
+    )
 
     # Subject Public Key Info - Curve Name if ECC, None otherwise
     spki_ec_curve = models.CharField(
-        verbose_name=_('Public Key Curve (ECC)'),
-        max_length=256,
-        editable=False,
-        default=None)
+        verbose_name=_('Public Key Curve (ECC)'), max_length=256, editable=False, default=None
+    )
 
     # ---------------------------------------------------- Raw Data ----------------------------------------------------
 
@@ -245,7 +232,8 @@ class CertificateModel(LoggerMixin, models.Model):
         editable=False,
         null=True,
         blank=True,
-        on_delete=models.PROTECT)
+        on_delete=models.PROTECT,
+    )
 
     subject_alternative_name_extension = models.ForeignKey(
         verbose_name=CertificateExtensionOid.SUBJECT_ALTERNATIVE_NAME.verbose_name,
@@ -254,7 +242,7 @@ class CertificateModel(LoggerMixin, models.Model):
         editable=False,
         null=True,
         blank=True,
-        on_delete=models.PROTECT
+        on_delete=models.PROTECT,
     )
 
     issuer_alternative_name_extension = models.ForeignKey(
@@ -264,7 +252,7 @@ class CertificateModel(LoggerMixin, models.Model):
         editable=False,
         null=True,
         blank=True,
-        on_delete=models.PROTECT
+        on_delete=models.PROTECT,
     )
 
     basic_constraints_extension = models.ForeignKey(
@@ -274,7 +262,8 @@ class CertificateModel(LoggerMixin, models.Model):
         editable=False,
         null=True,
         blank=True,
-        on_delete=models.CASCADE)
+        on_delete=models.CASCADE,
+    )
 
     authority_key_identifier_extension = models.ForeignKey(
         verbose_name=CertificateExtensionOid.AUTHORITY_KEY_IDENTIFIER.verbose_name,
@@ -283,7 +272,7 @@ class CertificateModel(LoggerMixin, models.Model):
         editable=False,
         null=True,
         blank=True,
-        on_delete=models.CASCADE
+        on_delete=models.CASCADE,
     )
 
     subject_key_identifier_extension = models.ForeignKey(
@@ -293,7 +282,7 @@ class CertificateModel(LoggerMixin, models.Model):
         editable=False,
         null=True,
         blank=True,
-        on_delete=models.CASCADE
+        on_delete=models.CASCADE,
     )
 
     certificate_policies_extension = models.ForeignKey(
@@ -303,7 +292,7 @@ class CertificateModel(LoggerMixin, models.Model):
         editable=False,
         null=True,
         blank=True,
-        on_delete=models.CASCADE
+        on_delete=models.CASCADE,
     )
 
     extended_key_usage_extension = models.ForeignKey(
@@ -313,7 +302,7 @@ class CertificateModel(LoggerMixin, models.Model):
         editable=False,
         null=True,
         blank=True,
-        on_delete=models.CASCADE
+        on_delete=models.CASCADE,
     )
 
     name_constraints_extension = models.ForeignKey(
@@ -322,7 +311,7 @@ class CertificateModel(LoggerMixin, models.Model):
         editable=False,
         null=True,
         blank=True,
-        on_delete=models.CASCADE
+        on_delete=models.CASCADE,
     )
 
     crl_distribution_points_extension = models.ForeignKey(
@@ -331,47 +320,30 @@ class CertificateModel(LoggerMixin, models.Model):
         editable=False,
         null=True,
         blank=True,
-        on_delete=models.CASCADE
+        on_delete=models.CASCADE,
     )
 
     authority_information_access_extension = models.ForeignKey(
-        AuthorityInformationAccessExtension,
-        null=True, blank=True, on_delete=models.CASCADE
+        AuthorityInformationAccessExtension, null=True, blank=True, on_delete=models.CASCADE
     )
 
     subject_information_access_extension = models.ForeignKey(
-        SubjectInformationAccessExtension,
-        null=True, blank=True, on_delete=models.CASCADE
+        SubjectInformationAccessExtension, null=True, blank=True, on_delete=models.CASCADE
     )
 
     inhibit_any_policy_extension = models.ForeignKey(
-        InhibitAnyPolicyExtension,
-        null=True,
-        blank=True,
-        on_delete=models.CASCADE
+        InhibitAnyPolicyExtension, null=True, blank=True, on_delete=models.CASCADE
     )
 
     policy_constraints_extension = models.ForeignKey(
-        PolicyConstraintsExtension,
-        null=True,
-        blank=True,
-        on_delete=models.CASCADE
+        PolicyConstraintsExtension, null=True, blank=True, on_delete=models.CASCADE
     )
 
     subject_directory_attributes_extension = models.ForeignKey(
-        SubjectDirectoryAttributesExtension,
-        null=True,
-        blank=True,
-        on_delete=models.CASCADE
+        SubjectDirectoryAttributesExtension, null=True, blank=True, on_delete=models.CASCADE
     )
 
-
-    freshest_crl_extension = models.ForeignKey(
-        FreshestCrlExtension,
-        null=True,
-        blank=True,
-        on_delete=models.CASCADE
-    )
+    freshest_crl_extension = models.ForeignKey(FreshestCrlExtension, null=True, blank=True, on_delete=models.CASCADE)
 
     # --------------------------------------------- No Cryptography support -------------------------------------
 
@@ -422,9 +394,7 @@ class CertificateModel(LoggerMixin, models.Model):
         subject = []
         for rdn in cert.subject.rdns:
             for attr_type_and_value in rdn:
-                subject.append(
-                    (attr_type_and_value.oid.dotted_string, attr_type_and_value.value)
-                )
+                subject.append((attr_type_and_value.oid.dotted_string, attr_type_and_value.value))
         return subject
 
     @staticmethod
@@ -432,9 +402,7 @@ class CertificateModel(LoggerMixin, models.Model):
         issuer = []
         for rdn in cert.issuer.rdns:
             for attr_type_and_value in rdn:
-                issuer.append(
-                    (attr_type_and_value.oid.dotted_string, attr_type_and_value.value)
-                )
+                issuer.append((attr_type_and_value.oid.dotted_string, attr_type_and_value.value))
         return issuer
 
     @staticmethod
@@ -501,9 +469,11 @@ class CertificateModel(LoggerMixin, models.Model):
 
         cert_pem = certificate.public_bytes(encoding=serialization.Encoding.PEM).decode()
 
-        public_key_pem = certificate.public_key().public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo).decode()
+        public_key_pem = (
+            certificate.public_key()
+            .public_bytes(encoding=serialization.Encoding.PEM, format=serialization.PublicFormat.SubjectPublicKeyInfo)
+            .decode()
+        )
 
         # ----------------------------------------- Certificate Model Instance -----------------------------------------
 
@@ -524,7 +494,7 @@ class CertificateModel(LoggerMixin, models.Model):
             spki_ec_curve=spki_ec_curve_oid.verbose_name,
             cert_pem=cert_pem,
             public_key_pem=public_key_pem,
-            is_self_signed=is_self_signed
+            is_self_signed=is_self_signed,
         )
 
         # --------------------------------------------- Store in DataBase ----------------------------------------------
@@ -555,58 +525,75 @@ class CertificateModel(LoggerMixin, models.Model):
             attr_type_and_val = cls._save_attribute_and_value_pairs(oid=oid, value=value)
             cert_model.issuer.add(attr_type_and_val)
 
-
     @staticmethod
     def _save_extensions(cert_model: CertificateModel, cert: x509.Certificate) -> None:
         for extension in cert.extensions:
             if isinstance(extension.value, x509.BasicConstraints):
-                cert_model.basic_constraints_extension = \
-                    BasicConstraintsExtension.save_from_crypto_extensions(extension)
+                cert_model.basic_constraints_extension = BasicConstraintsExtension.save_from_crypto_extensions(
+                    extension
+                )
             elif isinstance(extension.value, x509.KeyUsage):
-                cert_model.key_usage_extension = \
-                    KeyUsageExtension.save_from_crypto_extensions(extension)
+                cert_model.key_usage_extension = KeyUsageExtension.save_from_crypto_extensions(extension)
             elif isinstance(extension.value, x509.IssuerAlternativeName):
-                cert_model.issuer_alternative_name_extension = \
+                cert_model.issuer_alternative_name_extension = (
                     IssuerAlternativeNameExtension.save_from_crypto_extensions(extension)
+                )
             elif isinstance(extension.value, x509.SubjectAlternativeName):
-                cert_model.subject_alternative_name_extension = \
+                cert_model.subject_alternative_name_extension = (
                     SubjectAlternativeNameExtension.save_from_crypto_extensions(extension)
+                )
             elif isinstance(extension.value, x509.AuthorityKeyIdentifier):
-                cert_model.authority_key_identifier_extension = \
+                cert_model.authority_key_identifier_extension = (
                     AuthorityKeyIdentifierExtension.save_from_crypto_extensions(extension)
+                )
             elif isinstance(extension.value, x509.SubjectKeyIdentifier):
-                cert_model.subject_key_identifier_extension = \
-                    SubjectKeyIdentifierExtension.save_from_crypto_extensions(extension)
+                cert_model.subject_key_identifier_extension = SubjectKeyIdentifierExtension.save_from_crypto_extensions(
+                    extension
+                )
             elif isinstance(extension.value, x509.CertificatePolicies):
-                cert_model.certificate_policies_extension = CertificatePoliciesExtension.save_from_crypto_extensions(extension)
+                cert_model.certificate_policies_extension = CertificatePoliciesExtension.save_from_crypto_extensions(
+                    extension
+                )
             elif isinstance(extension.value, x509.ExtendedKeyUsage):
-                cert_model.extended_key_usage_extension = ExtendedKeyUsageExtension.save_from_crypto_extensions(extension)
+                cert_model.extended_key_usage_extension = ExtendedKeyUsageExtension.save_from_crypto_extensions(
+                    extension
+                )
             elif isinstance(extension.value, x509.NameConstraints):
                 cert_model.name_constraints_extension = NameConstraintsExtension.save_from_crypto_extensions(extension)
             elif isinstance(extension.value, x509.CRLDistributionPoints):
-                cert_model.crl_distribution_points_extension = CrlDistributionPointsExtension.save_from_crypto_extensions(extension)
+                cert_model.crl_distribution_points_extension = (
+                    CrlDistributionPointsExtension.save_from_crypto_extensions(extension)
+                )
             elif isinstance(extension.value, x509.AuthorityInformationAccess):
-                cert_model.authority_information_access_extension = AuthorityInformationAccessExtension.save_from_crypto_extensions(extension)
+                cert_model.authority_information_access_extension = (
+                    AuthorityInformationAccessExtension.save_from_crypto_extensions(extension)
+                )
             elif isinstance(extension.value, x509.SubjectInformationAccess):
-                cert_model.subject_information_access_extension = SubjectInformationAccessExtension.save_from_crypto_extensions(extension)
+                cert_model.subject_information_access_extension = (
+                    SubjectInformationAccessExtension.save_from_crypto_extensions(extension)
+                )
             elif isinstance(extension.value, x509.InhibitAnyPolicy):
-                cert_model.inhibit_any_policy_extension = InhibitAnyPolicyExtension.save_from_crypto_extensions(extension)
+                cert_model.inhibit_any_policy_extension = InhibitAnyPolicyExtension.save_from_crypto_extensions(
+                    extension
+                )
             # elif isinstance(extension.value, x509.PolicyMappings):  # no x509 PolicyMapping implemented
             #     cert_model.pol = InhibitAnyPolicyExtension.save_from_crypto_extensions(extension)
             elif isinstance(extension.value, x509.PolicyConstraints):
-                cert_model.policy_constraints_extension = PolicyConstraintsExtension.save_from_crypto_extensions(extension)
+                cert_model.policy_constraints_extension = PolicyConstraintsExtension.save_from_crypto_extensions(
+                    extension
+                )
             elif isinstance(extension.value, x509.FreshestCRL):
                 cert_model.freshest_crl_extension = FreshestCrlExtension.save_from_crypto_extensions(extension)
 
     @classmethod
     @transaction.atomic
     def _atomic_save(
-            cls,
-            cert_model: CertificateModel,
-            certificate: x509.Certificate,
-            subject: list[tuple[str, str]],
-            issuer: list[tuple[str, str]]) -> 'CertificateModel':
-
+        cls,
+        cert_model: CertificateModel,
+        certificate: x509.Certificate,
+        subject: list[tuple[str, str]],
+        issuer: list[tuple[str, str]],
+    ) -> 'CertificateModel':
         cert_model._save()
         for oid, value in subject:
             if oid == NameOid.COMMON_NAME.dotted_string:
@@ -654,6 +641,7 @@ class RevokedCertificateModel(models.Model):
 
     class ReasonCode(models.TextChoices):
         """Revocation reasons per RFC 5280"""
+
         UNSPECIFIED = 'unspecified', _('Unspecified')
         KEY_COMPROMISE = 'keyCompromise', _('Key Compromise')
         CA_COMPROMISE = 'cACompromise', _('CA Compromise')
@@ -666,18 +654,13 @@ class RevokedCertificateModel(models.Model):
         REMOVE_FROM_CRL = 'removeFromCRL', _('Remove from CRL')
 
     certificate = models.OneToOneField(
-        CertificateModel,
-        verbose_name=_('Certificate'),
-        related_name='revoked_certificate',
-        on_delete=models.CASCADE
+        CertificateModel, verbose_name=_('Certificate'), related_name='revoked_certificate', on_delete=models.CASCADE
     )
 
     revoked_at = models.DateTimeField(verbose_name=_('Revocation Date'), auto_now_add=True)
 
     revocation_reason = models.TextField(
-        verbose_name=_('Revocation Reason'),
-        choices=ReasonCode,
-        default=ReasonCode.UNSPECIFIED
+        verbose_name=_('Revocation Reason'), choices=ReasonCode, default=ReasonCode.UNSPECIFIED
     )
 
     ca = models.ForeignKey(
@@ -685,7 +668,7 @@ class RevokedCertificateModel(models.Model):
         verbose_name=_('Issuing CA'),
         related_name='revoked_certificates',
         on_delete=models.SET_NULL,  # Safe to remove CRL if CA is removed?
-        null=True
+        null=True,
     )
 
     def __str__(self) -> str:

--- a/trustpoint/pki/models/certificate.py
+++ b/trustpoint/pki/models/certificate.py
@@ -10,6 +10,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519, rsa
 from django.db import models, transaction
 from django.utils.translation import gettext_lazy as _
+from django_stubs_ext.db.models import TypedModelMeta
 
 
 from trustpoint_core.oid import (
@@ -60,6 +61,11 @@ class CertificateModel(LoggerMixin, models.Model):
 
     See RFC5280 for more information.
     """
+
+    objects: models.Manager[CertificateModel]
+
+    class Meta(TypedModelMeta):
+        """Meta class configuration."""
 
     class CertificateStatus(models.TextChoices):
         """CertificateModel status"""
@@ -640,6 +646,11 @@ class CertificateModel(LoggerMixin, models.Model):
 
 class RevokedCertificateModel(models.Model):
     """Model to store revoked certificates."""
+
+    objects: models.Manager[RevokedCertificateModel]
+
+    class Meta(TypedModelMeta):
+        """Meta class configuration."""
 
     class ReasonCode(models.TextChoices):
         """Revocation reasons per RFC 5280"""

--- a/trustpoint/pki/models/devid_registration.py
+++ b/trustpoint/pki/models/devid_registration.py
@@ -7,34 +7,29 @@ from .domain import DomainModel
 
 __all__ = ['DevIdRegistration']
 
+
 class DevIdRegistration(models.Model):
     """Represents a DevID Registration, linking a Truststore, Domain, unique name, and a serial number regex pattern."""
 
     unique_name = models.CharField(
-        verbose_name=_('Unique Name'),
-        max_length=100,
-        unique=True,
-        validators=[UniqueNameValidator()]
+        verbose_name=_('Unique Name'), max_length=100, unique=True, validators=[UniqueNameValidator()]
     )
 
     truststore = models.ForeignKey(
         TruststoreModel,
         on_delete=models.CASCADE,
         verbose_name=_('Associated Truststore'),
-        related_name='devid_registrations'
+        related_name='devid_registrations',
     )
 
     domain = models.ForeignKey(
-        DomainModel,
-        on_delete=models.CASCADE,
-        verbose_name=_('Associated Domain'),
-        related_name='devid_registrations'
+        DomainModel, on_delete=models.CASCADE, verbose_name=_('Associated Domain'), related_name='devid_registrations'
     )
 
     serial_number_pattern = models.CharField(
         verbose_name=_('Serial Number Pattern'),
         max_length=255,
-        help_text=_('A regex pattern to match valid serial numbers for this registration.')
+        help_text=_('A regex pattern to match valid serial numbers for this registration.'),
     )
 
     def __str__(self) -> str:

--- a/trustpoint/pki/models/domain.py
+++ b/trustpoint/pki/models/domain.py
@@ -1,4 +1,5 @@
 """Module that contains the DomainModel."""
+
 from __future__ import annotations
 
 from util.field import UniqueNameValidator
@@ -10,9 +11,7 @@ from django_stubs_ext.db.models import TypedModelMeta
 
 from . import IssuingCaModel
 
-__all__ = [
-    'DomainModel'
-]
+__all__ = ['DomainModel']
 
 
 class DomainModel(models.Model):
@@ -23,11 +22,7 @@ class DomainModel(models.Model):
     class Meta(TypedModelMeta):
         """Meta class configuration."""
 
-    unique_name = models.CharField(
-        _('Domain Name'),
-        max_length=100,
-        unique=True,
-        validators=[UniqueNameValidator()])
+    unique_name = models.CharField(_('Domain Name'), max_length=100, unique=True, validators=[UniqueNameValidator()])
 
     issuing_ca = models.ForeignKey(
         IssuingCaModel,

--- a/trustpoint/pki/models/domain.py
+++ b/trustpoint/pki/models/domain.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from trustpoint_core import oid
+from django_stubs_ext.db.models import TypedModelMeta
 
 from . import IssuingCaModel
 
@@ -16,6 +17,11 @@ __all__ = [
 
 class DomainModel(models.Model):
     """Domain Model."""
+
+    objects: models.Manager[DomainModel]
+
+    class Meta(TypedModelMeta):
+        """Meta class configuration."""
 
     unique_name = models.CharField(
         _('Domain Name'),

--- a/trustpoint/pki/models/extension.py
+++ b/trustpoint/pki/models/extension.py
@@ -1,6 +1,5 @@
 """Module that contains X.509 Extension Models."""
 
-
 from __future__ import annotations
 
 import abc
@@ -17,6 +16,7 @@ if TYPE_CHECKING:
     from typing import Union
 
     from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519, rsa
+
     PrivateKey = Union[rsa.RSAPrivateKey, ec.EllipticCurvePrivateKey, ed448.Ed448PrivateKey, ed25519.Ed25519PrivateKey]
     PublicKey = Union[rsa.RSAPublicKey, ec.EllipticCurvePublicKey, ed448.Ed448PublicKey, ed25519.Ed25519PublicKey]
 
@@ -35,7 +35,7 @@ __all__ = [
     'GeneralNamesModel',
     'IssuerAlternativeNameExtension',
     'KeyUsageExtension',
-    'SubjectAlternativeNameExtension'
+    'SubjectAlternativeNameExtension',
 ]
 
 
@@ -50,13 +50,12 @@ class AttributeTypeAndValue(models.Model):
 
     See RFC5280 for more information.
     """
+
     oid = models.CharField(max_length=256, editable=False, verbose_name='OID')
     value = models.CharField(max_length=16384, editable=False, verbose_name='Value')
 
-
     class Meta:  # noqa: D106
         unique_together = ('oid', 'value')
-
 
     def __str__(self) -> str:
         """Returns a string representation of the attribute type and value."""
@@ -84,6 +83,7 @@ class GeneralNameRFC822Name(models.Model):
 
     See RFC5280 for more information.
     """
+
     value = models.CharField(max_length=1024, editable=False, verbose_name='Value', unique=True)
 
     def __str__(self) -> str:
@@ -96,6 +96,7 @@ class GeneralNameDNSName(models.Model):
 
     See RFC5280 for more information.
     """
+
     value = models.CharField(max_length=1024, editable=False, verbose_name='Value', unique=True)
 
     def __str__(self) -> str:
@@ -110,10 +111,8 @@ class GeneralNameDirectoryName(models.Model):
 
     See RFC5280 for more information.
     """
-    names = models.ManyToManyField(
-        AttributeTypeAndValue,
-        verbose_name=_('Name'),
-        editable=False)
+
+    names = models.ManyToManyField(AttributeTypeAndValue, verbose_name=_('Name'), editable=False)
 
     def __str__(self) -> str:
         """Returns a string representation of the GeneralNameDirectoryName."""
@@ -132,6 +131,7 @@ class GeneralNameUniformResourceIdentifier(models.Model):
 
     See RFC5280 for more information.
     """
+
     value = models.CharField(max_length=16384, editable=False, verbose_name='Value', unique=True)
 
     def __str__(self) -> str:
@@ -146,6 +146,7 @@ class GeneralNameIpAddress(models.Model):
 
     See RFC5280 for more information.
     """
+
     class IpType(models.TextChoices):  # noqa: D106
         IPV4_ADDRESS = 'A4', _('IPv4 Address')
         IPV6_ADDRESS = 'A6', _('IPv6 Address')
@@ -170,6 +171,7 @@ class GeneralNameRegisteredId(models.Model):
 
     See RFC5280 for more information.
     """
+
     value = models.CharField(max_length=256, editable=False, verbose_name='Value')
 
     def __str__(self) -> str:
@@ -184,13 +186,12 @@ class GeneralNameOtherName(models.Model):
 
     See RFC5280 for more information.
     """
+
     type_id = models.CharField(max_length=256, editable=False, verbose_name='OID')
     value = models.CharField(max_length=16384, editable=False, verbose_name='Value')
 
-
     class Meta:  # noqa: D106
         unique_together = ('type_id', 'value')
-
 
     def __str__(self) -> str:
         """Returns a string representation of the GeneralNameOtherName."""
@@ -206,8 +207,7 @@ class CertificateExtension:
 
     @classmethod
     @abc.abstractmethod
-    def save_from_crypto_extensions(cls, extension: x509.Extension) \
-            -> None | CertificateExtension:
+    def save_from_crypto_extensions(cls, extension: x509.Extension) -> None | CertificateExtension:
         """Stores the extension in the database.
 
         Meant to be called within an atomic transaction while storing a certificate.
@@ -225,31 +225,30 @@ class BasicConstraintsExtension(CertificateExtension, models.Model):
 
     This extension indicates whether a certificate is a CA and its path length.
     """
+
     critical = models.BooleanField(verbose_name=_('Critical'), editable=False)
     ca = models.BooleanField(verbose_name=_('CA'), editable=False)
     path_length_constraint = models.PositiveSmallIntegerField(
-        verbose_name=_('Path Length Constraint'),
-        editable=False,
-        null=True,
-        blank=True)
+        verbose_name=_('Path Length Constraint'), editable=False, null=True, blank=True
+    )
 
     class Meta:  # noqa: D106
         unique_together = ('critical', 'ca', 'path_length_constraint')
 
     def __str__(self) -> str:
         """Returns a string representation of the extension."""
-        return (
-            f'BasicConstraintsExtension(critical={self.critical}, '
-            f'oid={self.extension_oid})')
+        return f'BasicConstraintsExtension(critical={self.critical}, oid={self.extension_oid})'
 
     @property
     def extension_oid(self) -> str:  # noqa: D102
         return CertificateExtensionOid.BASIC_CONSTRAINTS.dotted_string
+
     extension_oid.fget.short_description = EXTENSION_STR
 
     @classmethod
-    def save_from_crypto_extensions(cls, crypto_basic_constraints_extension: x509.Extension) \
-            -> None | BasicConstraintsExtension:
+    def save_from_crypto_extensions(
+        cls, crypto_basic_constraints_extension: x509.Extension
+    ) -> None | BasicConstraintsExtension:
         """Stores the BasicConstraintsExtension in the database.
 
         Args:
@@ -263,7 +262,8 @@ class BasicConstraintsExtension(CertificateExtension, models.Model):
             existing_entry = BasicConstraintsExtension.objects.filter(
                 critical=crypto_basic_constraints_extension.critical,
                 ca=crypto_basic_constraints_extension.value.ca,
-                path_length_constraint=crypto_basic_constraints_extension.value.path_length).first()
+                path_length_constraint=crypto_basic_constraints_extension.value.path_length,
+            ).first()
             if existing_entry:
                 return existing_entry
 
@@ -305,23 +305,23 @@ class KeyUsageExtension(CertificateExtension, models.Model):
             'key_cert_sign',
             'crl_sign',
             'encipher_only',
-            'decipher_only')
+            'decipher_only',
+        )
 
     def __str__(self) -> str:
         """Returns a string representation of the extension."""
-        return (
-            f'KeyUsageExtension(critical={self.critical}, '
-            f'oid={self.extension_oid})')
+        return f'KeyUsageExtension(critical={self.critical}, oid={self.extension_oid})'
 
     @property
     def extension_oid(self) -> str:  # noqa: D102
         return CertificateExtensionOid.KEY_USAGE.dotted_string
+
     extension_oid.fget.short_description = EXTENSION_STR
 
-
     @classmethod
-    def save_from_crypto_extensions(cls, crypto_basic_constraints_extension: x509.Extension) \
-            -> None | KeyUsageExtension:
+    def save_from_crypto_extensions(
+        cls, crypto_basic_constraints_extension: x509.Extension
+    ) -> None | KeyUsageExtension:
         """Stores the KeyUsage extension in the database.
 
         Args:
@@ -343,7 +343,8 @@ class KeyUsageExtension(CertificateExtension, models.Model):
                 key_cert_sign=crypto_basic_constraints_extension.value.key_cert_sign,
                 crl_sign=crypto_basic_constraints_extension.value.crl_sign,
                 encipher_only=crypto_basic_constraints_extension.value._encipher_only,
-                decipher_only=crypto_basic_constraints_extension.value._decipher_only).first()
+                decipher_only=crypto_basic_constraints_extension.value._decipher_only,
+            ).first()
             if existing_entry:
                 return existing_entry
 
@@ -375,41 +376,35 @@ class GeneralNamesModel(models.Model):
 
     _alternative_name_extension_type: str
 
-
     rfc822_names = models.ManyToManyField(
-        to=GeneralNameRFC822Name,
-        verbose_name=_('RFC822 Names'),
-        related_name='issuer_alternative_names')
+        to=GeneralNameRFC822Name, verbose_name=_('RFC822 Names'), related_name='issuer_alternative_names'
+    )
 
     dns_names = models.ManyToManyField(
-        GeneralNameDNSName,
-        verbose_name=_('DNS Names'),
-        related_name='issuer_alternative_names')
+        GeneralNameDNSName, verbose_name=_('DNS Names'), related_name='issuer_alternative_names'
+    )
 
     directory_names = models.ManyToManyField(
-        GeneralNameDirectoryName,
-        verbose_name=_('Directory Names'),
-        related_name='issuer_alternative_names')
+        GeneralNameDirectoryName, verbose_name=_('Directory Names'), related_name='issuer_alternative_names'
+    )
 
     uniform_resource_identifiers = models.ManyToManyField(
         GeneralNameUniformResourceIdentifier,
         verbose_name=_('Uniform Resource Identifiers'),
-        related_name='issuer_alternative_names')
+        related_name='issuer_alternative_names',
+    )
 
     ip_addresses = models.ManyToManyField(
-        GeneralNameIpAddress,
-        verbose_name=_('IP Addresses'),
-        related_name='issuer_alternative_names')
+        GeneralNameIpAddress, verbose_name=_('IP Addresses'), related_name='issuer_alternative_names'
+    )
 
     registered_ids = models.ManyToManyField(
-        GeneralNameRegisteredId,
-        verbose_name=_('Registered IDs'),
-        related_name='issuer_alternative_names')
+        GeneralNameRegisteredId, verbose_name=_('Registered IDs'), related_name='issuer_alternative_names'
+    )
 
     other_names = models.ManyToManyField(
-        GeneralNameOtherName,
-        verbose_name=_('Other Names'),
-        related_name='issuer_alternative_names')
+        GeneralNameOtherName, verbose_name=_('Other Names'), related_name='issuer_alternative_names'
+    )
 
     def __str__(self) -> str:
         """Returns a string representation of the GeneralNamesModel."""
@@ -422,13 +417,13 @@ class GeneralNamesModel(models.Model):
             ('URI', self.uniform_resource_identifiers),
             ('IP', self.ip_addresses),
             ('RegisteredID', self.registered_ids),
-            ('OtherName', self.other_names)
+            ('OtherName', self.other_names),
         ]:
             values = [str(name) for name in related_manager.all()]
             if values:
-                parts.append(f"{field_name}: {', '.join(values)}")
+                parts.append(f'{field_name}: {", ".join(values)}')
 
-        return f"GeneralNamesModel({'; '.join(parts)})" if parts else 'GeneralNamesModel(Empty)'
+        return f'GeneralNamesModel({"; ".join(parts)})' if parts else 'GeneralNamesModel(Empty)'
 
     @property
     def extension_oid(self) -> str:  # noqa: D102
@@ -506,10 +501,7 @@ class GeneralNamesModel(models.Model):
         if existing_entry:
             self.other_names.add(existing_entry)
         else:
-            other_name = GeneralNameOtherName(
-                type_id=type_id,
-                value=value
-            )
+            other_name = GeneralNameOtherName(type_id=type_id, value=value)
             other_name.save()
             self.other_names.add(other_name)
         self.save()
@@ -532,10 +524,7 @@ class GeneralNamesModel(models.Model):
 
         directory_name.save()
 
-    def save_general_names(
-            self,
-            general_names: x509.Extension | list[x509.GeneralName]) \
-            -> None | GeneralNamesModel:
+    def save_general_names(self, general_names: x509.Extension | list[x509.GeneralName]) -> None | GeneralNamesModel:
         """Stores general names in the database.
 
         Args:
@@ -572,29 +561,28 @@ class IssuerAlternativeNameExtension(CertificateExtension, models.Model):
 
     See RFC5280 for more information.
     """
+
     critical = models.BooleanField(verbose_name=_('Critical'), editable=False)
     issuer_alt_name = models.ForeignKey(
         GeneralNamesModel,
         on_delete=models.CASCADE,
         null=True,
         blank=True,
-        verbose_name=_('Issuer Alternative Name Issuer')
+        verbose_name=_('Issuer Alternative Name Issuer'),
     )
 
     def __str__(self) -> str:
         """Returns a string representation of the IssuerAlternativeName extension."""
-        return (
-            f'{self.__class__.__name__}(critical={self.critical}, '
-            f'oid={self.extension_oid})')
+        return f'{self.__class__.__name__}(critical={self.critical}, oid={self.extension_oid})'
 
     @property
     def extension_oid(self) -> str:  # noqa: D102
         return CertificateExtensionOid.ISSUER_ALTERNATIVE_NAME.dotted_string
+
     extension_oid.fget.short_description = EXTENSION_STR
 
     @classmethod
-    def save_from_crypto_extensions(cls, extension: x509.Extension) \
-            -> None | IssuerAlternativeNameExtension:
+    def save_from_crypto_extensions(cls, extension: x509.Extension) -> None | IssuerAlternativeNameExtension:
         """Stores the IssuerAlternativeNameExtension in the database.
 
         Meant to be called within an atomic transaction while storing a certificate.
@@ -624,29 +612,28 @@ class SubjectAlternativeNameExtension(CertificateExtension, models.Model):
 
     Stores alternative names for the certificate's subject.
     """
+
     critical = models.BooleanField(verbose_name=_('Critical'), editable=False)
     subject_alt_name = models.ForeignKey(
         GeneralNamesModel,
         on_delete=models.CASCADE,
         null=True,
         blank=True,
-        verbose_name=_('Issuer Alternative Name Issuer')
+        verbose_name=_('Issuer Alternative Name Issuer'),
     )
 
     def __str__(self) -> str:
         """Returns a string representation of the SubjectAlternativeName extension."""
-        return (
-            f'{self.__class__.__name__}(critical={self.critical}, '
-            f'oid={self.extension_oid})')
+        return f'{self.__class__.__name__}(critical={self.critical}, oid={self.extension_oid})'
 
     @property
     def extension_oid(self) -> str:  # noqa: D102
         return CertificateExtensionOid.SUBJECT_ALTERNATIVE_NAME.dotted_string
+
     extension_oid.fget.short_description = EXTENSION_STR
 
     @classmethod
-    def save_from_crypto_extensions(cls, extension: x509.Extension) \
-            -> None | SubjectAlternativeNameExtension:
+    def save_from_crypto_extensions(cls, extension: x509.Extension) -> None | SubjectAlternativeNameExtension:
         """Stores the SubjectAlternativeName extension in the database.
 
         Args:
@@ -677,17 +664,10 @@ class AuthorityKeyIdentifierExtension(CertificateExtension, models.Model):
     _extension_type = 'AuthorityKeyIdentifier'
 
     key_identifier = models.CharField(  # noqa: DJ001
-        max_length=256,
-        editable=False,
-        null=True, blank=True,
-        verbose_name='Key Identifier'
+        max_length=256, editable=False, null=True, blank=True, verbose_name='Key Identifier'
     )
     authority_cert_serial_number = models.CharField(  # noqa: DJ001
-        max_length=256,
-        editable=False,
-        null=True,
-        blank=True,
-        verbose_name='Authority Cert Serial Number'
+        max_length=256, editable=False, null=True, blank=True, verbose_name='Authority Cert Serial Number'
     )
     critical = models.BooleanField(verbose_name=_('Critical'), editable=False)
     authority_cert_issuer = models.ForeignKey(
@@ -695,23 +675,21 @@ class AuthorityKeyIdentifierExtension(CertificateExtension, models.Model):
         on_delete=models.CASCADE,
         null=True,
         blank=True,
-        verbose_name=_('Issuer Alternative Name Issuer')
+        verbose_name=_('Issuer Alternative Name Issuer'),
     )
 
     def __str__(self) -> str:
         """Returns a string representation of the AuthorityKeyIdentifier extension."""
-        return (
-            f'{self._extension_type}(critical={self.critical}, '
-            f'oid={self.extension_oid})')
+        return f'{self._extension_type}(critical={self.critical}, oid={self.extension_oid})'
 
     @property
     def extension_oid(self) -> str:
         return CertificateExtensionOid.AUTHORITY_KEY_IDENTIFIER.dotted_string
+
     extension_oid.fget.short_description = EXTENSION_STR
 
     @classmethod
-    def save_from_crypto_extensions(cls, extension: x509.Extension) \
-            -> None | AuthorityKeyIdentifierExtension:
+    def save_from_crypto_extensions(cls, extension: x509.Extension) -> None | AuthorityKeyIdentifierExtension:
         """Stores the AuthorityKeyIdentifier extension in the database.
 
         Args:
@@ -723,8 +701,9 @@ class AuthorityKeyIdentifierExtension(CertificateExtension, models.Model):
         try:
             aki: x509.AuthorityKeyIdentifier = extension.value
             key_identifier = aki.key_identifier.hex().upper() if aki.key_identifier else None
-            authority_cert_serial_number = hex(aki.authority_cert_serial_number)[2:].upper() \
-                if aki.authority_cert_serial_number else None
+            authority_cert_serial_number = (
+                hex(aki.authority_cert_serial_number)[2:].upper() if aki.authority_cert_serial_number else None
+            )
             gn = None
 
             if aki.authority_cert_issuer:
@@ -736,7 +715,7 @@ class AuthorityKeyIdentifierExtension(CertificateExtension, models.Model):
                 key_identifier=key_identifier,
                 authority_cert_serial_number=authority_cert_serial_number,
                 critical=extension.critical,
-                authority_cert_issuer=gn
+                authority_cert_issuer=gn,
             )
             aki_extension.save()
         except ExtensionNotFound:
@@ -750,15 +729,11 @@ class SubjectKeyIdentifierExtension(CertificateExtension, models.Model):
 
     Stores the Subject Key Identifier (SKI) extension of an X.509 certificate.
     """
+
     # TODO(Anyone): Add critical and storage mechanism
 
     # The key_identifier is a hex-encoded, uppercase string representing the SKI
-    key_identifier = models.CharField(
-        max_length=256,
-        editable=False,
-        verbose_name='Key Identifier',
-        unique=True
-    )
+    key_identifier = models.CharField(max_length=256, editable=False, verbose_name='Key Identifier', unique=True)
 
     def __str__(self) -> str:
         """Returns a string representation of the SubjectKeyIdentifier extension."""
@@ -767,11 +742,11 @@ class SubjectKeyIdentifierExtension(CertificateExtension, models.Model):
     @property
     def extension_oid(self) -> str:
         return CertificateExtensionOid.SUBJECT_KEY_IDENTIFIER.dotted_string
+
     extension_oid.fget.short_description = EXTENSION_STR
 
     @classmethod
-    def save_from_crypto_extensions(cls, extension: x509.Extension) \
-            -> None | SubjectKeyIdentifierExtension:
+    def save_from_crypto_extensions(cls, extension: x509.Extension) -> None | SubjectKeyIdentifierExtension:
         """Stores the SubjectKeyIdentifierExtension in the database.
 
         Meant to be called within an atomic transaction while storing a certificate.
@@ -800,13 +775,10 @@ class SubjectKeyIdentifierExtension(CertificateExtension, models.Model):
 
 class NoticeReference(models.Model):
     """Represents a NoticeReference as per RFC5280."""
+
     organization = models.CharField(max_length=200, editable=False, verbose_name='Organization', null=True, blank=True)  # noqa: DJ001
     notice_numbers = models.CharField(  # noqa: DJ001
-        max_length=1024,
-        editable=False,
-        verbose_name='Notice Numbers',
-        null=True,
-        blank=True
+        max_length=1024, editable=False, verbose_name='Notice Numbers', null=True, blank=True
     )
 
     def __str__(self) -> str:
@@ -816,13 +788,10 @@ class NoticeReference(models.Model):
 
 class UserNotice(models.Model):
     """Represents a UserNotice as per RFC5280."""
+
     notice_ref = models.ForeignKey(NoticeReference, null=True, blank=True, on_delete=models.CASCADE)
-    explicit_text = models.CharField( # noqa: DJ001
-        max_length=200,
-        editable=False,
-        verbose_name='Explicit Text',
-        null=True,
-        blank=True
+    explicit_text = models.CharField(  # noqa: DJ001
+        max_length=200, editable=False, verbose_name='Explicit Text', null=True, blank=True
     )
 
     def __str__(self) -> str:
@@ -832,6 +801,7 @@ class UserNotice(models.Model):
 
 class CPSUriModel(models.Model):
     """Represents a CPS URI as per RFC5280."""
+
     cps_uri = models.CharField(max_length=2048, editable=False, verbose_name='CPS URI')
 
     def __str__(self) -> str:
@@ -841,13 +811,10 @@ class CPSUriModel(models.Model):
 
 class QualifierModel(models.Model):
     """Generic model to represent either a CPS URI or a User Notice."""
+
     cps_uri = models.ForeignKey(CPSUriModel, null=True, blank=True, on_delete=models.CASCADE, related_name='qualifiers')
     user_notice = models.ForeignKey(
-        UserNotice,
-        null=True,
-        blank=True,
-        on_delete=models.CASCADE,
-        related_name='qualifiers'
+        UserNotice, null=True, blank=True, on_delete=models.CASCADE, related_name='qualifiers'
     )
 
     def __str__(self) -> str:
@@ -867,6 +834,7 @@ class QualifierModel(models.Model):
 
 class PolicyQualifierInfo(models.Model):
     """Represents a PolicyQualifierInfo as per RFC5280."""
+
     policy_qualifier_id = models.CharField(max_length=256, editable=False, verbose_name='Policy Qualifier ID')
     qualifier = models.ForeignKey(QualifierModel, null=True, blank=True, on_delete=models.CASCADE)
 
@@ -877,6 +845,7 @@ class PolicyQualifierInfo(models.Model):
 
 class PolicyInformation(models.Model):
     """Model representing PolicyInformation as per RFC5280."""
+
     policy_identifier = models.CharField(max_length=256, editable=False, verbose_name='Policy Identifier')
     policy_qualifiers = models.ManyToManyField(PolicyQualifierInfo, blank=True, related_name='policies', editable=False)
 
@@ -890,22 +859,24 @@ class CertificatePoliciesExtension(CertificateExtension, models.Model):
 
     Stores the certificatePolicies extension as per RFC5280.
     """
+
     critical = models.BooleanField(verbose_name='Critical', editable=False)
     certificate_policies = models.ManyToManyField(
-        PolicyInformation,
-        related_name='certificate_policies',
-        editable=False
+        PolicyInformation, related_name='certificate_policies', editable=False
     )
+
     def __str__(self) -> str:
         """Returns a string representation of the CertificatePolicies extension."""
-        return f'CertificatePoliciesExtension(critical={self.critical}, ' \
-               f'policies={[policy.policy_identifier for policy in self.certificate_policies.all()]})'  # noqa: ISC002
+        return (
+            f'CertificatePoliciesExtension(critical={self.critical}, '
+            f'policies={[policy.policy_identifier for policy in self.certificate_policies.all()]})'
+        )  # noqa: ISC002
 
     @property
     def extension_oid(self) -> str:
         return CertificateExtensionOid.CERTIFICATE_POLICIES.dotted_string
-    extension_oid.fget.short_description = EXTENSION_STR
 
+    extension_oid.fget.short_description = EXTENSION_STR
 
     @classmethod
     def save_from_crypto_extensions(cls, extension: x509.Extension) -> None | CertificatePoliciesExtension:
@@ -941,9 +912,12 @@ class CertificatePoliciesExtension(CertificateExtension, models.Model):
                         user_notice = UserNotice.objects.create(
                             notice_ref=NoticeReference.objects.create(
                                 organization=notice_reference.organization if notice_reference else None,
-                                notice_numbers=','.join(map(str, notice_reference.notice_numbers)) \
-                                    if notice_reference else None,
-                            ) if notice_reference else None,
+                                notice_numbers=','.join(map(str, notice_reference.notice_numbers))
+                                if notice_reference
+                                else None,
+                            )
+                            if notice_reference
+                            else None,
                             explicit_text=qualifier.explicit_text,
                         )
                         qualifier_model = QualifierModel(user_notice=user_notice)
@@ -973,6 +947,7 @@ class CertificatePoliciesExtension(CertificateExtension, models.Model):
 
 class KeyPurposeIdModel(models.Model):
     """Represents a KeyPurposeId (OID) used in Extended Key Usage extension."""
+
     oid = models.CharField(max_length=256, editable=False, verbose_name='Key Purpose OID', unique=True)
 
     def __str__(self) -> str:
@@ -985,6 +960,7 @@ class ExtendedKeyUsageExtension(models.Model):
 
     Specifies additional purposes for which the certified public key may be used.
     """
+
     critical = models.BooleanField(verbose_name='Critical', editable=False)
     key_purpose_ids = models.ManyToManyField(KeyPurposeIdModel, related_name='extended_key_usages', editable=False)
 
@@ -996,7 +972,6 @@ class ExtendedKeyUsageExtension(models.Model):
     @property
     def extension_oid(self) -> str:
         return CertificateExtensionOid.EXTENDED_KEY_USAGE.dotted_string
-
 
     @classmethod
     def save_from_crypto_extensions(cls, extension: x509.Extension) -> None | ExtendedKeyUsageExtension:
@@ -1030,6 +1005,7 @@ class ExtendedKeyUsageExtension(models.Model):
             return None
         return eku_extension
 
+
 class GeneralNameModel(models.Model):
     rfc822_name = models.ForeignKey(GeneralNameRFC822Name, null=True, blank=True, on_delete=models.CASCADE)
     dns_name = models.ForeignKey(GeneralNameDNSName, null=True, blank=True, on_delete=models.CASCADE)
@@ -1050,7 +1026,7 @@ class GeneralNameModel(models.Model):
         if self.dns_name:
             return f'dNSName={self.dns_name.value}'
         if self.directory_name:
-            return f"directoryName={','.join(str(n) for n in self.directory_name.names.all())}"
+            return f'directoryName={",".join(str(n) for n in self.directory_name.names.all())}'
         if self.uri:
             return f'uri={self.uri.value}'
         if self.ip_address:
@@ -1088,9 +1064,7 @@ class GeneralNameModel(models.Model):
             for rdn in gname.value.rdns:
                 for attr in rdn:
                     # Possibly store attribute in your DB
-                    atv = AttributeTypeAndValue.objects.filter(
-                        oid=attr.oid.dotted_string, value=attr.value
-                    ).first()
+                    atv = AttributeTypeAndValue.objects.filter(oid=attr.oid.dotted_string, value=attr.value).first()
                     if not atv:
                         atv = AttributeTypeAndValue(oid=attr.oid.dotted_string, value=attr.value)
                         atv.save()
@@ -1119,9 +1093,7 @@ class GeneralNameModel(models.Model):
         elif isinstance(gname, x509.OtherName):
             # Convert the value to hex
             hex_val = gname.value.hex().upper()
-            obj, _ = GeneralNameOtherName.objects.get_or_create(
-                type_id=gname.type_id.dotted_string, value=hex_val
-            )
+            obj, _ = GeneralNameOtherName.objects.get_or_create(type_id=gname.type_id.dotted_string, value=hex_val)
             gn_model.other_name = obj
 
         else:
@@ -1137,6 +1109,7 @@ class GeneralSubtree(models.Model):  # noqa: DJ008
     Base is a single GeneralName.
     minimum defaults to 0 and maximum is optional.
     """
+
     base = models.ForeignKey(GeneralNameModel, on_delete=models.CASCADE)
 
     minimum = models.PositiveIntegerField(default=0, editable=False)
@@ -1153,14 +1126,15 @@ class NameConstraintsExtension(CertificateExtension, models.Model):
         permitted = [str(subtree) for subtree in self.permitted_subtrees.all()]
         excluded = [str(subtree) for subtree in self.excluded_subtrees.all()]
 
-        permitted_str = f"Permitted: {', '.join(permitted)}" if permitted else 'Permitted: None'
-        excluded_str = f"Excluded: {', '.join(excluded)}" if excluded else 'Excluded: None'
+        permitted_str = f'Permitted: {", ".join(permitted)}' if permitted else 'Permitted: None'
+        excluded_str = f'Excluded: {", ".join(excluded)}' if excluded else 'Excluded: None'
 
         return f'NameConstraintsExtension(critical={self.critical}, {permitted_str}; {excluded_str})'
 
     @property
     def extension_oid(self) -> str:
         return CertificateExtensionOid.NAME_CONSTRAINTS.dotted_string
+
     extension_oid.fget.short_description = EXTENSION_STR
 
     @classmethod
@@ -1204,19 +1178,14 @@ class NameConstraintsExtension(CertificateExtension, models.Model):
 
 
 class DistributionPointName(models.Model):
-    full_name = models.ForeignKey(
-        GeneralNamesModel,
-        on_delete=models.CASCADE,
-        null=True,
-        blank=True
-    )
+    full_name = models.ForeignKey(GeneralNamesModel, on_delete=models.CASCADE, null=True, blank=True)
 
     name_relative_to_crl_issuer = models.ManyToManyField(
         AttributeTypeAndValue,
         verbose_name=_('Name relative to crl issuer'),
         related_name='distribution_point_name',
         editable=False,
-        blank=True
+        blank=True,
     )
 
     def __str__(self) -> str:
@@ -1235,18 +1204,11 @@ class DistributionPointName(models.Model):
 
 class DistributionPointModel(CertificateExtension, models.Model):
     distribution_point_name = models.ForeignKey(
-        DistributionPointName,
-        verbose_name='Distribution Point Name',
-        blank=True,
-        on_delete=models.CASCADE
+        DistributionPointName, verbose_name='Distribution Point Name', blank=True, on_delete=models.CASCADE
     )
     reasons = models.CharField(max_length=16, blank=True, null=True, verbose_name=_('Reasons'))  # noqa: DJ001
     crl_issuer = models.ForeignKey(
-        GeneralNamesModel,
-        on_delete=models.CASCADE,
-        null=True,
-        blank=True,
-        verbose_name=_('CRL Issuer')
+        GeneralNamesModel, on_delete=models.CASCADE, null=True, blank=True, verbose_name=_('CRL Issuer')
     )
 
     mapping: ClassVar[dict[str, int]] = {
@@ -1258,7 +1220,7 @@ class DistributionPointModel(CertificateExtension, models.Model):
         'cessationOfOperation': 5,
         'certificateHold': 6,
         'privilegeWithdrawn': 7,
-        'aACompromise': 8
+        'aACompromise': 8,
     }
 
     def __str__(self) -> str:
@@ -1292,7 +1254,6 @@ class DistributionPointModel(CertificateExtension, models.Model):
                 reasons.append(reverse_mapping[i])
         return reasons
 
-
     @classmethod
     def parse_distribution_points(cls, extension: x509.Extension) -> list[DistributionPointModel]:
         """Parses and stores DistributionPoints from an x509.Extension.
@@ -1321,10 +1282,7 @@ class DistributionPointModel(CertificateExtension, models.Model):
                 dpn.save()
             elif dp.relative_name:
                 for atv in dp.relative_name:
-                    attr, _ = AttributeTypeAndValue.objects.get_or_create(
-                        oid=atv.oid.dotted_string,
-                        value=atv.value
-                    )
+                    attr, _ = AttributeTypeAndValue.objects.get_or_create(oid=atv.oid.dotted_string, value=atv.value)
                     dpn.name_relative_to_crl_issuer.add(attr)
                 dpn.save()
 
@@ -1359,9 +1317,7 @@ class DistributionPointModel(CertificateExtension, models.Model):
                 # reasons_list = cls.reasons_list_to_bitstring(dp.reasons)"""
 
             dp_model, _created = DistributionPointModel.objects.get_or_create(
-                distribution_point_name=dpn,
-                reasons=reasons_list,
-                crl_issuer=crl_issuer
+                distribution_point_name=dpn, reasons=reasons_list, crl_issuer=crl_issuer
             )
             distribution_points.append(dp_model)
 
@@ -1373,12 +1329,9 @@ class CrlDistributionPointsExtension(CertificateExtension, models.Model):
 
     Specifies where to retrieve CRLs related to the certificate.
     """
+
     critical = models.BooleanField(verbose_name=_('Critical'), editable=False)
-    distribution_points = models.ManyToManyField(
-        DistributionPointModel,
-        verbose_name='Distribution Points',
-        blank=True
-    )
+    distribution_points = models.ManyToManyField(DistributionPointModel, verbose_name='Distribution Points', blank=True)
 
     def __str__(self) -> str:
         """Returns a string representation of the extension."""
@@ -1387,8 +1340,8 @@ class CrlDistributionPointsExtension(CertificateExtension, models.Model):
     @property
     def extension_oid(self) -> str:
         return CertificateExtensionOid.CRL_DISTRIBUTION_POINTS.dotted_string
-    extension_oid.fget.short_description = EXTENSION_STR
 
+    extension_oid.fget.short_description = EXTENSION_STR
 
     @classmethod
     def save_from_crypto_extensions(cls, extension: x509.Extension) -> CrlDistributionPointsExtension | None:
@@ -1411,6 +1364,7 @@ class CrlDistributionPointsExtension(CertificateExtension, models.Model):
         ext_instance.save()
         return ext_instance
 
+
 class AccessDescriptionModel(CertificateExtension, models.Model):
     access_method = models.CharField(max_length=256, editable=False, verbose_name='Access Method OID')
     access_location = models.ForeignKey(GeneralNameModel, verbose_name='Access Location', on_delete=models.CASCADE)
@@ -1423,9 +1377,7 @@ class AccessDescriptionModel(CertificateExtension, models.Model):
 class AuthorityInformationAccessExtension(CertificateExtension, models.Model):
     critical = models.BooleanField(verbose_name='Critical', editable=False)
     authority_info_access_syntax = models.ManyToManyField(
-        AccessDescriptionModel,
-        related_name='authority_info_access_syntax',
-        blank=True
+        AccessDescriptionModel, related_name='authority_info_access_syntax', blank=True
     )
 
     def __str__(self) -> str:
@@ -1434,8 +1386,8 @@ class AuthorityInformationAccessExtension(CertificateExtension, models.Model):
     @property
     def extension_oid(self) -> str:
         return CertificateExtensionOid.AUTHORITY_INFORMATION_ACCESS.dotted_string
-    extension_oid.fget.short_description = EXTENSION_STR
 
+    extension_oid.fget.short_description = EXTENSION_STR
 
     @classmethod
     def save_from_crypto_extensions(cls, extension: x509.Extension) -> AuthorityInformationAccessExtension | None:
@@ -1466,11 +1418,10 @@ class AuthorityInformationAccessExtension(CertificateExtension, models.Model):
 
 class SubjectInformationAccessExtension(CertificateExtension, models.Model):
     """Represents the SubjectInformationAccess extension (SIA)."""
+
     critical = models.BooleanField(verbose_name='Critical', editable=False)
     subject_info_access_syntax = models.ManyToManyField(
-        AccessDescriptionModel,
-        related_name='subject_info_access_syntax',
-        blank=True
+        AccessDescriptionModel, related_name='subject_info_access_syntax', blank=True
     )
 
     def __str__(self) -> str:
@@ -1480,6 +1431,7 @@ class SubjectInformationAccessExtension(CertificateExtension, models.Model):
     @property
     def extension_oid(self) -> str:
         return CertificateExtensionOid.SUBJECT_INFORMATION_ACCESS.dotted_string
+
     extension_oid.fget.short_description = EXTENSION_STR
 
     @classmethod
@@ -1508,18 +1460,17 @@ class SubjectInformationAccessExtension(CertificateExtension, models.Model):
         sia_ext.save()
         return sia_ext
 
+
 class InhibitAnyPolicyExtension(CertificateExtension, models.Model):
     """Represents the InhibitAnyPolicy extension in X.509 certificates.
 
     This extension specifies the number of additional certificates that may appear
     in the path before an explicit policy is required.
     """
+
     critical = models.BooleanField(verbose_name='Critical', editable=False)
     inhibit_any_policy = models.PositiveIntegerField(
-        blank=True,
-        null=True,
-        verbose_name='InhibitAnyPolicy',
-        editable=False
+        blank=True, null=True, verbose_name='InhibitAnyPolicy', editable=False
     )
 
     def __str__(self) -> str:
@@ -1532,6 +1483,7 @@ class InhibitAnyPolicyExtension(CertificateExtension, models.Model):
     @property
     def extension_oid(self) -> str:
         return CertificateExtensionOid.INHIBIT_ANY_POLICY.dotted_string
+
     extension_oid.fget.short_description = EXTENSION_STR
 
     @classmethod
@@ -1554,16 +1506,9 @@ class PolicyMappingModel(models.Model):
 
     Each mapping includes an issuerDomainPolicy and a subjectDomainPolicy.
     """
-    issuer_domain_policy = models.CharField(
-        max_length=256,
-        verbose_name='Issuer Domain Policy OID',
-        editable=False
-    )
-    subject_domain_policy = models.CharField(
-        max_length=256,
-        verbose_name='Subject Domain Policy OID',
-        editable=False
-    )
+
+    issuer_domain_policy = models.CharField(max_length=256, verbose_name='Issuer Domain Policy OID', editable=False)
+    subject_domain_policy = models.CharField(max_length=256, verbose_name='Subject Domain Policy OID', editable=False)
 
     class Meta:
         unique_together = ('issuer_domain_policy', 'subject_domain_policy')
@@ -1576,9 +1521,7 @@ class PolicyMappingModel(models.Model):
 class PolicyMappingsExtension(CertificateExtension, models.Model):
     critical = models.BooleanField(verbose_name='Critical', editable=False)
     policy_mappings = models.ManyToManyField(
-        PolicyMappingModel,
-        related_name='policy_mappings_extension',
-        editable=False
+        PolicyMappingModel, related_name='policy_mappings_extension', editable=False
     )
 
     def __str__(self) -> str:
@@ -1591,6 +1534,7 @@ class PolicyMappingsExtension(CertificateExtension, models.Model):
     @property
     def extension_oid(self) -> str:
         return CertificateExtensionOid.POLICY_MAPPINGS.dotted_string
+
     extension_oid.fget.short_description = EXTENSION_STR
 
     @classmethod
@@ -1616,8 +1560,7 @@ class PolicyMappingsExtension(CertificateExtension, models.Model):
                 subject_policy = mapping.subject_domain_policy.dotted_string
 
                 policy_mapping, _ = PolicyMappingModel.objects.get_or_create(
-                    issuer_domain_policy=issuer_policy,
-                    subject_domain_policy=subject_policy
+                    issuer_domain_policy=issuer_policy, subject_domain_policy=subject_policy
                 )
                 mappings_ext.policy_mappings.add(policy_mapping)
 
@@ -1632,18 +1575,13 @@ class PolicyConstraintsExtension(CertificateExtension, models.Model):
 
     This extension specifies whether an explicit policy is required and whether policy mapping is inhibited.
     """
+
     critical = models.BooleanField(verbose_name='Critical', editable=False)
     require_explicit_policy = models.PositiveIntegerField(
-        blank=True,
-        null=True,
-        verbose_name='requireExplicitPolicy',
-        editable=False
+        blank=True, null=True, verbose_name='requireExplicitPolicy', editable=False
     )
     inhibit_policy_mapping = models.PositiveIntegerField(
-        blank=True,
-        null=True,
-        verbose_name='inhibitPolicyMapping',
-        editable=False
+        blank=True, null=True, verbose_name='inhibitPolicyMapping', editable=False
     )
 
     def __str__(self) -> str:
@@ -1657,6 +1595,7 @@ class PolicyConstraintsExtension(CertificateExtension, models.Model):
     @property
     def extension_oid(self) -> str:
         return CertificateExtensionOid.POLICY_CONSTRAINTS.dotted_string
+
     extension_oid.fget.short_description = EXTENSION_STR
 
     @classmethod
@@ -1677,7 +1616,7 @@ class PolicyConstraintsExtension(CertificateExtension, models.Model):
             policy_constraint_ext = cls(
                 critical=extension.critical,
                 require_explicit_policy=extension.value.require_explicit_policy,
-                inhibit_policy_mapping=extension.value.inhibit_policy_mapping
+                inhibit_policy_mapping=extension.value.inhibit_policy_mapping,
             )
             policy_constraint_ext.save()
         except x509.ExtensionNotFound:
@@ -1690,12 +1629,10 @@ class SubjectDirectoryAttributesExtension(CertificateExtension, models.Model):
 
     This extension contains additional subject attributes, such as date of birth or place of birth.
     """
+
     critical = models.BooleanField(verbose_name='Critical', editable=False)
-    subject_directory_attributes  = models.ManyToManyField(
-        AttributeTypeAndValue,
-        verbose_name=_('Subject Directory Attributes'),
-        editable=False,
-        blank=True
+    subject_directory_attributes = models.ManyToManyField(
+        AttributeTypeAndValue, verbose_name=_('Subject Directory Attributes'), editable=False, blank=True
     )
 
     def __str__(self) -> str:
@@ -1706,6 +1643,7 @@ class SubjectDirectoryAttributesExtension(CertificateExtension, models.Model):
     @property
     def extension_oid(self) -> str:
         return CertificateExtensionOid.SUBJECT_DIRECTORY_ATTRIBUTES.dotted_string
+
     extension_oid.fget.short_description = EXTENSION_STR
 
     @classmethod
@@ -1744,6 +1682,7 @@ class FreshestCrlExtension(CertificateExtension, models.Model):
 
     Specifies the location of the freshest CRL available for a certificate.
     """
+
     critical = models.BooleanField(verbose_name='Critical', editable=False)
     distribution_points = models.ManyToManyField(DistributionPointModel, blank=True)
 

--- a/trustpoint/pki/models/issuing_ca.py
+++ b/trustpoint/pki/models/issuing_ca.py
@@ -1,4 +1,5 @@
 """Module that contains the IssuingCaModel."""
+
 from __future__ import annotations
 
 import datetime
@@ -20,6 +21,7 @@ from trustpoint.views.base import LoggerMixin
 if TYPE_CHECKING:
     from trustpoint_core.serializer import CredentialSerializer
 
+
 class IssuingCaModel(LoggerMixin, models.Model):
     """Issuing CA Model.
 
@@ -32,6 +34,7 @@ class IssuingCaModel(LoggerMixin, models.Model):
         Depending on the type other fields may be set, e.g. a credential will only be available for local
         Issuing CAs.
         """
+
         AUTOGEN_ROOT = 0, _('Auto-Generated Root')
         AUTOGEN = 1, _('Auto-Generated')
         LOCAL_UNPROTECTED = 2, _('Local-Unprotected')
@@ -40,16 +43,12 @@ class IssuingCaModel(LoggerMixin, models.Model):
         REMOTE_CMP = 5, _('Remote-CMP')
 
     unique_name = models.CharField(
-        verbose_name=_('Issuing CA Name'),
-        max_length=100,
-        validators=[UniqueNameValidator()],
-        unique=True)
+        verbose_name=_('Issuing CA Name'), max_length=100, validators=[UniqueNameValidator()], unique=True
+    )
     credential = models.OneToOneField(CredentialModel, related_name='issuing_cas', on_delete=models.PROTECT)
 
     issuing_ca_type = models.IntegerField(
-        verbose_name=_('Issuing CA Type'),
-        choices=IssuingCaTypeChoice,
-        null=False, blank=False
+        verbose_name=_('Issuing CA Type'), choices=IssuingCaTypeChoice, null=False, blank=False
     )
 
     is_active = models.BooleanField(
@@ -82,10 +81,11 @@ class IssuingCaModel(LoggerMixin, models.Model):
     @classmethod
     @LoggerMixin.log_exceptions
     def create_new_issuing_ca(
-            cls,
-            unique_name: str,
-            credential_serializer: CredentialSerializer,
-            issuing_ca_type: IssuingCaModel.IssuingCaTypeChoice) -> IssuingCaModel:
+        cls,
+        unique_name: str,
+        credential_serializer: CredentialSerializer,
+        issuing_ca_type: IssuingCaModel.IssuingCaTypeChoice,
+    ) -> IssuingCaModel:
         """Creates a new Issuing CA model and returns it.
 
         Args:
@@ -102,7 +102,7 @@ class IssuingCaModel(LoggerMixin, models.Model):
             cls.IssuingCaTypeChoice.AUTOGEN_ROOT,
             cls.IssuingCaTypeChoice.AUTOGEN,
             cls.IssuingCaTypeChoice.LOCAL_UNPROTECTED,
-            cls.IssuingCaTypeChoice.LOCAL_PKCS11
+            cls.IssuingCaTypeChoice.LOCAL_PKCS11,
         )
         if issuing_ca_type in issuing_ca_types:
             credential_type = CredentialModel.CredentialTypeChoice.ISSUING_CA
@@ -111,8 +111,7 @@ class IssuingCaModel(LoggerMixin, models.Model):
             raise ValueError(exc_msg)
 
         credential_model = CredentialModel.save_credential_serializer(
-            credential_serializer=credential_serializer,
-            credential_type=credential_type
+            credential_serializer=credential_serializer, credential_type=credential_type
         )
 
         issuing_ca = cls(
@@ -136,17 +135,17 @@ class IssuingCaModel(LoggerMixin, models.Model):
             crl_builder = x509.CertificateRevocationListBuilder(
                 issuer_name=ca_subject,
                 last_update=crl_issued_at,
-                next_update=crl_issued_at + datetime.timedelta(hours=24) #(minutes=self.next_crl_generation_time)
+                next_update=crl_issued_at + datetime.timedelta(hours=24),  # (minutes=self.next_crl_generation_time)
             )
 
             crl_certificates = self.revoked_certificates.all()
 
             for cert in crl_certificates:
-                revoked_cert = (x509.RevokedCertificateBuilder()
+                revoked_cert = (
+                    x509.RevokedCertificateBuilder()
                     .serial_number(int(cert.certificate.serial_number, 16))
                     .revocation_date(cert.revoked_at)
-                    .add_extension(x509.CRLReason(
-                        x509.ReasonFlags(cert.revocation_reason)), critical=False)
+                    .add_extension(x509.CRLReason(x509.ReasonFlags(cert.revocation_reason)), critical=False)
                     .build()
                 )
                 crl_builder = crl_builder.add_revoked_certificate(revoked_cert)
@@ -155,10 +154,7 @@ class IssuingCaModel(LoggerMixin, models.Model):
 
             priv_k = self.credential.get_private_key_serializer().as_crypto()
 
-            crl = crl_builder.sign(
-                private_key=priv_k,
-                algorithm=hash_algorithm
-            )
+            crl = crl_builder.sign(private_key=priv_k, algorithm=hash_algorithm)
 
             self.crl_pem = crl.public_bytes(encoding=serialization.Encoding.PEM).decode()
             self.save()
@@ -183,17 +179,14 @@ class IssuingCaModel(LoggerMixin, models.Model):
         # Note: This goes through all active certificates and checks issuance by this CA based on cert.issuer_public_bytes == ca.subject_public_bytes
         # WARNING: This means that it may inadvertently revoke certificates that were issued by a different CA with the same subject name
         ca_subject_public_bytes = self.credential.certificate.subject_public_bytes
-        qs = CertificateModel.objects.filter(issuer_public_bytes=ca_subject_public_bytes) \
-                                     .exclude(subject_public_bytes=ca_subject_public_bytes) # do not self-revoke self-signed CA certificate
+        qs = CertificateModel.objects.filter(issuer_public_bytes=ca_subject_public_bytes).exclude(
+            subject_public_bytes=ca_subject_public_bytes
+        )  # do not self-revoke self-signed CA certificate
 
         for cert in qs:
             if cert.certificate_status != CertificateModel.CertificateStatus.OK:
                 continue
-            RevokedCertificateModel.objects.create(
-                certificate=cert,
-                revocation_reason=reason,
-                ca=self
-            )
+            RevokedCertificateModel.objects.create(certificate=cert, revocation_reason=reason, ca=self)
 
         self.logger.info('All %i certificates issued by CA %s have been revoked.', qs.count(), self.unique_name)
         self.issue_crl()

--- a/trustpoint/pki/models/truststore.py
+++ b/trustpoint/pki/models/truststore.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from trustpoint_core.serializer import CertificateSerializer, CertificateCollectionSerializer
+from trustpoint_core.serializer import CertificateCollectionSerializer
+from django_stubs_ext.db.models import TypedModelMeta
 from util.field import UniqueNameValidator
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -25,6 +26,12 @@ class TrustpointTlsServerCredentialModel(models.Model):
     communication, storing the private key and linking it to a specific
     certificate.
     """
+
+    objects: models.Manager[TrustpointTlsServerCredentialModel]
+
+    class Meta(TypedModelMeta):
+        """Meta class configuration."""
+
     private_key_pem = models.CharField(verbose_name=_('Private Key (PEM)'), max_length=65536, editable=False)
     certificate = models.ForeignKey(CertificateModel, on_delete=models.CASCADE)
 
@@ -43,6 +50,12 @@ class ActiveTrustpointTlsServerCredentialModel(models.Model):
     This model tracks the active server credential, ensuring that it is always
     up-to-date and linked to a specific `TrustpointTlsServerCredentialModel` instance.
     """
+
+    objects: models.Manager[ActiveTrustpointTlsServerCredentialModel]
+
+    class Meta(TypedModelMeta):
+        """Meta class configuration."""
+
     credential = models.ForeignKey(
         TrustpointTlsServerCredentialModel,
         on_delete=models.CASCADE,
@@ -79,6 +92,11 @@ class TruststoreModel(models.Model):
     by a unique name and supports operations like retrieving the number of certificates
     or serializing its content.
     """
+
+    class Meta(TypedModelMeta):
+        """Meta class configuration."""
+
+    objects: models.Manager[TruststoreModel]
 
     class IntendedUsage(models.IntegerChoices):
         """Intended Usage of the Truststore."""
@@ -136,9 +154,14 @@ class TruststoreModel(models.Model):
         )
 
 
-
 class TruststoreOrderModel(models.Model):
     """Represents the order of certificates in a truststore."""
+
+    objects: models.Manager[TruststoreOrderModel]
+
+    class Meta(TypedModelMeta):
+        """Meta class configuration."""
+        unique_together = ('order', 'trust_store')
 
     order = models.PositiveSmallIntegerField(
         verbose_name=_('Trust Store Certificate Index (Order)'),
@@ -156,9 +179,6 @@ class TruststoreOrderModel(models.Model):
         editable=False
     )
 
-    class Meta:
-        """Meta options for TruststoreOrderModel."""
-        unique_together = ('order', 'trust_store')
 
     def __str__(self) -> str:
         """Returns a human-readable string representation of the TruststoreOrderModel."""

--- a/trustpoint/pki/models/truststore.py
+++ b/trustpoint/pki/models/truststore.py
@@ -14,9 +14,8 @@ __all__ = [
     'TrustpointTlsServerCredentialModel',
     'ActiveTrustpointTlsServerCredentialModel',
     'TruststoreModel',
-    'TruststoreOrderModel'
+    'TruststoreOrderModel',
 ]
-
 
 
 class TrustpointTlsServerCredentialModel(models.Model):
@@ -56,12 +55,7 @@ class ActiveTrustpointTlsServerCredentialModel(models.Model):
     class Meta(TypedModelMeta):
         """Meta class configuration."""
 
-    credential = models.ForeignKey(
-        TrustpointTlsServerCredentialModel,
-        on_delete=models.CASCADE,
-        blank=True,
-        null=True
-    )
+    credential = models.ForeignKey(TrustpointTlsServerCredentialModel, on_delete=models.CASCADE, blank=True, null=True)
 
     def __str__(self) -> str:
         """Returns a human-readable string representation of the active credential.
@@ -69,7 +63,7 @@ class ActiveTrustpointTlsServerCredentialModel(models.Model):
         Returns:
             str: Description of the active TLS server credential.
         """
-        return f"Active TLS Credential: {self.credential.id if self.credential else 'None'}"
+        return f'Active TLS Credential: {self.credential.id if self.credential else "None"}'
 
     def save(self, *args: tuple, **kwargs: dict) -> None:
         """Ensures the model instance always has an ID of 1 to enforce singleton-like behavior.
@@ -83,6 +77,7 @@ class ActiveTrustpointTlsServerCredentialModel(models.Model):
         """
         self.id = 1
         super().save(*args, **kwargs)
+
 
 class TruststoreModel(models.Model):
     """Represents a truststore, which is a collection of certificates used for specific purposes.
@@ -106,22 +101,16 @@ class TruststoreModel(models.Model):
         GENERIC = 2, _('Generic')
 
     unique_name = models.CharField(
-        verbose_name=_('Unique Name'),
-        max_length=100,
-        validators=[UniqueNameValidator()],
-        unique=True
+        verbose_name=_('Unique Name'), max_length=100, validators=[UniqueNameValidator()], unique=True
     )
 
     certificates = models.ManyToManyField(
-        to=CertificateModel,
-        verbose_name=_('Truststore certificates'),
-        through='TruststoreOrderModel')
+        to=CertificateModel, verbose_name=_('Truststore certificates'), through='TruststoreOrderModel'
+    )
 
     intended_usage = models.IntegerField(
-        verbose_name=_('Intended Usage'),
-        choices=IntendedUsage,
-        null=False,
-        blank=False)
+        verbose_name=_('Intended Usage'), choices=IntendedUsage, null=False, blank=False
+    )
 
     created_at = models.DateTimeField(verbose_name=_('Created-At'), auto_now_add=True)
 
@@ -161,24 +150,14 @@ class TruststoreOrderModel(models.Model):
 
     class Meta(TypedModelMeta):
         """Meta class configuration."""
+
         unique_together = ('order', 'trust_store')
 
-    order = models.PositiveSmallIntegerField(
-        verbose_name=_('Trust Store Certificate Index (Order)'),
-                                             editable=False
-    )
+    order = models.PositiveSmallIntegerField(verbose_name=_('Trust Store Certificate Index (Order)'), editable=False)
     certificate = models.ForeignKey(
-        CertificateModel,
-        on_delete=models.CASCADE,
-        editable=False,
-        related_name='trust_store_components'
+        CertificateModel, on_delete=models.CASCADE, editable=False, related_name='trust_store_components'
     )
-    trust_store = models.ForeignKey(
-        TruststoreModel,
-        on_delete=models.CASCADE,
-        editable=False
-    )
-
+    trust_store = models.ForeignKey(TruststoreModel, on_delete=models.CASCADE, editable=False)
 
     def __str__(self) -> str:
         """Returns a human-readable string representation of the TruststoreOrderModel."""

--- a/trustpoint/pki/tests/conftest.py
+++ b/trustpoint/pki/tests/conftest.py
@@ -1,4 +1,5 @@
 """pytest configuration for the tests in the PKI app."""
+
 import pytest
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 
@@ -6,13 +7,14 @@ from cryptography.hazmat.primitives.asymmetric import ec, rsa
 @pytest.fixture(autouse=True)
 def enable_db_access_for_all_tests(db: None) -> None:
     """Fixture to enable database access for all tests."""
-    
- 
+
+
 # ----------------------------
 # RSA Private Key Fixture
 # ----------------------------
 
-@pytest.fixture(scope="function")
+
+@pytest.fixture(scope='function')
 def rsa_private_key() -> rsa.RSAPrivateKey:
     """Generate a reusable RSA private key."""
     return rsa.generate_private_key(
@@ -20,11 +22,13 @@ def rsa_private_key() -> rsa.RSAPrivateKey:
         key_size=2048,
     )
 
+
 # ----------------------------
 # EC Private Key Fixture
 # ----------------------------
 
-@pytest.fixture(scope="function")
+
+@pytest.fixture(scope='function')
 def ec_private_key() -> ec.EllipticCurvePrivateKey:
     """Generate a reusable EC private key."""
     return ec.generate_private_key(ec.SECP256R1())

--- a/trustpoint/pki/tests/fixtures.py
+++ b/trustpoint/pki/tests/fixtures.py
@@ -52,16 +52,19 @@ from pki.tests import (
 # Basic Self-Signed Certificate Fixture
 # ----------------------------
 
-@pytest.fixture(scope="function")
+
+@pytest.fixture(scope='function')
 def self_signed_cert_basic(rsa_private_key) -> CertificateModel:
     """Creates a self-signed CA certificate with minimal extensions and saves it to the database once per module.
 
     We manually unblock the DB because this fixture has 'module' scope.
     """
-    subject = x509.Name([
-        x509.NameAttribute(NameOID.COMMON_NAME, COMMON_NAME),
-        x509.NameAttribute(NameOID.COUNTRY_NAME, COUNTRY_NAME),
-    ])
+    subject = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COMMON_NAME, COMMON_NAME),
+            x509.NameAttribute(NameOID.COUNTRY_NAME, COUNTRY_NAME),
+        ]
+    )
     issuer = subject
     now = datetime.now(timezone.utc)
 
@@ -82,17 +85,21 @@ def self_signed_cert_basic(rsa_private_key) -> CertificateModel:
     cert_model = CertificateModel.save_certificate(cert)
     return (cert_model, cert)
 
+
 # ----------------------------
 # Self-Signed Certificate with Extensions Fixture
 # ----------------------------
 
-@pytest.fixture(scope="function")
+
+@pytest.fixture(scope='function')
 def self_signed_cert_with_ext(rsa_private_key) -> x509.Certificate:
     """Create a self-signed certificate with multiple extensions."""
-    subject = x509.Name([
-        x509.NameAttribute(NameOID.COMMON_NAME, COMMON_NAME),
-        x509.NameAttribute(NameOID.COUNTRY_NAME, COUNTRY_NAME),
-    ])
+    subject = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COMMON_NAME, COMMON_NAME),
+            x509.NameAttribute(NameOID.COUNTRY_NAME, COUNTRY_NAME),
+        ]
+    )
     issuer = subject
     now = datetime.now(timezone.utc)
 
@@ -100,101 +107,95 @@ def self_signed_cert_with_ext(rsa_private_key) -> x509.Certificate:
     rfc822_name = RFC822Name(RFC822_EMAIL)
     dns_name = DNSName(DNS_NAME_VALUE)
     uri = UniformResourceIdentifier(URI_VALUE)
-    directory_name = DirectoryName(
-        x509.Name([x509.NameAttribute(NameOID.ORGANIZATION_NAME, ORGANIZATION_NAME)])
-    )
+    directory_name = DirectoryName(x509.Name([x509.NameAttribute(NameOID.ORGANIZATION_NAME, ORGANIZATION_NAME)]))
     registered_id = RegisteredID(ObjectIdentifier(REGISTERED_ID_OID))
     ip_addr = IPAddress(ipaddress.ip_address(IP_ADDRESS_VALUE))
 
     other_name_content = char.UTF8String(OTHER_NAME_CONTENT)
     other_name_der = encode(other_name_content)
-    other_name = OtherName(
-        type_id=ObjectIdentifier(OTHER_NAME_OID),
-        value=other_name_der
-    )
+    other_name = OtherName(type_id=ObjectIdentifier(OTHER_NAME_OID), value=other_name_der)
 
     serial_number = x509.random_serial_number()
 
-    san = SubjectAlternativeName([
-        rfc822_name, dns_name, uri, directory_name, registered_id, ip_addr, other_name
-    ])
-    ian = IssuerAlternativeName([
-        rfc822_name, dns_name, uri, directory_name, registered_id, ip_addr, other_name
-    ])
+    san = SubjectAlternativeName([rfc822_name, dns_name, uri, directory_name, registered_id, ip_addr, other_name])
+    ian = IssuerAlternativeName([rfc822_name, dns_name, uri, directory_name, registered_id, ip_addr, other_name])
 
     key_usage = KeyUsage(**KEY_USAGE_FLAGS)
 
     public_key = rsa_private_key.public_key()
     public_key_bytes = public_key.public_bytes(
-        encoding=serialization.Encoding.DER,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo
+        encoding=serialization.Encoding.DER, format=serialization.PublicFormat.SubjectPublicKeyInfo
     )
     key_identifier = hashlib.sha1(public_key_bytes).digest()
 
     aki = AuthorityKeyIdentifier(
         key_identifier=key_identifier,
         authority_cert_issuer=[rfc822_name, dns_name, uri, directory_name, registered_id, ip_addr, other_name],
-        authority_cert_serial_number=serial_number
+        authority_cert_serial_number=serial_number,
     )
     ski = SubjectKeyIdentifier(digest=key_identifier)
 
-    cp = x509.CertificatePolicies([
-        PolicyInformation(
-            policy_identifier=ObjectIdentifier("2.23.140.1.1"),
-            policy_qualifiers=[
-                "https://example-ev-certs.com/cps",
-                UserNotice(
-                    notice_reference=NoticeReference(
-                        organization="Example EV Certification Authority",
-                        notice_numbers=[1, 2]
+    cp = x509.CertificatePolicies(
+        [
+            PolicyInformation(
+                policy_identifier=ObjectIdentifier('2.23.140.1.1'),
+                policy_qualifiers=[
+                    'https://example-ev-certs.com/cps',
+                    UserNotice(
+                        notice_reference=NoticeReference(
+                            organization='Example EV Certification Authority', notice_numbers=[1, 2]
+                        ),
+                        explicit_text="EV certificates issued under Example EV CA's CP/CPS.",
                     ),
-                    explicit_text="EV certificates issued under Example EV CA's CP/CPS."
-                ),
-            ],
-        ),
-        x509.PolicyInformation(
-            policy_identifier=x509.ObjectIdentifier("2.23.140.1.2.1"),
-            policy_qualifiers=[
-                'https://example-dv-certs.com/cps',
-                x509.UserNotice(
-                    notice_reference=None,
-                    explicit_text='DV certificates issued with minimal identity validation.'
-                )
-            ]
-        )
-    ])
-
-    eku = ExtendedKeyUsage([
-        ExtendedKeyUsageOID.SERVER_AUTH,
-        ExtendedKeyUsageOID.CLIENT_AUTH,
-        ExtendedKeyUsageOID.CODE_SIGNING,
-        ExtendedKeyUsageOID.EMAIL_PROTECTION,
-        ExtendedKeyUsageOID.TIME_STAMPING,
-        ExtendedKeyUsageOID.OCSP_SIGNING,
-    ])
-
-    name_constraints = NameConstraints(
-        permitted_subtrees=[rfc822_name, dns_name, uri],
-        excluded_subtrees=[directory_name, registered_id, other_name]
+                ],
+            ),
+            x509.PolicyInformation(
+                policy_identifier=x509.ObjectIdentifier('2.23.140.1.2.1'),
+                policy_qualifiers=[
+                    'https://example-dv-certs.com/cps',
+                    x509.UserNotice(
+                        notice_reference=None, explicit_text='DV certificates issued with minimal identity validation.'
+                    ),
+                ],
+            ),
+        ]
     )
 
-    aia = x509.AuthorityInformationAccess([
-        x509.AccessDescription(
-            access_method=x509.AuthorityInformationAccessOID.CA_ISSUERS,
-            access_location=x509.DNSName(DNS_NAME_VALUE)
-        ),
-        x509.AccessDescription(
-            access_method=x509.AuthorityInformationAccessOID.OCSP,
-            access_location=x509.UniformResourceIdentifier(URI_VALUE)
-        )
-    ])
+    eku = ExtendedKeyUsage(
+        [
+            ExtendedKeyUsageOID.SERVER_AUTH,
+            ExtendedKeyUsageOID.CLIENT_AUTH,
+            ExtendedKeyUsageOID.CODE_SIGNING,
+            ExtendedKeyUsageOID.EMAIL_PROTECTION,
+            ExtendedKeyUsageOID.TIME_STAMPING,
+            ExtendedKeyUsageOID.OCSP_SIGNING,
+        ]
+    )
 
-    sia = x509.SubjectInformationAccess([
-        x509.AccessDescription(
-            access_method=SubjectInformationAccessOID.CA_REPOSITORY,
-            access_location=x509.DNSName(DNS_NAME_VALUE)
-        )
-    ])
+    name_constraints = NameConstraints(
+        permitted_subtrees=[rfc822_name, dns_name, uri], excluded_subtrees=[directory_name, registered_id, other_name]
+    )
+
+    aia = x509.AuthorityInformationAccess(
+        [
+            x509.AccessDescription(
+                access_method=x509.AuthorityInformationAccessOID.CA_ISSUERS,
+                access_location=x509.DNSName(DNS_NAME_VALUE),
+            ),
+            x509.AccessDescription(
+                access_method=x509.AuthorityInformationAccessOID.OCSP,
+                access_location=x509.UniformResourceIdentifier(URI_VALUE),
+            ),
+        ]
+    )
+
+    sia = x509.SubjectInformationAccess(
+        [
+            x509.AccessDescription(
+                access_method=SubjectInformationAccessOID.CA_REPOSITORY, access_location=x509.DNSName(DNS_NAME_VALUE)
+            )
+        ]
+    )
 
     iap = x509.InhibitAnyPolicy(INHIBIT_ANY_POLICY_VALUE)
 
@@ -210,14 +211,11 @@ def self_signed_cert_with_ext(rsa_private_key) -> x509.Certificate:
     # ])
 
     policy_constraints = x509.PolicyConstraints(
-        inhibit_policy_mapping=INHIBIT_POLICY_MAPPING,
-        require_explicit_policy=REQUIRE_EXPLICIT_POLICY
+        inhibit_policy_mapping=INHIBIT_POLICY_MAPPING, require_explicit_policy=REQUIRE_EXPLICIT_POLICY
     )
-
 
     # freshest_crl = x509.FreshestCRL()
     # CRLDistribution
-
 
     cert = (
         x509.CertificateBuilder()

--- a/trustpoint/pki/tests/test_auto_gen_pki.py
+++ b/trustpoint/pki/tests/test_auto_gen_pki.py
@@ -32,7 +32,7 @@ def test_auto_gen_pki(key_alg: AutoGenPkiKeyAlgorithm) -> None:
         serial_number='1234567890',
         domain=domain,
         onboarding_protocol=DeviceModel.OnboardingProtocol.NO_ONBOARDING,
-        onboarding_status=DeviceModel.OnboardingStatus.PENDING
+        onboarding_status=DeviceModel.OnboardingStatus.PENDING,
     )
     test_device.save()
     credential_issuer = LocalDomainCredentialIssuer(device=test_device, domain=domain)

--- a/trustpoint/pki/tests/test_models/test_certificate_extensions.py
+++ b/trustpoint/pki/tests/test_models/test_certificate_extensions.py
@@ -115,8 +115,7 @@ def test_authority_key_identifier_ext(self_signed_cert_with_ext) -> None:
     # Schlüssel-ID
     public_key = self_signed_cert_with_ext.public_key()
     public_key_bytes = public_key.public_bytes(
-        encoding=serialization.Encoding.DER,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo
+        encoding=serialization.Encoding.DER, format=serialization.PublicFormat.SubjectPublicKeyInfo
     )
     expected_key_identifier = hashlib.sha1(public_key_bytes).digest().hex().upper()
     assert aki_ext.key_identifier == expected_key_identifier
@@ -152,8 +151,7 @@ def test_subject_key_identifier_ext(self_signed_cert_with_ext) -> None:
 
     public_key = self_signed_cert_with_ext.public_key()
     public_key_bytes = public_key.public_bytes(
-        encoding=serialization.Encoding.DER,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo
+        encoding=serialization.Encoding.DER, format=serialization.PublicFormat.SubjectPublicKeyInfo
     )
     expected_key_identifier = hashlib.sha1(public_key_bytes).digest().hex().upper()
     assert ski_ext.key_identifier == expected_key_identifier
@@ -168,25 +166,33 @@ def test_certificate_policies_multiple_entries(self_signed_cert_with_ext) -> Non
     assert policies_ext.certificate_policies.count() == 2
 
     # EV
-    ev_policy = policies_ext.certificate_policies.filter(policy_identifier="2.23.140.1.1").first()
+    ev_policy = policies_ext.certificate_policies.filter(policy_identifier='2.23.140.1.1').first()
     assert ev_policy is not None
     assert ev_policy.policy_qualifiers.count() == 2
 
-    ev_cps_uri = ev_policy.policy_qualifiers.filter(qualifier__cps_uri__cps_uri="https://example-ev-certs.com/cps").first()
+    ev_cps_uri = ev_policy.policy_qualifiers.filter(
+        qualifier__cps_uri__cps_uri='https://example-ev-certs.com/cps'
+    ).first()
     assert ev_cps_uri is not None
 
-    ev_user_notice = ev_policy.policy_qualifiers.filter(qualifier__user_notice__explicit_text__contains="EV certificates issued").first()
+    ev_user_notice = ev_policy.policy_qualifiers.filter(
+        qualifier__user_notice__explicit_text__contains='EV certificates issued'
+    ).first()
     assert ev_user_notice is not None
 
     # DV
-    dv_policy = policies_ext.certificate_policies.filter(policy_identifier="2.23.140.1.2.1").first()
+    dv_policy = policies_ext.certificate_policies.filter(policy_identifier='2.23.140.1.2.1').first()
     assert dv_policy is not None
     assert dv_policy.policy_qualifiers.count() == 2
 
-    dv_cps_uri = dv_policy.policy_qualifiers.filter(qualifier__cps_uri__cps_uri="https://example-dv-certs.com/cps").first()
+    dv_cps_uri = dv_policy.policy_qualifiers.filter(
+        qualifier__cps_uri__cps_uri='https://example-dv-certs.com/cps'
+    ).first()
     assert dv_cps_uri is not None
 
-    dv_user_notice = dv_policy.policy_qualifiers.filter(qualifier__user_notice__explicit_text__contains="DV certificates issued").first()
+    dv_user_notice = dv_policy.policy_qualifiers.filter(
+        qualifier__user_notice__explicit_text__contains='DV certificates issued'
+    ).first()
     assert dv_user_notice is not None
 
 
@@ -226,10 +232,7 @@ def test_name_constraints_ext(self_signed_cert_with_ext) -> None:
         st.base.dns_name.value == DNS_NAME_VALUE if st.base.dns_name else False
         for st in nc_ext.permitted_subtrees.all()
     )
-    assert any(
-        st.base.uri.value == URI_VALUE if st.base.uri else False
-        for st in nc_ext.permitted_subtrees.all()
-    )
+    assert any(st.base.uri.value == URI_VALUE if st.base.uri else False for st in nc_ext.permitted_subtrees.all())
 
     # excludedSubtrees
     assert nc_ext.excluded_subtrees.count() == 3
@@ -245,9 +248,7 @@ def test_name_constraints_ext(self_signed_cert_with_ext) -> None:
     excluded_other_name = nc_ext.excluded_subtrees.filter(base__other_name__isnull=False).first()
     assert excluded_other_name is not None
     assert excluded_other_name.base.other_name.type_id == OTHER_NAME_OID
-    decoded_asn1, _ = decode(
-        bytes.fromhex(excluded_other_name.base.other_name.value), asn1Spec=char.UTF8String()
-    )
+    decoded_asn1, _ = decode(bytes.fromhex(excluded_other_name.base.other_name.value), asn1Spec=char.UTF8String())
     assert str(decoded_asn1) == OTHER_NAME_CONTENT
 
 
@@ -285,7 +286,6 @@ def test_subject_information_access_extension(self_signed_cert_with_ext):
     assert ad.access_location is not None
     assert ad.access_location.dns_name is not None
     assert ad.access_location.dns_name.value == DNS_NAME_VALUE
-
 
 
 @pytest.mark.django_db

--- a/trustpoint/pki/tests/test_models/test_certificate_values.py
+++ b/trustpoint/pki/tests/test_models/test_certificate_values.py
@@ -24,6 +24,7 @@ from pki.tests.fixtures import self_signed_cert_basic
 # Certificate Property Tests
 # ----------------------------
 
+
 @pytest.mark.django_db
 def test_certificate_status(self_signed_cert_basic) -> None:
     """Test if the certificate status is correctly set to OK."""
@@ -124,19 +125,19 @@ def test_subject_attributes(self_signed_cert_basic) -> None:
 def test_certificate_pem(self_signed_cert_basic) -> None:
     """Test if the PEM-encoded certificate is correctly saved."""
     cert_model, cert = self_signed_cert_basic
-    assert cert.public_bytes(
-        encoding=serialization.Encoding.PEM
-    ).decode() == cert_model.cert_pem
+    assert cert.public_bytes(encoding=serialization.Encoding.PEM).decode() == cert_model.cert_pem
 
 
 @pytest.mark.django_db
 def test_public_key_pem(self_signed_cert_basic) -> None:
     """Test if the PEM-encoded public key is correctly saved."""
     cert_model, cert = self_signed_cert_basic
-    assert cert.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo
-    ).decode() == cert_model.public_key_pem
+    assert (
+        cert.public_key()
+        .public_bytes(encoding=serialization.Encoding.PEM, format=serialization.PublicFormat.SubjectPublicKeyInfo)
+        .decode()
+        == cert_model.public_key_pem
+    )
 
 
 @pytest.mark.django_db

--- a/trustpoint/pki/urls.py
+++ b/trustpoint/pki/urls.py
@@ -13,12 +13,8 @@ urlpatterns = [
         truststores.TruststoreTableView.as_view(),
         name='truststores',
     ),
-    path('truststores/add/',
-         truststores.TruststoreCreateView.as_view(),
-         name='truststores-add'),
-    path('truststores/add/<int:pk>/',
-         truststores.TruststoreCreateView.as_view(),
-         name='truststores-add-with-pk'),
+    path('truststores/add/', truststores.TruststoreCreateView.as_view(), name='truststores-add'),
+    path('truststores/add/<int:pk>/', truststores.TruststoreCreateView.as_view(), name='truststores-add-with-pk'),
     re_path(
         r'^truststores/download/(?P<pk>[0-9]+)/?$',
         truststores.TruststoreDownloadView.as_view(),
@@ -42,9 +38,7 @@ urlpatterns = [
         truststores.TruststoreDownloadView.as_view(),
         name='truststore-file-download',
     ),
-    path('truststores/details/<int:pk>/',
-         truststores.TruststoreDetailView.as_view(),
-         name='truststore-detail'),
+    path('truststores/details/<int:pk>/', truststores.TruststoreDetailView.as_view(), name='truststore-detail'),
     re_path(
         r'^truststores/delete/(?P<pks>([0-9]+/)+[0-9]*)/?$',
         truststores.TruststoreBulkDeleteConfirmView.as_view(),
@@ -83,9 +77,7 @@ urlpatterns = [
         certificates.CmpIssuingCaCertificateDownloadView.as_view(),
         name='certificate-issuing-ca-download',
     ),
-    path('certificates/details/<int:pk>/',
-         certificates.CertificateDetailView.as_view(),
-         name='certificate-detail'),
+    path('certificates/details/<int:pk>/', certificates.CertificateDetailView.as_view(), name='certificate-detail'),
     path('issuing-cas/', issuing_cas.IssuingCaTableView.as_view(), name='issuing_cas'),
     path(
         'issuing-cas/add/method-select/',
@@ -134,8 +126,7 @@ urlpatterns = [
         DevIdRegistrationCreateView.as_view(),
         name='devid_registration_create-with_truststore_id',
     ),
-    path('devid-registration/delete/<int:pk>/',
-         DevIdRegistrationDeleteView.as_view(),
-         name='devid_registration_delete'),
-
+    path(
+        'devid-registration/delete/<int:pk>/', DevIdRegistrationDeleteView.as_view(), name='devid_registration_delete'
+    ),
 ]

--- a/trustpoint/pki/util/keys.py
+++ b/trustpoint/pki/util/keys.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 class AutoGenPkiKeyAlgorithm(models.TextChoices):
     """The key algorithms supported by the AutoGenPKI."""
+
     RSA2048 = 'RSA2048SHA256', 'RSA2048'
     RSA4096 = 'RSA4096SHA256', 'RSA4096'
     SECP256R1 = 'SECP256R1SHA256', 'SECP256R1'
@@ -33,6 +34,7 @@ class AutoGenPkiKeyAlgorithm(models.TextChoices):
             return PublicKeyInfo(public_key_algorithm_oid=PublicKeyAlgorithmOid.ECC, named_curve=NamedCurve.SECP256R1)
         exc_msg = f'Unsupported key algorithm type for AutoGenPKI: {self.value}'
         raise ValueError(exc_msg)
+
 
 class KeyGenerator:
     """Utility class for generating private keys."""

--- a/trustpoint/pki/util/x509.py
+++ b/trustpoint/pki/util/x509.py
@@ -20,25 +20,28 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
 class CertificateGenerator:
     """Methods for generating X.509 certificates."""
 
     @staticmethod
-    def create_root_ca(cn: str,
-            validity_days: int = 7300,
-            private_key: None | rsa.RSAPrivateKey | ec.EllipticCurvePrivateKey = None,
-            hash_algorithm: None | HashAlgorithm = None) -> tuple[x509.Certificate, PrivateKey]:
+    def create_root_ca(
+        cn: str,
+        validity_days: int = 7300,
+        private_key: None | rsa.RSAPrivateKey | ec.EllipticCurvePrivateKey = None,
+        hash_algorithm: None | HashAlgorithm = None,
+    ) -> tuple[x509.Certificate, PrivateKey]:
         """Creates a root CA certificate. (for testing and AutoGenPKI)"""
         return CertificateGenerator.create_issuing_ca(None, cn, cn, private_key, validity_days, hash_algorithm)
 
     @staticmethod
     def create_issuing_ca(
-            issuer_private_key: None | PrivateKey,
-            issuer_cn: str,
-            subject_cn: str,
-            private_key: None | PrivateKey = None,
-            validity_days: int = 3650,
-            hash_algorithm: None | HashAlgorithm = None
+        issuer_private_key: None | PrivateKey,
+        issuer_cn: str,
+        subject_cn: str,
+        private_key: None | PrivateKey = None,
+        validity_days: int = 3650,
+        hash_algorithm: None | HashAlgorithm = None,
     ) -> tuple[x509.Certificate, PrivateKey]:
         """Creates an issuing CA certificate + key pair."""
         one_day = datetime.timedelta(1, 0, 0)
@@ -57,46 +60,49 @@ class CertificateGenerator:
 
         public_key = private_key.public_key()
         builder = x509.CertificateBuilder()
-        builder = builder.subject_name(x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, subject_cn),
-        ]))
-        builder = builder.issuer_name(x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, issuer_cn),
-        ]))
+        builder = builder.subject_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, subject_cn),
+                ]
+            )
+        )
+        builder = builder.issuer_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, issuer_cn),
+                ]
+            )
+        )
         builder = builder.not_valid_before(datetime.datetime.now(tz=datetime.timezone.utc) - one_day)
         builder = builder.not_valid_after(datetime.datetime.now(tz=datetime.timezone.utc) + (one_day * validity_days))
         builder = builder.serial_number(x509.random_serial_number())
         builder = builder.public_key(public_key)
-        builder = builder.add_extension(
-            x509.BasicConstraints(ca=True, path_length=None), critical=True
-        )
-        builder = builder.add_extension(
-            x509.SubjectKeyIdentifier.from_public_key(public_key), critical=False
-        )
+        builder = builder.add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        builder = builder.add_extension(x509.SubjectKeyIdentifier.from_public_key(public_key), critical=False)
         builder = builder.add_extension(
             x509.AuthorityKeyIdentifier.from_issuer_public_key(issuer_private_key.public_key()), critical=False
         )
 
         certificate = builder.sign(
-            private_key=issuer_private_key, algorithm=hash_algorithm,
+            private_key=issuer_private_key,
+            algorithm=hash_algorithm,
         )
         return certificate, private_key
 
     @staticmethod
     def create_ee(  # noqa: PLR0913
-            issuer_private_key: PrivateKey,
-            issuer_cn: str,
-            subject_cn: str,
-            private_key: None | PrivateKey = None,
-            key_usage_extension: x509.KeyUsage=None,
-            validity_days: int = 365) -> tuple[x509.Certificate, PrivateKey]:
+        issuer_private_key: PrivateKey,
+        issuer_cn: str,
+        subject_cn: str,
+        private_key: None | PrivateKey = None,
+        key_usage_extension: x509.KeyUsage = None,
+        validity_days: int = 365,
+    ) -> tuple[x509.Certificate, PrivateKey]:
         """Creates a generic end entity certificate + key pair."""
         one_day = datetime.timedelta(1, 0, 0)
         if private_key is None:
-            private_key = rsa.generate_private_key(
-                public_exponent=65537,
-                key_size=2048
-            )
+            private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 
         not_valid_before = datetime.datetime.now(tz=datetime.timezone.utc)
         not_valid_after = not_valid_before + (one_day * validity_days)
@@ -106,18 +112,27 @@ class CertificateGenerator:
 
         public_key = private_key.public_key()
         builder = x509.CertificateBuilder()
-        builder = builder.subject_name(x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, subject_cn),
-        ]))
-        builder = builder.issuer_name(x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, issuer_cn),
-        ]))
+        builder = builder.subject_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, subject_cn),
+                ]
+            )
+        )
+        builder = builder.issuer_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, issuer_cn),
+                ]
+            )
+        )
         builder = builder.not_valid_before(not_valid_before)
         builder = builder.not_valid_after(not_valid_after)
         builder = builder.serial_number(x509.random_serial_number())
         builder = builder.public_key(public_key)
         builder = builder.add_extension(
-            x509.BasicConstraints(ca=False, path_length=None), critical=True,
+            x509.BasicConstraints(ca=False, path_length=None),
+            critical=True,
         )
         if key_usage_extension:
             builder = builder.add_extension(key_usage_extension, critical=False)
@@ -125,18 +140,19 @@ class CertificateGenerator:
         hash_algorithm = CryptographyUtils.get_hash_algorithm_for_private_key(issuer_private_key)
 
         certificate = builder.sign(
-            private_key=issuer_private_key, algorithm=hash_algorithm,
+            private_key=issuer_private_key,
+            algorithm=hash_algorithm,
         )
         return certificate, private_key
 
     @staticmethod
     def save_issuing_ca(
-            issuing_ca_cert: x509.Certificate,
-            chain: list[x509.Certificate],
-            private_key: PrivateKey,
-            unique_name: str ='issuing_ca',
-            ca_type: IssuingCaModel.IssuingCaTypeChoice = IssuingCaModel.IssuingCaTypeChoice.LOCAL_UNPROTECTED
-        ) -> IssuingCaModel:
+        issuing_ca_cert: x509.Certificate,
+        chain: list[x509.Certificate],
+        private_key: PrivateKey,
+        unique_name: str = 'issuing_ca',
+        ca_type: IssuingCaModel.IssuingCaTypeChoice = IssuingCaModel.IssuingCaTypeChoice.LOCAL_UNPROTECTED,
+    ) -> IssuingCaModel:
         """Saves an Issuing CA certificate to the database."""
         issuing_ca_credential_serializer = CredentialSerializer(
             (
@@ -147,9 +163,7 @@ class CertificateGenerator:
         )
 
         issuing_ca = IssuingCaModel.create_new_issuing_ca(
-            unique_name=unique_name,
-            credential_serializer=issuing_ca_credential_serializer,
-            issuing_ca_type=ca_type
+            unique_name=unique_name, credential_serializer=issuing_ca_credential_serializer, issuing_ca_type=ca_type
         )
 
         logger.info("Issuing CA '%s' saved successfully.", unique_name)

--- a/trustpoint/pki/views/certificates.py
+++ b/trustpoint/pki/views/certificates.py
@@ -42,6 +42,7 @@ class CertificateTableView(CertificatesContextMixin, TpLoginRequiredMixin, Sorta
     paginate_by = UIConfig.paginate_by
     default_sort_param = 'common_name'
 
+
 class CertificateDetailView(CertificatesContextMixin, TpLoginRequiredMixin, DetailView):
     """The certificate detail view."""
 
@@ -50,6 +51,7 @@ class CertificateDetailView(CertificatesContextMixin, TpLoginRequiredMixin, Deta
     ignore_url = reverse_lazy('pki:certificates')
     template_name = 'pki/certificates/details.html'
     context_object_name = 'cert'
+
 
 class CmpIssuingCaCertificateDownloadView(CertificatesContextMixin, TpLoginRequiredMixin, DetailView):
     """View for downloading a single certificate."""
@@ -220,7 +222,9 @@ class CertificateMultipleDownloadView(
             raise Http404 from exception
 
         file_bytes = CertificateArchiveFileBuilder.build(
-            certificate_serializers=[certificate_model.get_certificate_serializer() for certificate_model in self.queryset],
+            certificate_serializers=[
+                certificate_model.get_certificate_serializer() for certificate_model in self.queryset
+            ],
             file_format=file_format_enum,
             archive_format=archive_format_enum,
         )

--- a/trustpoint/pki/views/domains.py
+++ b/trustpoint/pki/views/domains.py
@@ -27,7 +27,6 @@ from trustpoint.views.base import (
 
 
 class PkiProtocol(enum.Enum):
-
     EST = 'est'
     CMP = 'cmp'
     REST = 'rest'
@@ -68,7 +67,7 @@ class DomainCreateView(DomainContextMixin, TpLoginRequiredMixin, CreateView):
         form.fields['issuing_ca'].queryset = IssuingCaModel.objects.exclude(
             issuing_ca_type=IssuingCaModel.IssuingCaTypeChoice.AUTOGEN_ROOT
         ).filter(is_active=True)
-        form.fields['issuing_ca'].empty_label = None # Remove empty "---------" choice
+        form.fields['issuing_ca'].empty_label = None  # Remove empty "---------" choice
         del form.fields['is_active']
         return form
 
@@ -87,7 +86,6 @@ class DomainUpdateView(DomainContextMixin, TpLoginRequiredMixin, UpdateView):
 
 
 class DomainDevIdRegistrationTableMixin(SortableTableMixin, ListInDetailView):
-
     model = DevIdRegistration
     paginate_by = UIConfig.paginate_by
     context_object_name = 'devid_registrations'
@@ -113,7 +111,7 @@ class DomainConfigView(DomainContextMixin, TpLoginRequiredMixin, DomainDevIdRegi
             'est': domain.est_protocol if hasattr(domain, 'est_protocol') else None,
             'acme': domain.acme_protocol if hasattr(domain, 'acme_protocol') else None,
             'scep': domain.scep_protocol if hasattr(domain, 'scep_protocol') else None,
-            'rest': domain.rest_protocol if hasattr(domain, 'rest_protocol') else None
+            'rest': domain.rest_protocol if hasattr(domain, 'rest_protocol') else None,
         }
 
         return context
@@ -130,12 +128,11 @@ class DomainConfigView(DomainContextMixin, TpLoginRequiredMixin, DomainDevIdRegi
                 protocol_object.status = protocol_name in active_protocols
                 protocol_object.save()
 
-        messages.success(request, _("Settings updated successfully."))
+        messages.success(request, _('Settings updated successfully.'))
         return HttpResponseRedirect(self.success_url)
 
 
 class DomainDetailView(DomainContextMixin, TpLoginRequiredMixin, DomainDevIdRegistrationTableMixin, ListInDetailView):
-
     detail_model = DomainModel
     template_name = 'pki/domains/details.html'
     detail_context_object_name = 'domain'
@@ -159,17 +156,11 @@ class DomainCaBulkDeleteConfirmView(DomainContextMixin, TpLoginRequiredMixin, Bu
             response = super().form_valid(form)
         except ProtectedError:
             messages.error(
-                self.request,
-                _(
-                    'Cannot delete the selected Domains(s) because they are referenced by other objects.'
-                )
+                self.request, _('Cannot delete the selected Domains(s) because they are referenced by other objects.')
             )
             return HttpResponseRedirect(self.success_url)
 
-        messages.success(
-            self.request,
-            _('Successfully deleted {count} Domains.').format(count=deleted_count)
-        )
+        messages.success(self.request, _('Successfully deleted {count} Domains.').format(count=deleted_count))
 
         return response
 
@@ -241,8 +232,10 @@ class DevIdRegistrationCreateView(DomainContextMixin, TpLoginRequiredMixin, Form
         domain = self.get_domain()
         return cast('str', reverse_lazy('pki:domains-config', kwargs={'pk': domain.id}))
 
+
 class DevIdRegistrationDeleteView(DomainContextMixin, TpLoginRequiredMixin, DeleteView):
     """View to delete a DevID Registration."""
+
     model = DevIdRegistration
     template_name = 'pki/devid_registration/confirm_delete.html'
     success_url = reverse_lazy('pki:domains')
@@ -253,26 +246,26 @@ class DevIdRegistrationDeleteView(DomainContextMixin, TpLoginRequiredMixin, Dele
         messages.success(request, _('DevID Registration Pattern deleted successfully.'))
         return response
 
+
 class DevIdMethodSelectView(DomainContextMixin, TpLoginRequiredMixin, FormView):
     template_name = 'pki/devid_registration/method_select.html'
     form_class = DevIdAddMethodSelectForm
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["domain"] = get_object_or_404(DomainModel, id=self.kwargs.get("pk"))
+        context['domain'] = get_object_or_404(DomainModel, id=self.kwargs.get('pk'))
         return context
 
     def form_valid(self, form) -> HttpResponseRedirect:
         method_select = form.cleaned_data.get('method_select')
-        domain_pk = self.kwargs.get("pk")  # Get domain ID
+        domain_pk = self.kwargs.get('pk')  # Get domain ID
 
         if not method_select:
             return HttpResponseRedirect(reverse('pki:devid_registration-method_select', kwargs={'pk': domain_pk}))
 
         if method_select == 'import_truststore':
             if domain_pk:
-                return HttpResponseRedirect(
-                    reverse('pki:truststores-add-with-pk', kwargs={'pk': domain_pk}))
+                return HttpResponseRedirect(reverse('pki:truststores-add-with-pk', kwargs={'pk': domain_pk}))
             return HttpResponseRedirect(reverse('pki:truststores-add'))
 
         if method_select == 'configure_pattern':

--- a/trustpoint/pki/views/issuing_cas.py
+++ b/trustpoint/pki/views/issuing_cas.py
@@ -31,6 +31,7 @@ class IssuingCaContextMixin(TpLoginRequiredMixin, ContextDataMixin):
     context_page_category = 'pki'
     context_page_name = 'issuing_cas'
 
+
 class IssuingCaTableView(IssuingCaContextMixin, TpLoginRequiredMixin, SortableTableMixin, ListView):
     """Issuing CA Table View."""
 
@@ -57,22 +58,19 @@ class IssuingCaAddMethodSelectView(IssuingCaContextMixin, TpLoginRequiredMixin, 
 
 
 class IssuingCaAddFileImportPkcs12View(IssuingCaContextMixin, TpLoginRequiredMixin, FormView):
-
     template_name = 'pki/issuing_cas/add/file_import.html'
     form_class = IssuingCaAddFileImportPkcs12Form
     success_url = reverse_lazy('pki:issuing_cas')
 
 
 class IssuingCaAddFileImportSeparateFilesView(IssuingCaContextMixin, TpLoginRequiredMixin, FormView):
-
     template_name = 'pki/issuing_cas/add/file_import.html'
     form_class = IssuingCaAddFileImportSeparateFilesForm
     success_url = reverse_lazy('pki:issuing_cas')
 
 
 class IssuingCaDetailView(IssuingCaContextMixin, TpLoginRequiredMixin, DetailView):
-
-    http_method_names = ('get', )
+    http_method_names = ('get',)
 
     model = IssuingCaModel
     success_url = reverse_lazy('pki:issuing_cas')
@@ -81,9 +79,7 @@ class IssuingCaDetailView(IssuingCaContextMixin, TpLoginRequiredMixin, DetailVie
     context_object_name = 'issuing_ca'
 
 
-
 class IssuingCaConfigView(LoggerMixin, IssuingCaContextMixin, TpLoginRequiredMixin, DetailView):
-
     model = IssuingCaModel
     success_url = reverse_lazy('pki:issuing_cas')
     ignore_url = reverse_lazy('pki:issuing_cas')
@@ -110,16 +106,11 @@ class IssuingCaBulkDeleteConfirmView(IssuingCaContextMixin, TpLoginRequiredMixin
         except ProtectedError:
             messages.error(
                 self.request,
-                _(
-                    'Cannot delete the selected Issuing CA(s) because they are referenced by other objects.'
-                )
+                _('Cannot delete the selected Issuing CA(s) because they are referenced by other objects.'),
             )
             return HttpResponseRedirect(self.success_url)
 
-        messages.success(
-            self.request,
-            _('Successfully deleted {count} Issuing CA(s).').format(count=deleted_count)
-        )
+        messages.success(self.request, _('Successfully deleted {count} Issuing CA(s).').format(count=deleted_count))
 
         return response
 
@@ -132,7 +123,7 @@ class IssuingCaCrlGenerationView(IssuingCaContextMixin, TpLoginRequiredMixin, De
     ignore_url = reverse_lazy('pki:issuing_cas')
     context_object_name = 'issuing_ca'
 
-    http_method_names = ('get', )
+    http_method_names = ('get',)
 
     # TODO(Air): This view should use a POST request as it is an action.
     # However, this is not trivial in the config view as that already contains a form.
@@ -148,7 +139,7 @@ class IssuingCaCrlGenerationView(IssuingCaContextMixin, TpLoginRequiredMixin, De
 class CrlDownloadView(IssuingCaContextMixin, DetailView):
     """Unauthenticated view to download the certificate revocation list of an Issuing CA."""
 
-    http_method_names = ('get', )
+    http_method_names = ('get',)
 
     model = IssuingCaModel
     success_url = reverse_lazy('pki:issuing_cas')

--- a/trustpoint/pki/views/truststores.py
+++ b/trustpoint/pki/views/truststores.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from trustpoint_core.file_builder.certificate import CertificateCollectionArchiveFileBuilder, CertificateCollectionBuilder
+from trustpoint_core.file_builder.certificate import (
+    CertificateCollectionArchiveFileBuilder,
+    CertificateCollectionBuilder,
+)
 from trustpoint_core.file_builder.enum import ArchiveFormat, CertificateFileFormat
 from django.contrib import messages
 from django.db.models import ProtectedError
@@ -44,6 +47,7 @@ class TruststoresContextMixin:
 
     extra_context: ClassVar = {'page_category': 'pki', 'page_name': 'truststores'}
 
+
 class TruststoreTableView(TruststoresContextMixin, TpLoginRequiredMixin, SortableTableMixin, ListView):
     """Truststore Table View."""
 
@@ -64,10 +68,15 @@ class TruststoreCreateView(TruststoresContextMixin, TpLoginRequiredMixin, FormVi
 
     def form_valid(self, form):
         truststore = form.cleaned_data['truststore']
-        domain_id = self.kwargs.get("pk")
+        domain_id = self.kwargs.get('pk')
 
         if domain_id:
-            return HttpResponseRedirect(reverse('pki:devid_registration_create-with_truststore_id', kwargs={'pk': domain_id, 'truststore_id': truststore.id}))
+            return HttpResponseRedirect(
+                reverse(
+                    'pki:devid_registration_create-with_truststore_id',
+                    kwargs={'pk': domain_id, 'truststore_id': truststore.id},
+                )
+            )
 
         return HttpResponseRedirect(reverse('pki:truststores'))
 
@@ -78,10 +87,11 @@ class TruststoreCreateView(TruststoresContextMixin, TpLoginRequiredMixin, FormVi
     def get_context_data(self, **kwargs):
         """Include domain in context only if pk is present."""
         context = super().get_context_data(**kwargs)
-        pk = self.kwargs.get("pk")
+        pk = self.kwargs.get('pk')
         if pk:
-            context["domain"] = get_object_or_404(DomainModel, id=pk)
+            context['domain'] = get_object_or_404(DomainModel, id=pk)
         return context
+
 
 class TruststoreDetailView(TruststoresContextMixin, TpLoginRequiredMixin, DetailView):
     """The truststore detail view."""
@@ -91,6 +101,7 @@ class TruststoreDetailView(TruststoresContextMixin, TpLoginRequiredMixin, Detail
     ignore_url = reverse_lazy('pki:truststores')
     template_name = 'pki/truststores/details.html'
     context_object_name = 'truststore'
+
 
 class TruststoreDownloadView(TruststoresContextMixin, TpLoginRequiredMixin, DetailView):
     """View for downloading a single truststore."""
@@ -137,14 +148,13 @@ class TruststoreDownloadView(TruststoresContextMixin, TpLoginRequiredMixin, Deta
 
         certificate_serializer = TruststoreModel.objects.get(pk=pk).get_certificate_collection_serializer()
 
-        file_bytes = CertificateCollectionBuilder.build(
-            certificate_serializer,
-            file_format=file_format_enum)
+        file_bytes = CertificateCollectionBuilder.build(certificate_serializer, file_format=file_format_enum)
 
         response = HttpResponse(file_bytes, content_type=file_format_enum.mime_type)
         response['Content-Disposition'] = f'attachment; filename="truststore{file_format_enum.file_extension}"'
 
         return response
+
 
 class TruststoreMultipleDownloadView(
     TruststoresContextMixin, TpLoginRequiredMixin, PrimaryKeyListFromPrimaryKeyString, ListView
@@ -231,13 +241,14 @@ class TruststoreMultipleDownloadView(
         file_bytes = CertificateCollectionArchiveFileBuilder.build(
             certificate_collection_serializers=certificate_collection_serializers,
             file_format=file_format_enum,
-            archive_format=archive_format_enum
+            archive_format=archive_format_enum,
         )
 
         response = HttpResponse(file_bytes, content_type=archive_format_enum.mime_type)
         response['Content-Disposition'] = f'attachment; filename="truststores{archive_format_enum.file_extension}"'
 
         return response
+
 
 class TruststoreBulkDeleteConfirmView(TruststoresContextMixin, TpLoginRequiredMixin, BulkDeleteView):
     """View for confirming the deletion of multiple truststores."""
@@ -259,15 +270,10 @@ class TruststoreBulkDeleteConfirmView(TruststoresContextMixin, TpLoginRequiredMi
         except ProtectedError:
             messages.error(
                 self.request,
-                _(
-                    'Cannot delete the selected Truststore(s) because they are referenced by other objects.'
-                )
+                _('Cannot delete the selected Truststore(s) because they are referenced by other objects.'),
             )
             return HttpResponseRedirect(self.success_url)
 
-        messages.success(
-            self.request,
-            _('Successfully deleted {count} Truststore(s).').format(count=deleted_count)
-        )
+        messages.success(self.request, _('Successfully deleted {count} Truststore(s).').format(count=deleted_count))
 
         return response

--- a/trustpoint/settings/apps.py
+++ b/trustpoint/settings/apps.py
@@ -1,8 +1,10 @@
 """Django apps"""
+
 from django.apps import AppConfig
 
 
 class SettingsConfig(AppConfig):
     """Settings App"""
+
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'settings'

--- a/trustpoint/settings/forms.py
+++ b/trustpoint/settings/forms.py
@@ -1,4 +1,5 @@
 """Forms definition"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -31,9 +32,7 @@ class SecurityConfigForm(forms.ModelForm):
         if 'security_mode' in self.data:
             current_mode = self.data['security_mode']
         else:
-            current_mode = (self.instance.security_mode
-                            if self.instance
-                            else SecurityConfig.SecurityModeChoices.LOW)
+            current_mode = self.instance.security_mode if self.instance else SecurityConfig.SecurityModeChoices.LOW
 
         sec_manager = manager.SecurityManager()
         features_not_allowed = sec_manager.get_features_to_disable(current_mode)
@@ -59,13 +58,11 @@ class SecurityConfigForm(forms.ModelForm):
                 _('Advanced security settings'),
                 'auto_gen_pki',
                 'auto_gen_pki_key_algorithm',
-            )
+            ),
         )
 
     security_mode = forms.ChoiceField(
-        choices=SecurityConfig.SecurityModeChoices.choices,
-        widget=forms.RadioSelect(),
-        label=''
+        choices=SecurityConfig.SecurityModeChoices.choices, widget=forms.RadioSelect(), label=''
     )
 
     auto_gen_pki = forms.BooleanField(
@@ -75,27 +72,21 @@ class SecurityConfigForm(forms.ModelForm):
             attrs={
                 'data-sl-defaults': '[true, true, false, false, false]',
                 'data-hide-at-sl': '[false, false, true, true, true]',
-                'data-more-secure': 'false'
+                'data-more-secure': 'false',
             }
-        )
+        ),
     )
 
     auto_gen_pki_key_algorithm = forms.ChoiceField(
         choices=AutoGenPkiKeyAlgorithm.choices,
         label=_('Key Algorithm for auto-generated PKI'),
         required=False,
-        widget=forms.Select(
-            attrs={'data-hide-at-sl': '[false, false, true, true, true]'}
-        )
+        widget=forms.Select(attrs={'data-hide-at-sl': '[false, false, true, true, true]'}),
     )
 
     class Meta:
         model = SecurityConfig
-        fields : ClassVar[list] = [
-            'security_mode',
-            'auto_gen_pki',
-            'auto_gen_pki_key_algorithm'
-        ]
+        fields: ClassVar[list] = ['security_mode', 'auto_gen_pki', 'auto_gen_pki_key_algorithm']
 
     def clean_auto_gen_pki_key_algorithm(self):
         """Keep the current value of `auto_gen_pki_key_algorithm` from the instance if the field was disabled."""

--- a/trustpoint/settings/models.py
+++ b/trustpoint/settings/models.py
@@ -10,19 +10,19 @@ class SecurityConfig(models.Model):
 
     class SecurityModeChoices(models.TextChoices):
         """Types of security modes"""
+
         DEV = '0', _('Testing env')
         LOW = '1', _('Basic')
         MEDIUM = '2', _('Medium')
         HIGH = '3', _('High')
         HIGHEST = '4', _('Highest')
 
-
     security_mode = models.CharField(max_length=6, choices=SecurityModeChoices.choices, default=SecurityModeChoices.LOW)
 
     auto_gen_pki = models.BooleanField(default=False)
-    auto_gen_pki_key_algorithm = models.CharField(max_length=24,
-                                                  choices=AutoGenPkiKeyAlgorithm,
-                                                  default=AutoGenPkiKeyAlgorithm.RSA2048)
+    auto_gen_pki_key_algorithm = models.CharField(
+        max_length=24, choices=AutoGenPkiKeyAlgorithm, default=AutoGenPkiKeyAlgorithm.RSA2048
+    )
 
     def __str__(self) -> str:
         """Output as string"""

--- a/trustpoint/settings/security/__init__.py
+++ b/trustpoint/settings/security/__init__.py
@@ -2,29 +2,19 @@ from settings.models import SecurityConfig
 from settings.security.features import AutoGenPkiFeature
 
 # 1) Minimal set: HIGHEST
-HIGHEST_FEATURES = {
-    None
-}
+HIGHEST_FEATURES = {None}
 
 # 2) HIGH inherits everything from HIGHEST,
-HIGH_FEATURES = HIGHEST_FEATURES | {
-    None
-}
+HIGH_FEATURES = HIGHEST_FEATURES | {None}
 
 # 3) MEDIUM inherits from HIGH
-MEDIUM_FEATURES = HIGH_FEATURES | {
-    None
-}
+MEDIUM_FEATURES = HIGH_FEATURES | {None}
 
 # 4) LOW inherits from MEDIUM
-LOW_FEATURES = MEDIUM_FEATURES | {
-    AutoGenPkiFeature
-}
+LOW_FEATURES = MEDIUM_FEATURES | {AutoGenPkiFeature}
 
 # 5) DEV inherits from LOW (All features available)
-DEV_FEATURES = LOW_FEATURES | {
-    None
-}
+DEV_FEATURES = LOW_FEATURES | {None}
 
 LEVEL_FEATURE_MAP = {
     SecurityConfig.SecurityModeChoices.HIGHEST: HIGHEST_FEATURES,

--- a/trustpoint/settings/security/decorators.py
+++ b/trustpoint/settings/security/decorators.py
@@ -27,6 +27,7 @@ def security_level(feature_name: SecurityFeature):
     PermissionDenied
         If the security level does not permit the requested feature.
     """
+
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
@@ -35,4 +36,5 @@ def security_level(feature_name: SecurityFeature):
             return func(*args, **kwargs)
 
         return wrapper
+
     return decorator

--- a/trustpoint/settings/security/features.py
+++ b/trustpoint/settings/security/features.py
@@ -46,18 +46,13 @@ class AutoGenPkiFeature(SecurityFeature):
     def enable(key_alg: AutoGenPkiKeyAlgorithm) -> None:
         """Starts a thread that enables the auto-generated PKI.Pass thread arguments as a tuple to avoid any issues."""
         if __class__.is_enabled():
-            thread = threading.Thread(
-                target=AutoGenPki.enable_auto_gen_pki,
-                args=(key_alg,)
-            )
+            thread = threading.Thread(target=AutoGenPki.enable_auto_gen_pki, args=(key_alg,))
             thread.start()
 
     @staticmethod
     def disable() -> None:
         """Starts a thread that disables the auto-generated PKI."""
-        thread = threading.Thread(
-            target=AutoGenPki.disable_auto_gen_pki
-        )
+        thread = threading.Thread(target=AutoGenPki.disable_auto_gen_pki)
         thread.start()
 
         conf = SecurityConfig.objects.first()

--- a/trustpoint/settings/security/manager.py
+++ b/trustpoint/settings/security/manager.py
@@ -1,4 +1,5 @@
 """Logic managing the security level setting of the Trustpoint."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -14,9 +15,7 @@ if TYPE_CHECKING:
 class SecurityManager(LoggerMixin):
     """Manages the security level setting of the Trustpoint."""
 
-    def is_feature_allowed(self,
-                           feature: SecurityFeature,
-                           target_level: None | str = None) -> bool:
+    def is_feature_allowed(self, feature: SecurityFeature, target_level: None | str = None) -> bool:
         """Checks if the specified feature is allowed under the given security level.
 
         If 'target_level' is None, the current security level is used.
@@ -33,7 +32,6 @@ class SecurityManager(LoggerMixin):
         # If the level is defined in the dictionary, check membership
         allowed_features = LEVEL_FEATURE_MAP.get(level_choice, set())
         return feature in allowed_features
-
 
     def get_security_level(self) -> str:
         """Returns the string representation of the security_mode, e.g. '0', '1', etc."""

--- a/trustpoint/settings/security/mixins.py
+++ b/trustpoint/settings/security/mixins.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 class SecurityLevelMixin:
     """A mixin that provides security feature checks for Django views."""
 
-    def __init__(self, security_feature: SecurityFeature=None, *args, **kwargs) -> None:
+    def __init__(self, security_feature: SecurityFeature = None, *args, **kwargs) -> None:
         """Initializes the SecurityLevelMixin with the specified security feature and redirect URL.
 
         Parameters:
@@ -40,6 +40,7 @@ class SecurityLevelMixin:
             The security mode of the current security level instance.
         """
         return self.sec.get_security_level()
+
 
 class SecurityLevelMixinRedirect(SecurityLevelMixin):
     """A mixin that provides security feature checks for Django views with redirect feature."""
@@ -75,7 +76,10 @@ class SecurityLevelMixinRedirect(SecurityLevelMixin):
             The HTTP response object, either continuing to the requested view or redirecting.
         """
         if not self.sec.is_feature_allowed(self.security_feature):
-            msg = _('Your security setting %s does not allow the feature: %s' % (self.get_security_level(), self.security_feature.value))
+            msg = _(
+                'Your security setting %s does not allow the feature: %s'
+                % (self.get_security_level(), self.security_feature.value)
+            )
             messages.error(request, msg)
             return redirect(self.disabled_by_security_level_url)
         return super().dispatch(request, *args, **kwargs)

--- a/trustpoint/settings/urls.py
+++ b/trustpoint/settings/urls.py
@@ -1,4 +1,5 @@
 """Routing configuration"""
+
 from django.urls import path, re_path
 
 from .views import language, logging, IndexView, security
@@ -11,14 +12,17 @@ urlpatterns = [
     re_path(
         r'^logging/files/details/(?P<filename>trustpoint\.log(?:\.\d{1,5})?)/?$',
         logging.LoggingFilesDetailsView.as_view(),
-        name='logging-files-details'),
+        name='logging-files-details',
+    ),
     re_path(
         r'^logging/files/download/(?P<filename>trustpoint\.log(?:\.\d{1,5})?)/?$',
         logging.LoggingFilesDownloadView.as_view(),
-        name='logging-files-download'),
+        name='logging-files-download',
+    ),
     re_path(
         r'^logging/files/download/(?P<archive_format>tar\.gz|zip)(?P<filenames>(?:/trustpoint\.log(\.\d{1,5})?)+)/?$',
         logging.LoggingFilesDownloadMultipleView.as_view(),
-        name='logging-files-download-multiple'),
+        name='logging-files-download-multiple',
+    ),
     path('security/', security.SecurityView.as_view(), name='security'),
 ]

--- a/trustpoint/settings/views/__init__.py
+++ b/trustpoint/settings/views/__init__.py
@@ -8,5 +8,6 @@ from django.views.generic.base import RedirectView
 
 class IndexView(RedirectView):
     """Index view"""
+
     permanent = True
     pattern_name = 'settings:language'

--- a/trustpoint/settings/views/language.py
+++ b/trustpoint/settings/views/language.py
@@ -1,4 +1,5 @@
 """Django Views"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -12,6 +13,7 @@ if TYPE_CHECKING:
     from typing import Any
 
     from django.http import HttpRequest, HttpResponse
+
 
 def language(request: HttpRequest) -> HttpResponse:
     """Handle language Configuration

--- a/trustpoint/settings/views/logging.py
+++ b/trustpoint/settings/views/logging.py
@@ -1,4 +1,5 @@
 """Logging setting specific views."""
+
 from __future__ import annotations
 
 import datetime
@@ -28,6 +29,7 @@ if TYPE_CHECKING:
 
 class IndexView(RedirectView):
     """Index view"""
+
     permanent = True
     pattern_name = 'settings:language'
 
@@ -40,21 +42,20 @@ def language(request: HttpRequest) -> HttpResponse:
     context = {'page_category': 'settings', 'page_name': 'language'}
     return render(request, 'settings/language.html', context=context)
 
+
 # ------------------------------------------------------- Logging ------------------------------------------------------
 
 
 class LoggingContextMixin:
     """Mixin which adds extra menu context for the Logging Views."""
 
-    extra_context : ClassVar[dict] = {
-        'page_category': 'settings',
-        'page_name': 'logging'
-    }
+    extra_context: ClassVar[dict] = {'page_category': 'settings', 'page_name': 'logging'}
 
 
 class LoggingFilesTableView(LoggerMixin, TpLoginRequiredMixin, LoggingContextMixin, SortableTableMixin, ListView):
     """View to display all log files in the log directory in a table."""
-    http_method_names = ('get', )
+
+    http_method_names = ('get',)
 
     template_name = 'settings/logging/logging_files.html'
     context_object_name = 'log_files'
@@ -64,7 +65,7 @@ class LoggingFilesTableView(LoggerMixin, TpLoginRequiredMixin, LoggingContextMix
     @staticmethod
     @LoggerMixin.log_exceptions
     def _get_first_and_last_entry_date(
-            log_file_path: Path
+        log_file_path: Path,
     ) -> tuple[None | datetime.datetime, None | datetime.datetime]:
         log_file = log_file_path.read_text(encoding='utf-8', errors='backslashreplace')
 
@@ -97,12 +98,7 @@ class LoggingFilesTableView(LoggerMixin, TpLoginRequiredMixin, LoggingContextMix
         else:
             updated_at = _('None')
 
-
-        return {
-            'filename': log_filename,
-            'created_at': created_at,
-            'updated_at': updated_at
-        }
+        return {'filename': log_filename, 'created_at': created_at, 'updated_at': updated_at}
 
     @LoggerMixin.log_exceptions
     def get_queryset(self) -> list[dict[str, str]]:
@@ -113,9 +109,11 @@ class LoggingFilesTableView(LoggerMixin, TpLoginRequiredMixin, LoggingContextMix
         self.queryset = [self._get_log_file_data(log_file_name) for log_file_name in valid_log_files]
         return super().get_queryset()
 
+
 class LoggingFilesDetailsView(LoggerMixin, LoggingContextMixin, TpLoginRequiredMixin, TemplateView):
     """Log file detail view, allows to view the content of a single log file without download."""
-    http_method_names = ('get', )
+
+    http_method_names = ('get',)
 
     template_name = 'settings/logging/logging_files_details.html'
     log_directory = LOG_DIR_PATH
@@ -138,7 +136,8 @@ class LoggingFilesDetailsView(LoggerMixin, LoggingContextMixin, TpLoginRequiredM
 
 class LoggingFilesDownloadView(LoggerMixin, LoggingContextMixin, TpLoginRequiredMixin, TemplateView):
     """View to download a single log file"""
-    http_method_names = ('get', )
+
+    http_method_names = ('get',)
 
     @LoggerMixin.log_exceptions
     def get(self, *_args: Any, **kwargs: Any) -> HttpResponse:
@@ -150,14 +149,17 @@ class LoggingFilesDownloadView(LoggerMixin, LoggingContextMixin, TpLoginRequired
             exc_msg = 'Log file not found.'
             raise Http404(exc_msg)
 
-        response = HttpResponse(log_file_path.read_text(encoding='utf-8', errors='backslashreplace'), content_type='text/plain')
+        response = HttpResponse(
+            log_file_path.read_text(encoding='utf-8', errors='backslashreplace'), content_type='text/plain'
+        )
         response['Content-Disposition'] = f'attachment; filename={filename}'
         return response
 
 
 class LoggingFilesDownloadMultipleView(LoggerMixin, LoggingContextMixin, TpLoginRequiredMixin, View):
     """View to download multiple log files as a single archive."""
-    http_method_names = ('get', )
+
+    http_method_names = ('get',)
 
     @classmethod
     @LoggerMixin.log_exceptions
@@ -177,10 +179,7 @@ class LoggingFilesDownloadMultipleView(LoggerMixin, LoggingContextMixin, TpLogin
 
         filenames = [filename for filename in filenames.split('/') if filename]
 
-        file_collection = [
-            (filename, (LOG_DIR_PATH / Path(filename)).read_bytes())
-            for filename in filenames
-        ]
+        file_collection = [(filename, (LOG_DIR_PATH / Path(filename)).read_bytes()) for filename in filenames]
 
         if archive_format.lower() == 'zip':
             bytes_io = io.BytesIO()

--- a/trustpoint/settings/views/security.py
+++ b/trustpoint/settings/views/security.py
@@ -1,4 +1,5 @@
 """Django Views"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -20,7 +21,6 @@ from trustpoint.views.base import (
 
 if TYPE_CHECKING:
     from typing import Any
-
 
 
 class SecurityView(TpLoginRequiredMixin, SecurityLevelMixin, FormView):

--- a/trustpoint/setup_wizard/__init__.py
+++ b/trustpoint/setup_wizard/__init__.py
@@ -6,14 +6,13 @@ import enum
 
 WIZARD_STATE_PATH = Path('/etc/trustpoint/wizard/state')
 
-class SetupWizardState(enum.Enum):
 
+class SetupWizardState(enum.Enum):
     WIZARD_INITIAL = WIZARD_STATE_PATH / Path('WIZARD_INITIAL')
     WIZARD_TLS_SERVER_CREDENTIAL_APPLY = WIZARD_STATE_PATH / Path('WIZARD_TLS_SERVER_CREDENTIAL_APPLY')
     WIZARD_DEMO_DATA = WIZARD_STATE_PATH / Path('WIZARD_DEMO_DATA')
     WIZARD_CREATE_SUPER_USER = WIZARD_STATE_PATH / Path('WIZARD_CREATE_SUPER_USER')
     WIZARD_COMPLETED = WIZARD_STATE_PATH / Path('WIZARD_COMPLETED')
-
 
     @classmethod
     def get_current_state(cls) -> SetupWizardState:

--- a/trustpoint/setup_wizard/forms.py
+++ b/trustpoint/setup_wizard/forms.py
@@ -11,19 +11,11 @@ class EmptyForm(forms.Form):
 
 class StartupWizardTlsCertificateForm(forms.Form):
     ipv4_addresses = forms.CharField(
-        label=_('IPv4-Addresses (comma-separated list)'),
-        initial='127.0.0.1, ',
-        required=False
+        label=_('IPv4-Addresses (comma-separated list)'), initial='127.0.0.1, ', required=False
     )
-    ipv6_addresses = forms.CharField(
-        label=_('IPv6-Addresses (comma-separated list)'),
-        initial='::1, ',
-        required=False
-    )
+    ipv6_addresses = forms.CharField(label=_('IPv6-Addresses (comma-separated list)'), initial='::1, ', required=False)
     domain_names = forms.CharField(
-        label=_('Domain-Names (comma-separated list)'),
-        initial='localhost, ',
-        required=False
+        label=_('Domain-Names (comma-separated list)'), initial='localhost, ', required=False
     )
 
     def clean_ipv4_addresses(self):
@@ -56,7 +48,6 @@ class StartupWizardTlsCertificateForm(forms.Form):
         domain_names = data.split(',')
         # TODO(AlexHx8472): Check for valid domains.
         return [domain_name.strip() for domain_name in domain_names if domain_name.strip() != '']
-
 
     def clean(self):
         cleaned_data = super().clean()

--- a/trustpoint/setup_wizard/tls_credential.py
+++ b/trustpoint/setup_wizard/tls_credential.py
@@ -12,13 +12,14 @@ from trustpoint_core.serializer import CredentialSerializer, PrivateKeySerialize
 
 ONE_DAY = datetime.timedelta(days=1)
 
-class Generator:
 
+class Generator:
     def __init__(
-            self,
-            ipv4_addresses: list[ipaddress.IPv4Address],
-            ipv6_addresses: list[ipaddress.IPv6Address],
-            domain_names: list[str]):
+        self,
+        ipv4_addresses: list[ipaddress.IPv4Address],
+        ipv6_addresses: list[ipaddress.IPv6Address],
+        domain_names: list[str],
+    ):
         self._ipv4_addresses = ipv4_addresses
         self._ipv6_addresses = ipv6_addresses
         self._domain_names = domain_names
@@ -33,27 +34,27 @@ class Generator:
         public_key = private_key_serializer.public_key_serializer.as_crypto()
 
         builder = x509.CertificateBuilder()
-        builder = builder.subject_name(x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, 'Trustpoint TLS Root CA'),
-        ]))
-        builder = builder.issuer_name(x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, 'Trustpoint TLS Root CA'),
-        ]))
+        builder = builder.subject_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, 'Trustpoint TLS Root CA'),
+                ]
+            )
+        )
+        builder = builder.issuer_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, 'Trustpoint TLS Root CA'),
+                ]
+            )
+        )
         builder = builder.not_valid_before(datetime.datetime.today() - ONE_DAY)
         builder = builder.not_valid_after(datetime.datetime.today() + (4 * 365 * ONE_DAY))
         builder = builder.serial_number(x509.random_serial_number())
         builder = builder.public_key(public_key)
-        builder = builder.add_extension(
-            x509.SubjectKeyIdentifier.from_public_key(public_key),
-            critical=False
-        )
-        builder = builder.add_extension(
-            x509.AuthorityKeyIdentifier.from_issuer_public_key(public_key),
-            critical=False
-        )
-        builder = builder.add_extension(
-            x509.BasicConstraints(ca=True, path_length=1), critical=True
-        )
+        builder = builder.add_extension(x509.SubjectKeyIdentifier.from_public_key(public_key), critical=False)
+        builder = builder.add_extension(x509.AuthorityKeyIdentifier.from_issuer_public_key(public_key), critical=False)
+        builder = builder.add_extension(x509.BasicConstraints(ca=True, path_length=1), critical=True)
         builder = builder.add_extension(
             x509.KeyUsage(
                 digital_signature=True,
@@ -66,10 +67,11 @@ class Generator:
                 encipher_only=False,
                 decipher_only=False,
             ),
-            critical=True
+            critical=True,
         )
         root_ca_certificate = builder.sign(
-            private_key=private_key, algorithm=hashes.SHA256(),
+            private_key=private_key,
+            algorithm=hashes.SHA256(),
         )
 
         return CredentialSerializer((private_key, root_ca_certificate, None))
@@ -80,27 +82,27 @@ class Generator:
         public_key = private_key_serializer.public_key_serializer.as_crypto()
 
         builder = x509.CertificateBuilder()
-        builder = builder.subject_name(x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, 'Trustpoint TLS Issuing CA'),
-        ]))
-        builder = builder.issuer_name(x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, 'Trustpoint TLS Root CA'),
-        ]))
+        builder = builder.subject_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, 'Trustpoint TLS Issuing CA'),
+                ]
+            )
+        )
+        builder = builder.issuer_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, 'Trustpoint TLS Root CA'),
+                ]
+            )
+        )
         builder = builder.not_valid_before(datetime.datetime.today() - ONE_DAY)
         builder = builder.not_valid_after(datetime.datetime.today() + (2 * 365 * ONE_DAY))
         builder = builder.serial_number(x509.random_serial_number())
         builder = builder.public_key(public_key)
-        builder = builder.add_extension(
-            x509.SubjectKeyIdentifier.from_public_key(public_key),
-            critical=False
-        )
-        builder = builder.add_extension(
-            x509.AuthorityKeyIdentifier.from_issuer_public_key(public_key),
-            critical=False
-        )
-        builder = builder.add_extension(
-            x509.BasicConstraints(ca=True, path_length=0), critical=True
-        )
+        builder = builder.add_extension(x509.SubjectKeyIdentifier.from_public_key(public_key), critical=False)
+        builder = builder.add_extension(x509.AuthorityKeyIdentifier.from_issuer_public_key(public_key), critical=False)
+        builder = builder.add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
         builder = builder.add_extension(
             x509.KeyUsage(
                 digital_signature=True,
@@ -113,27 +115,36 @@ class Generator:
                 encipher_only=False,
                 decipher_only=False,
             ),
-            critical=True
+            critical=True,
         )
         issuing_ca_certificate = builder.sign(
-            private_key=root_ca_credential.credential_private_key.as_crypto(), algorithm=hashes.SHA256(),
+            private_key=root_ca_credential.credential_private_key.as_crypto(),
+            algorithm=hashes.SHA256(),
         )
 
         return CredentialSerializer(
-            (private_key, issuing_ca_certificate, [root_ca_credential.credential_certificate.as_crypto()]))
-
+            (private_key, issuing_ca_certificate, [root_ca_credential.credential_certificate.as_crypto()])
+        )
 
     def _generate_tls_server_credential(self, issuing_ca_credential: CredentialSerializer) -> CredentialSerializer:
         one_day = datetime.timedelta(1, 0, 0)
         private_key = ec.generate_private_key(curve=ec.SECP256R1())
         public_key = private_key.public_key()
         builder = x509.CertificateBuilder()
-        builder = builder.subject_name(x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, 'Trustpoint Self-Signed TLS-Server Credential'),
-        ]))
-        builder = builder.issuer_name(x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, 'Trustpoint Self-Signed TLS-Server Credential'),
-        ]))
+        builder = builder.subject_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, 'Trustpoint Self-Signed TLS-Server Credential'),
+                ]
+            )
+        )
+        builder = builder.issuer_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, 'Trustpoint Self-Signed TLS-Server Credential'),
+                ]
+            )
+        )
         builder = builder.not_valid_before(datetime.datetime.today() - one_day)
         builder = builder.not_valid_after(datetime.datetime.today() + (one_day * 365))
         builder = builder.serial_number(x509.random_serial_number())
@@ -143,14 +154,8 @@ class Generator:
             x509.BasicConstraints(ca=False, path_length=None),
             critical=False,
         )
-        builder = builder.add_extension(
-            x509.SubjectKeyIdentifier.from_public_key(public_key),
-            critical=False
-        )
-        builder = builder.add_extension(
-            x509.AuthorityKeyIdentifier.from_issuer_public_key(public_key),
-            critical=False
-        )
+        builder = builder.add_extension(x509.SubjectKeyIdentifier.from_public_key(public_key), critical=False)
+        builder = builder.add_extension(x509.AuthorityKeyIdentifier.from_issuer_public_key(public_key), critical=False)
         builder = builder.add_extension(
             x509.KeyUsage(
                 digital_signature=True,
@@ -163,11 +168,10 @@ class Generator:
                 encipher_only=False,
                 decipher_only=False,
             ),
-            critical=True
+            critical=True,
         )
         builder = builder.add_extension(
-            x509.ExtendedKeyUsage([x509.oid.ExtendedKeyUsageOID.SERVER_AUTH]),
-            critical=False
+            x509.ExtendedKeyUsage([x509.oid.ExtendedKeyUsageOID.SERVER_AUTH]), critical=False
         )
         san = []
         for ipv4_address in self._ipv4_addresses:
@@ -176,13 +180,11 @@ class Generator:
             san.append(x509.IPAddress(ipv6_address))
         for domain_name in self._domain_names:
             san.append(x509.DNSName(domain_name))
-        builder = builder.add_extension(
-            x509.SubjectAlternativeName(san),
-            critical=True
-        )
+        builder = builder.add_extension(x509.SubjectAlternativeName(san), critical=True)
 
         certificate = builder.sign(
-            private_key=private_key, algorithm=hashes.SHA256(),
+            private_key=private_key,
+            algorithm=hashes.SHA256(),
         )
 
         return CredentialSerializer(
@@ -191,14 +193,12 @@ class Generator:
                 certificate,
                 [
                     issuing_ca_credential.credential_certificate.as_crypto(),
-                    issuing_ca_credential.additional_certificates.as_crypto()[0]
-                ]
+                    issuing_ca_credential.additional_certificates.as_crypto()[0],
+                ],
             )
         )
 
-
     def generate_tls_credential(self) -> CredentialSerializer:
-
         root_ca_credential = self._generate_root_ca()
         issuing_ca_credential = self._generate_issuing_ca_credential(root_ca_credential)
         return self._generate_tls_server_credential(issuing_ca_credential)

--- a/trustpoint/setup_wizard/urls.py
+++ b/trustpoint/setup_wizard/urls.py
@@ -1,6 +1,5 @@
 """URL configuration for the users application."""
 
-
 from django.urls import path
 
 from setup_wizard.views import (
@@ -10,48 +9,37 @@ from setup_wizard.views import (
     SetupWizardTlsServerCredentialApplyView,
     SetupWizardTlsServerCredentialApplyCancelView,
     SetupWizardDemoDataView,
-    SetupWizardCreateSuperUserView
+    SetupWizardCreateSuperUserView,
 )
 
 app_name = 'setup_wizard'
 urlpatterns = [
-    path(
-        '',
-        SetupWizardInitialView.as_view(),
-        name='initial'),
+    path('', SetupWizardInitialView.as_view(), name='initial'),
     path(
         'generate-tls-server-credential/',
         SetupWizardGenerateTlsServerCredentialView.as_view(),
-        name='generate_tls_server_credential'
+        name='generate_tls_server_credential',
     ),
     path(
         'import-tls-server-credential/',
         SetupWizardImportTlsServerCredentialView.as_view(),
-        name='import_tls_server_credential'
+        name='import_tls_server_credential',
     ),
     path(
         'tls-server-credential-apply/',
         SetupWizardTlsServerCredentialApplyView.as_view(),
-        name='tls_server_credential_apply'
+        name='tls_server_credential_apply',
     ),
     path(
         'tls-server-credential-apply/<str:file_format>/',
         SetupWizardTlsServerCredentialApplyView.as_view(),
-        name='tls_server_credential_apply'
+        name='tls_server_credential_apply',
     ),
     path(
         'tls-server-credential-apply-cancel/',
         SetupWizardTlsServerCredentialApplyCancelView.as_view(),
-        name='tls_server_credential_apply_cancel'
+        name='tls_server_credential_apply_cancel',
     ),
-    path(
-        'demo-data/',
-        SetupWizardDemoDataView.as_view(),
-        name='demo_data'
-    ),
-    path(
-        'create-super-user',
-        SetupWizardCreateSuperUserView.as_view(),
-        name='create_super_user'
-    )
+    path('demo-data/', SetupWizardDemoDataView.as_view(), name='demo_data'),
+    path('create-super-user', SetupWizardCreateSuperUserView.as_view(), name='create_super_user'),
 ]

--- a/trustpoint/setup_wizard/views.py
+++ b/trustpoint/setup_wizard/views.py
@@ -236,7 +236,7 @@ class SetupWizardGenerateTlsServerCredentialView(FormView):
 
             _ = CredentialModel.save_credential_serializer(
                 credential_serializer=tls_server_credential,
-                credential_type=CredentialModel.CredentialTypeChoice.TRUSTPOINT_TLS_SERVER
+                credential_type=CredentialModel.CredentialTypeChoice.TRUSTPOINT_TLS_SERVER,
             )
 
             execute_shell_script(SCRIPT_WIZARD_INITIAL)
@@ -252,7 +252,9 @@ class SetupWizardGenerateTlsServerCredentialView(FormView):
             messages.add_message(self.request, messages.ERROR, f'Transition script not found: {SCRIPT_WIZARD_INITIAL}.')
             return redirect('setup_wizard:initial', permanent=False)
         except Exception as e:  # noqa: BLE001
-            messages.add_message(self.request, messages.ERROR, f'Error generating TLS Server Credential: {e} {traceback.format_exc()}')
+            messages.add_message(
+                self.request, messages.ERROR, f'Error generating TLS Server Credential: {e} {traceback.format_exc()}'
+            )
             return redirect('setup_wizard:initial', permanent=False)
 
     def _get_error_message_from_return_code(self, return_code: int) -> str:
@@ -439,7 +441,7 @@ class SetupWizardTlsServerCredentialApplyView(FormView):
             messages.add_message(
                 self.request,
                 messages.ERROR,
-                f"Invalid file format requested: {file_format}. Supported formats: {', '.join(valid_formats)}.",
+                f'Invalid file format requested: {file_format}. Supported formats: {", ".join(valid_formats)}.',
             )
             return redirect('setup_wizard:tls_server_credential_apply', permanent=False)
 

--- a/trustpoint/templates/devices/credentials/certificate_lifecycle_management.html
+++ b/trustpoint/templates/devices/credentials/certificate_lifecycle_management.html
@@ -56,6 +56,12 @@
                     <br>
                     <a href="{% url 'devices:certificate_lifecycle_management-issue_tls_server_credential' pk=device.id %}"
                        class="btn btn-primary tp-table-btn min-width-20 mt-3">{% trans "Issue New TLS-Server Credential" %}</a>
+                    <hr>
+                    <a href="{% url 'devices:certificate_lifecycle_management-issue_opcua_client_credential' pk=device.id %}"
+                       class="btn btn-primary tp-table-btn min-width-20">{% trans "Issue New OPC UA Client Credential" %}</a>
+                    <br>
+                    <a href="{% url 'devices:certificate_lifecycle_management-issue_opcua_server_credential' pk=device.id %}"
+                       class="btn btn-primary tp-table-btn min-width-20 mt-3">{% trans "Issue New OPC UA Server Credential" %}</a>
                     <div class="mb-5"></div>
                 {% endif %}
             {% else %}

--- a/trustpoint/templates/devices/credentials/certificate_lifecycle_management.html
+++ b/trustpoint/templates/devices/credentials/certificate_lifecycle_management.html
@@ -51,18 +51,21 @@
                 {% if device.pki_protocol == device.PkiProtocol.MANUAL.value %}
                     <h2>{% trans "Issue New Application Credentials" %}</h2>
                     <hr>
-                    <a href="{% url 'devices:certificate_lifecycle_management-issue_tls_client_credential' pk=device.id %}"
-                       class="btn btn-primary tp-table-btn min-width-20">{% trans "Issue New TLS-Client Credential" %}</a>
+                    <div class="d-flex flex-wrap align-items-start gap-2">
+                        <a href="{% url 'devices:certificate_lifecycle_management-issue_tls_client_credential' pk=device.id %}"
+                           class="btn btn-primary tp-table-btn min-width-20">{% trans "TLS-Client Credential" %}</a>
+                        <a href="{% url 'devices:certificate_lifecycle_management-issue_tls_server_credential' pk=device.id %}"
+                           class="btn btn-primary tp-table-btn min-width-20">{% trans "TLS-Server Credential" %}</a>
+                    </div>
                     <br>
-                    <a href="{% url 'devices:certificate_lifecycle_management-issue_tls_server_credential' pk=device.id %}"
-                       class="btn btn-primary tp-table-btn min-width-20 mt-3">{% trans "Issue New TLS-Server Credential" %}</a>
-                    <hr>
-                    <a href="{% url 'devices:certificate_lifecycle_management-issue_opcua_client_credential' pk=device.id %}"
-                       class="btn btn-primary tp-table-btn min-width-20">{% trans "Issue New OPC UA Client Credential" %}</a>
+                    <div class="d-flex flex-wrap align-items-start gap-2">
+                        <a href="{% url 'devices:certificate_lifecycle_management-issue_opcua_client_credential' pk=device.id %}"
+                           class="btn btn-primary tp-table-btn min-width-20">{% trans "OPC UA Client Credential" %}</a>
+                        <a href="{% url 'devices:certificate_lifecycle_management-issue_opcua_server_credential' pk=device.id %}"
+                           class="btn btn-primary tp-table-btn min-width-20">{% trans "OPC UA Server Credential" %}</a>
+                        <div class="mb-5"></div>
+                    </div>
                     <br>
-                    <a href="{% url 'devices:certificate_lifecycle_management-issue_opcua_server_credential' pk=device.id %}"
-                       class="btn btn-primary tp-table-btn min-width-20 mt-3">{% trans "Issue New OPC UA Server Credential" %}</a>
-                    <div class="mb-5"></div>
                 {% endif %}
             {% else %}
                 <h2 class="d-flex justify-content-between align-items-center">

--- a/trustpoint/templates/devices/credentials/issue_application_credential.html
+++ b/trustpoint/templates/devices/credentials/issue_application_credential.html
@@ -10,12 +10,12 @@
         <div class="card">
             <div class="card-header">
                 <div>
-                    <h1>{% trans 'Issue Domain Credential' %}</h1>
+                    <h1>{% trans 'Issue Application Credential' %}</h1>
                 </div>
             </div>
             <div class="card-body">
                 <div class="tp-card-centered-content">
-                    <h2>{% trans 'Domain Credential Details' %}</h2>
+                    <h2>{% trans 'Application Credential Details' %}</h2>
                     <hr>
                     {{ form|crispy }}
                 </div>
@@ -24,7 +24,7 @@
             <div class="card-footer d-flex justify-content-between align-items-center">
                 <div class="tp-card-btn-footer m-1">
                     <a href="{% url 'devices:certificate_lifecycle_management' pk=device.pk %}" class="btn btn-secondary">{% trans "Cancel" %}</a>
-                    <button type="submit" class="btn btn-primary">{% trans "Issue Domain Credential" %}</button>
+                    <button type="submit" class="btn btn-primary">{% trans "Issue Application Credential" %}</button>
                 </div>
             </div>
         </div>

--- a/trustpoint/trustpoint/__init__.py
+++ b/trustpoint/trustpoint/__init__.py
@@ -1,2 +1,1 @@
 """Core of the Trustpoint Django Application."""
-

--- a/trustpoint/trustpoint/forms.py
+++ b/trustpoint/trustpoint/forms.py
@@ -1,0 +1,21 @@
+"""This module provides utility methods for forms in the overall project."""
+from __future__ import annotations
+
+from django import forms
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+    from django.forms import BaseForm
+    _TypingForm = BaseForm
+else:
+    _TypingForm = object
+
+class CleanedDataNotNoneMixin(_TypingForm):
+
+    def clean(self) -> dict[str, Any]:
+        cleaned_data = super().clean()
+        if cleaned_data is None:
+            err_msg = 'Failed to get cleaned form data.'
+            raise forms.ValidationError(err_msg)
+        return cleaned_data

--- a/trustpoint/trustpoint/forms.py
+++ b/trustpoint/trustpoint/forms.py
@@ -1,4 +1,5 @@
 """This module provides utility methods for forms in the overall project."""
+
 from __future__ import annotations
 
 from django import forms
@@ -7,12 +8,13 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Any
     from django.forms import BaseForm
+
     _TypingForm = BaseForm
 else:
     _TypingForm = object
 
-class CleanedDataNotNoneMixin(_TypingForm):
 
+class CleanedDataNotNoneMixin(_TypingForm):
     def clean(self) -> dict[str, Any]:
         cleaned_data = super().clean()
         if cleaned_data is None:

--- a/trustpoint/trustpoint/settings.py
+++ b/trustpoint/trustpoint/settings.py
@@ -40,6 +40,7 @@ DATABASE_NAME = 'trustpoint_db'
 DATABASE_USER = 'admin'
 DATABASE_PASSWORD = 'testing321'  # noqa: S105
 
+
 def is_postgre_available() -> bool:
     """Checks whether PostgreSQL is available and issues differentiated error messages.
 
@@ -86,6 +87,7 @@ def is_postgre_available() -> bool:
         return False
 
     return True
+
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
@@ -185,9 +187,7 @@ else:
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
             'NAME': BASE_DIR / 'db.sqlite3',
-            'OPTIONS': {
-                'timeout': 20
-            }
+            'OPTIONS': {'timeout': 20},
         },
     }
 
@@ -220,7 +220,6 @@ LANGUAGES = [
     ('de', _('German')),
     ('en', _('English')),
 ]
-
 
 
 USE_I18N = True
@@ -266,9 +265,12 @@ LOG_FILE_PATH = LOG_DIR_PATH / Path('trustpoint.log')
 
 DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
 
+
 class UTCFormatter(logging.Formatter):
     """Custom logging formatter to use UTC time."""
+
     converter = time.gmtime
+
 
 LOGGING = {
     'version': 1,  # Indicates the version of the logging configuration
@@ -304,8 +306,10 @@ LOGGING = {
     },
 }
 
+
 # User interface config defaults
 class UIConfig:
     """User interface configuration defaults."""
+
     paginate_by: ClassVar[int] = 50
     notifications_paginate_by: ClassVar[int] = 5

--- a/trustpoint/trustpoint/urls.py
+++ b/trustpoint/trustpoint/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 
 """
+
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
@@ -31,10 +32,8 @@ from .views import base
 last_modified_date = timezone.now()
 
 
-if  settings.DEBUG:
-    urlpatterns = [
-        path('admin/', admin.site.urls)
-    ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+if settings.DEBUG:
+    urlpatterns = [path('admin/', admin.site.urls)] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 else:
     urlpatterns = []
 
@@ -48,14 +47,11 @@ urlpatterns += [
     path('home/', include('home.urls')),
     path('devices/', include('devices.urls')),
     path('settings/', include('settings.urls')),
-    path('i18n/', include("django.conf.urls.i18n")),
+    path('i18n/', include('django.conf.urls.i18n')),
     path(
         'jsi18n/',
-        vary_on_cookie(
-            last_modified(lambda req, **kw: last_modified_date)(
-                JavaScriptCatalog.as_view()
-        )),
-        name='javascript-catalog'
+        vary_on_cookie(last_modified(lambda req, **kw: last_modified_date)(JavaScriptCatalog.as_view())),
+        name='javascript-catalog',
     ),
     path('', base.IndexView.as_view()),
 ]

--- a/trustpoint/trustpoint/views/base.py
+++ b/trustpoint/trustpoint/views/base.py
@@ -6,18 +6,18 @@ which can be used within the apps.
 
 from __future__ import annotations
 
-from typing import Any, Callable
+import functools
 import logging
 import traceback
-import functools
+from collections.abc import Callable
+from typing import Any
 
 from django import forms as dj_forms
 from django.contrib import messages
-from django.db.models import QuerySet
-from django.http import Http404
-from django.core.exceptions import ImproperlyConfigured
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpRequest, HttpResponseRedirect
+from django.core.exceptions import ImproperlyConfigured
+from django.db.models import QuerySet, Model
+from django.http import Http404, HttpRequest, HttpResponseRedirect, HttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import RedirectView
@@ -39,16 +39,18 @@ class ListInDetailView(ListView):
     Note that 'model' and 'context_object_name' refer to the ListView.
     Use 'detail_model' and 'detail_context_object_name' for the DetailView.
     """
-    detail_context_object_name = 'object'
 
-    def get(self, request, *args, **kwargs):
+    detail_context_object_name = 'object'
+    object: Model
+
+    def get(self, *args: Any, **kwargs: Any) -> HttpResponse:
         self.object = self.get_object()
-        return super().get(request, *args, **kwargs)
+        return super().get(*args, **kwargs)
 
     def get_queryset_for_object(self):
         return self.detail_model.objects.all()
 
-    def get_object(self):
+    def get_object(self) -> Model:
         queryset = self.get_queryset_for_object()
         pk = self.kwargs.get('pk')
         if pk is None:
@@ -60,7 +62,7 @@ class ListInDetailView(ListView):
         context = super().get_context_data(**kwargs)
         context[self.detail_context_object_name] = self.object
         return context
-    
+
 
 class SortableTableMixin:
     """Adds utility for sorting a ListView query by URL parameters
@@ -81,7 +83,7 @@ class SortableTableMixin:
         """
         return sorted(list_of_dicts, key=lambda x: x[sort_param.lstrip('-')], reverse=sort_param.startswith('-'))
 
-    def get_queryset(self) -> QuerySet | list:
+    def get_queryset(self) -> QuerySet[Any]:
         if hasattr(self, 'queryset') and self.queryset is not None:
             queryset = self.queryset
         else:
@@ -113,6 +115,7 @@ class SortableTableMixin:
 
 class TpLoginRequiredMixin(LoginRequiredMixin):
     """LoginRequiredMixin that adds a warning message if the user is not logged in."""
+
     request: HttpRequest
 
     def handle_no_permission(self) -> HttpResponseRedirect:
@@ -147,17 +150,15 @@ class ContextDataMixin:
         prefix = 'context_'
         for attr in dir(self):
             if attr.startswith(prefix) and len(attr) > len(prefix):
-                kwargs.setdefault(attr[len(prefix):], getattr(self, attr))
+                kwargs.setdefault(attr[len(prefix) :], getattr(self, attr))
 
         super_get_context_method = getattr(super(), 'get_context_data', None)
         if super_get_context_method is None:
             return kwargs
-        else:
-            return super_get_context_method(**kwargs)
+        return super_get_context_method(**kwargs)
 
 
 class BulkDeletionMixin:
-
     queryset: Any
     get_queryset: Callable
     success_url = None
@@ -176,11 +177,10 @@ class BulkDeletionMixin:
         if self.success_url:
             return self.success_url
 
-        raise ImproperlyConfigured("No URL to redirect to. Provide a success_url.")
+        raise ImproperlyConfigured('No URL to redirect to. Provide a success_url.')
 
 
 class BaseBulkDeleteView(BulkDeletionMixin, FormMixin, BaseListView):
-
     form_class = dj_forms.Form
 
     def post(self, *args, **kwargs):
@@ -197,7 +197,6 @@ class BaseBulkDeleteView(BulkDeletionMixin, FormMixin, BaseListView):
 
 
 class PrimaryKeyListFromPrimaryKeyString:
-
     @staticmethod
     def get_pks_as_list(pks: str) -> list[str]:
         if pks:
@@ -213,7 +212,8 @@ class PrimaryKeyListFromPrimaryKeyString:
             return pks_list
 
         return []
-    
+
+
 class PrimaryKeyQuerysetFromUrlMixin(PrimaryKeyListFromPrimaryKeyString):
     def get_pks_path(self) -> str:
         return self.kwargs.get('pks')
@@ -250,11 +250,9 @@ class LoggerMixin:
 
         cls.logger = logging.getLogger('trustpoint').getChild(cls.__module__).getChild(cls.__name__)
 
-
     @staticmethod
     def log_exceptions(function):
-        """
-        Decorator that gets an appropriate logger and logs any unhandled exception.
+        """Decorator that gets an appropriate logger and logs any unhandled exception.
 
         Logs the type and message to both levels error and debug.
         Also adds the traceback to the debug level log.
@@ -269,11 +267,8 @@ class LoggerMixin:
                 return function(*args, **kwargs)
             except Exception as exception:
                 logger = logging.getLogger('trustpoint').getChild(function.__module__).getChild(function.__qualname__)
-                logger.error(
-                    f'Exception in {function.__name__}. '
-                    f'Type: {type(exception)}, '
-                    f'Message: {exception}'
-                )
+                logger.error(f'Exception in {function.__name__}. Type: {type(exception)}, Message: {exception}')
+
                 logger.debug(
                     f'Exception in {function.__name__}. '
                     f'Type: {type(exception)}, '

--- a/trustpoint/users/apps.py
+++ b/trustpoint/users/apps.py
@@ -1,7 +1,10 @@
 """Django apps module which defines the app configuration."""
+
 from django.apps import AppConfig
+
 
 class UsersConfig(AppConfig):
     """App configuration for the users app."""
+
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'users'

--- a/trustpoint/users/urls.py
+++ b/trustpoint/users/urls.py
@@ -1,6 +1,5 @@
 """URL configuration for the users application."""
 
-
 from django.contrib.auth import views as auth_views
 from django.urls import path
 
@@ -10,5 +9,5 @@ from users.views import TrustpointLoginView
 app_name = 'users'
 urlpatterns = [
     path('login/', TrustpointLoginView.as_view(template_name='users/login.html'), name='login'),
-    path('logout/', auth_views.LogoutView.as_view(template_name='users/logout.html'), name='logout')
+    path('logout/', auth_views.LogoutView.as_view(template_name='users/logout.html'), name='logout'),
 ]

--- a/trustpoint/users/views.py
+++ b/trustpoint/users/views.py
@@ -1,4 +1,5 @@
 """Views for the users application."""
+
 from __future__ import annotations
 
 from django.contrib.auth.views import LoginView

--- a/uv.lock
+++ b/uv.lock
@@ -1456,7 +1456,7 @@ requires-dist = [
     { name = "crispy-bootstrap5", specifier = "~=2024.10" },
     { name = "cryptography", specifier = ">=44.0.1" },
     { name = "devtools", marker = "extra == 'dev'", specifier = ">=0.12.2,<0.13" },
-    { name = "django", specifier = ">=5.1.6,<6" },
+    { name = "django", specifier = ">=5.1.6" },
     { name = "django-crispy-forms", specifier = "~=2.3" },
     { name = "django-extensions", marker = "extra == 'dev'", specifier = ">=3.2.3" },
     { name = "django-filter", specifier = "~=25.1" },


### PR DESCRIPTION
- Added BaseTlsCredentialIssuer
- New CredentialIssuer: OpcUaServerCredentialIssuer & OpcUaClientCredentialIssuer
- Reworked CredentialIssuer: LocalDomainCredentialIssuer, LocalTlsServerCredentialIssuer & LocalTlsClientCredentialIssuer
- Added manual issuance for OPC UA client and server certs
- Added OPC UA client and server certs for CMP CmpCertificationRequestView

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.