### PR TITLE
Only reset database on first container start

### DIFF
--- a/docker/RESET_DB
+++ b/docker/RESET_DB
@@ -1,0 +1,2 @@
+If this file is present in /etc/trustpoint and named RESET_DB, it will reset the database and run migrations on startup.
+Then it is deleted so the database is kept between container restarts.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,10 +14,18 @@ if [ "$DATABASE_ENGINE" == "django.db.backends.postgresql" ]; then
   echo "PostgreSQL database is available!"
 fi
 
-# Reset the database
-echo "Resetting the database..."
-run_as_www_data "uv run trustpoint/manage.py reset_db --no-user --force"
-echo "Database reset."
+# Reset the database if the RESET_DB file exists
+RESET_DB_FILE="/etc/trustpoint/RESET_DB"
+
+if [ -f "$RESET_DB_FILE" ]; then
+  # Reset the database
+  echo "Resetting the database..."
+  run_as_www_data "uv run trustpoint/manage.py reset_db --no-user --force"
+  echo "Database reset."
+  rm -f "$RESET_DB_FILE"
+else
+  echo "Skipping database reset."
+fi
 
 # Collect static files
 echo "Collecting static files..."

--- a/trustpoint/templates/setup_wizard/generate_tls_server_credential.html
+++ b/trustpoint/templates/setup_wizard/generate_tls_server_credential.html
@@ -42,7 +42,7 @@
                 <hr>
                 <div class="tp-form-btn-group tp-form-btn-group">
                     <a href="{% url 'setup_wizard:initial' %}" class="btn btn-secondary w-100 mt-1">{% trans "Cancel" %}</a>
-                    <button class="btn btn-primary w-100 mt-1" type="submit">{% trans "Generate Self-Singed TLS-Server Credential" %}</button>
+                    <button class="btn btn-primary w-100 mt-1" type="submit">{% trans "Generate Self-Signed TLS-Server Credential" %}</button>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
**Description of changes**
Only resets the database and runs migrations if the `RESET_DB` file is present - afterwards delete it.
This file is part of the container build, so the DB is always reset when re-building the container, but never when just re-starting it.

Fixed typo in wizard

**Notes** <!-- optional -->
Use `docker compose up -d` for starting the containers.
Important: DO NOT use `docker compose down` if you intend to keep the DB, as this will remove the containers. On the next start, they will be regenerated including the reset file. Use `docker compose stop` instead.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.