### PR TITLE
Default login: Swap condition order and add docstring

### DIFF
--- a/trustpoint/trustpoint/middleware.py
+++ b/trustpoint/trustpoint/middleware.py
@@ -18,8 +18,9 @@ class TrustpointLoginRequiredMiddleware(LoginRequiredMiddleware):  # type: ignor
         view_args,  # noqa: ANN001
         view_kwargs,  # noqa: ANN001
     ):
-        """TODO(AlexHx8472): Add proper docstring."""
-        if any(request.path.startswith(path) for path in settings.PUBLIC_PATHS) and not request.user.is_authenticated:
+        """Allow unauthenticated access to public paths, else redirect to login page."""
+        if (not request.user.is_authenticated
+            and any(request.path.startswith(path) for path in settings.PUBLIC_PATHS)):
             return None
 
         return super().process_view(request, view_func, view_args, view_kwargs)


### PR DESCRIPTION
<!-- related issue number, remove if n/a -->
Related to #315

**Description of changes**
Swap the order of conditions in the if-statement
- that way, in case the user is authenticated, `any()` with the public parts does not have to be evaluated
- more readable

Replace placeholder docstring

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.