### PR TITLE
Add additional tests for model deletion and relation checking

### DIFF
--- a/trustpoint/devices/tests/test_model_delete.py
+++ b/trustpoint/devices/tests/test_model_delete.py
@@ -1,0 +1,64 @@
+"""Test cases for Trustpoint model deletion."""
+
+from typing import Any
+
+import pytest
+from django.core.exceptions import ValidationError
+from django.db.models import ProtectedError
+from pki.models.certificate import CertificateModel
+from pki.models.credential import CredentialModel
+from pki.models.domain import DomainModel
+
+from devices.models import DeviceModel, IssuedCredentialModel
+
+
+def test_device_delete_revocation(mock_models: dict[str, Any]) -> None:
+    """Tests that credentials issued to a device are deleted and certificates revoked on device deletion."""
+    device = mock_models['device']
+    assert device.issued_credentials.count() == 1, 'Mock Device should have one issued credential.'
+    issued_cred = device.issued_credentials.first()
+    assert issued_cred.credential.certificate.certificate_status == CertificateModel.CertificateStatus.OK, (
+        'Mock Device credential should not be revoked before deletion.'
+    )
+    device_id = device.id
+    issued_cred_id = issued_cred.id
+    cred_id = issued_cred.credential.id
+    cert_id = issued_cred.credential.certificate.id
+    device.delete()
+    # Ensure device, issued credential and credential are deleted
+    with pytest.raises(DeviceModel.DoesNotExist):
+        DeviceModel.objects.get(id=device_id)
+    with pytest.raises(IssuedCredentialModel.DoesNotExist):
+        IssuedCredentialModel.objects.get(id=issued_cred_id)
+    with pytest.raises(CredentialModel.DoesNotExist):
+        CredentialModel.objects.get(id=cred_id)
+
+    # Ensure certificate is revoked
+    cert = CertificateModel.objects.get(id=cert_id)
+    assert cert.certificate_status == CertificateModel.CertificateStatus.REVOKED, (
+        'Certificate should be revoked after delete.'
+    )
+
+
+def test_domain_delete(mock_models: dict[str, Any]) -> None:
+    """Tests that a domain can be deleted only if it has no associated devices."""
+    domain = mock_models['domain']
+    assert domain.devices.exists(), 'Mock Domain should have associated devices.'
+    domain_id = domain.id
+    with pytest.raises(ProtectedError):
+        domain.delete()
+
+    DeviceModel.objects.filter(domain=domain).delete()
+    # Ensure domain is deleted after device deletion
+    domain.delete()
+    with pytest.raises(DomainModel.DoesNotExist):
+        DomainModel.objects.get(id=domain_id)
+
+
+def test_ca_delete_with_issued_certificates(mock_models: dict[str, Any]) -> None:
+    """Tests that a CA can be deleted only if it has no associated domains and no issued unexpired certificates."""
+    ca = mock_models['ca']
+    assert ca.domains.exists(), 'Mock CA should have associated domains.'
+    # Ensure CA cannot be deleted with issued certificates
+    with pytest.raises(ValidationError):
+        ca.delete()

--- a/trustpoint/pki/tests/conftest.py
+++ b/trustpoint/pki/tests/conftest.py
@@ -1,7 +1,15 @@
 """pytest configuration for the tests in the PKI app."""
 
+from typing import Any
+
 import pytest
+from cryptography import x509
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+
+from pki.models.domain import DomainModel
+from pki.models.issuing_ca import IssuingCaModel
+from pki.util.x509 import CertificateGenerator
 
 
 @pytest.fixture(autouse=True)
@@ -32,3 +40,42 @@ def rsa_private_key() -> rsa.RSAPrivateKey:
 def ec_private_key() -> ec.EllipticCurvePrivateKey:
     """Generate a reusable EC private key."""
     return ec.generate_private_key(ec.SECP256R1())
