### PR TITLE
Store apache config and trustpoint config in volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
       - "443:443"
     depends_on:
       - postgres
+    volumes:
+        - trustpoint_config:/etc/trustpoint
+        - apache_config:/etc/apache2
     environment:
       DATABASE_ENGINE: "django.db.backends.postgresql"
       DATABASE_NAME: "trustpoint_db"
@@ -32,4 +35,6 @@ services:
       POSTGRES_DB: "trustpoint_db"
 
 volumes:
+  trustpoint_config:
+  apache_config:
   postgres_data:


### PR DESCRIPTION
Related to #330 

**Description of changes**
Add apache and trustpoint config to volume, so after container restart or new build, we can still access it.


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ x ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.