### PR TITLE
When creating a new keyless credentiial it tries to store the private…

### DIFF
--- a/trustpoint/pki/models/credential.py
+++ b/trustpoint/pki/models/credential.py
@@ -160,7 +160,7 @@ class CredentialModel(models.Model):
         """Stores a credential without a private key."""
         certificate_model = CertificateModel.save_certificate(certificate)
 
-        credential_model = cls.objects.create(credential_type=credential_type)
+        credential_model = cls.objects.create(credential_type=credential_type, private_key='')
 
         PrimaryCredentialCertificate.objects.create(
             certificate=certificate_model, credential=credential_model, is_primary=True

--- a/trustpoint/pki/models/credential.py
+++ b/trustpoint/pki/models/credential.py
@@ -160,7 +160,7 @@ class CredentialModel(models.Model):
         """Stores a credential without a private key."""
         certificate_model = CertificateModel.save_certificate(certificate)
 
-        credential_model = cls.objects.create(credential_type=credential_type, private_key=None)
+        credential_model = cls.objects.create(credential_type=credential_type)
 
         PrimaryCredentialCertificate.objects.create(
             certificate=certificate_model, credential=credential_model, is_primary=True


### PR DESCRIPTION
… key with None, which violates the database scheme.



**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.