+
+
+# ----------------------------
+# Test model instance Fixtures
+# ----------------------------
+
+CA_COMMON_NAME = 'Root CA'
+UNIQUE_NAME = CA_COMMON_NAME.replace(' ', '_').lower()
+CA_TYPE = IssuingCaModel.IssuingCaTypeChoice.LOCAL_UNPROTECTED
+
+DOMAIN_UNIQUE_NAME = 'domain_name'
+
+
+@pytest.fixture
+def issuing_ca_instance() -> dict[str, Any]:
+    """Fixture for a testing IssuingCaModel instance."""
+    cert, priv_key = CertificateGenerator.create_root_ca(cn=CA_COMMON_NAME)
+    issuing_ca = CertificateGenerator.save_issuing_ca(
+        issuing_ca_cert=cert, private_key=priv_key, chain=[], unique_name=UNIQUE_NAME, ca_type=CA_TYPE
+    )
+    return {'issuing_ca': issuing_ca, 'cert': cert, 'priv_key': priv_key}
+
+
+@pytest.fixture
+def domain_instance(issuing_ca_instance: dict[str, Any]) -> dict[str, Any]:
+    """Fixture for a DomainModel instance using a valid issuing CA."""
+    issuing_ca = issuing_ca_instance.get('issuing_ca')
+    priv_key = issuing_ca_instance.get('priv_key')
+    cert = issuing_ca_instance.get('cert')
+    if (
+        not isinstance(issuing_ca, IssuingCaModel)
+        or not isinstance(cert, x509.Certificate)
+        or not isinstance(priv_key, RSAPrivateKey)
+    ):
+        msg = 'Issuing CA not created properly'
+        raise TypeError(msg)
+    domain = DomainModel.objects.create(unique_name=DOMAIN_UNIQUE_NAME, issuing_ca=issuing_ca, is_active=True)
+    issuing_ca_instance.update({'domain': domain})
+    return issuing_ca_instance

--- a/trustpoint/pki/tests/test_models/test_domain_model.py
+++ b/trustpoint/pki/tests/test_models/test_domain_model.py
@@ -1,47 +1,20 @@
+"""Test the DomainModel class."""
+
 import datetime
 from typing import Any
 
 import pytest
 from cryptography import x509
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from django.utils import timezone
 from trustpoint_core import oid
 
 from pki.models import DomainModel, IssuingCaModel
-from pki.util.x509 import CertificateGenerator
 
 COMMON_NAME = 'Root CA'
 UNIQUE_NAME = COMMON_NAME.replace(' ', '_').lower()
 CA_TYPE = IssuingCaModel.IssuingCaTypeChoice.LOCAL_UNPROTECTED
 
 DOMAIN_UNIQUE_NAME = 'domain_name'
-
-
-@pytest.fixture
-def issuing_ca_instance() -> dict[str, Any]:
-    cert, priv_key = CertificateGenerator.create_root_ca(cn=COMMON_NAME)
-    issuing_ca = CertificateGenerator.save_issuing_ca(
-        issuing_ca_cert=cert, private_key=priv_key, chain=[], unique_name=UNIQUE_NAME, ca_type=CA_TYPE
-    )
-    return {'issuing_ca': issuing_ca, 'cert': cert, 'priv_key': priv_key}
-
-
-@pytest.fixture
-def domain_instance(issuing_ca_instance: dict[str, Any]) -> dict[str, Any]:
-    """Fixture for a DomainModel instance using a valid issuing CA."""
-    issuing_ca = issuing_ca_instance.get('issuing_ca')
-    priv_key = issuing_ca_instance.get('priv_key')
-    cert = issuing_ca_instance.get('cert')
-    if (
-        not isinstance(issuing_ca, IssuingCaModel)
-        or not isinstance(cert, x509.Certificate)
-        or not isinstance(priv_key, RSAPrivateKey)
-    ):
-        msg = 'Issuig CA not created properly'
-        raise TypeError(msg)
-    domain = DomainModel.objects.create(unique_name=DOMAIN_UNIQUE_NAME, issuing_ca=issuing_ca, is_active=True)
-    issuing_ca_instance.update({'domain': domain})
-    return issuing_ca_instance
 
 
 def test_attributes_and_properties(domain_instance: dict[str, Any]) -> None:


### PR DESCRIPTION
<!-- related issue number, remove if n/a -->
Related to #322 

**Description of changes**
Adds some more tests to ensure model deletion protection constraints work as intended.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.