### PR TITLE
Added success messages to PKI model create views

### DIFF
--- a/trustpoint/pki/forms.py
+++ b/trustpoint/pki/forms.py
@@ -548,8 +548,9 @@ class IssuingCaAddFileImportSeparateFilesForm(LoggerMixin, forms.Form):
             certificate_serializer.as_crypto().fingerprint(algorithm=hashes.SHA256()).hex()
         )
         if certificate_in_db:
-            issuing_ca_in_db = IssuingCaModel.objects.get(credential__certificate=certificate_in_db)
-            if issuing_ca_in_db:
+            issuing_ca_qs = IssuingCaModel.objects.filter(credential__certificate=certificate_in_db)
+            if issuing_ca_qs.exists():
+                issuing_ca_in_db = issuing_ca_qs.first()
                 err_msg = (
                     f'Issuing CA {issuing_ca_in_db.unique_name} is already configured '
                     'with the same Issuing CA certificate.'

--- a/trustpoint/pki/views/domains.py
+++ b/trustpoint/pki/views/domains.py
@@ -70,6 +70,15 @@ class DomainCreateView(DomainContextMixin, CreateView[DomainModel, BaseModelForm
         del form.fields['is_active']
         return form
 
+    def form_valid(self, form: BaseModelForm[DomainModel]) -> HttpResponse:
+        """Handle the case where the form is valid."""
+        domain = form.save()
+        messages.success(
+            self.request,
+            _('Successfully created domain {name}.').format(name=domain.unique_name),
+        )
+        return super().form_valid(form)
+
 
 class DomainUpdateView(DomainContextMixin, UpdateView[DomainModel]):
     """View to edit a domain."""
@@ -269,7 +278,7 @@ class DevIdRegistrationCreateView(DomainContextMixin, FormView[DevIdRegistration
         dev_id_registration = form.save()
         messages.success(
             self.request,
-            f'Successfully created DevID Registration: {dev_id_registration.unique_name}',
+            _('Successfully created DevID registration pattern {name}.').format(name=dev_id_registration.unique_name),
         )
         return super().form_valid(form)
 

--- a/trustpoint/pki/views/issuing_cas.py
+++ b/trustpoint/pki/views/issuing_cas.py
@@ -77,6 +77,14 @@ class IssuingCaAddFileImportPkcs12View(IssuingCaContextMixin, FormView[IssuingCa
     form_class = IssuingCaAddFileImportPkcs12Form
     success_url = reverse_lazy('pki:issuing_cas')
 
+    def form_valid(self, form: IssuingCaAddFileImportPkcs12Form) -> HttpResponse:
+        """Handle the case where the form is valid."""
+        messages.success(
+            self.request,
+            _('Successfully added Issuing CA {name}.').format(name=form.cleaned_data['unique_name']),
+        )
+        return super().form_valid(form)
+
 
 class IssuingCaAddFileImportSeparateFilesView(IssuingCaContextMixin, FormView[IssuingCaAddFileImportSeparateFilesForm]):
     """View to import an Issuing CA from separate PEM files."""
@@ -84,6 +92,14 @@ class IssuingCaAddFileImportSeparateFilesView(IssuingCaContextMixin, FormView[Is
     template_name = 'pki/issuing_cas/add/file_import.html'
     form_class = IssuingCaAddFileImportSeparateFilesForm
     success_url = reverse_lazy('pki:issuing_cas')
+
+    def form_valid(self, form: IssuingCaAddFileImportSeparateFilesForm) -> HttpResponse:
+        """Handle the case where the form is valid."""
+        messages.success(
+            self.request,
+            _('Successfully added Issuing CA {name}.').format(name=form.cleaned_data['unique_name']),
+        )
+        return super().form_valid(form)
 
 
 class IssuingCaConfigView(LoggerMixin, IssuingCaContextMixin, DetailView[IssuingCaModel]):

--- a/trustpoint/pki/views/truststores.py
+++ b/trustpoint/pki/views/truststores.py
@@ -11,13 +11,13 @@ from django.http import Http404, HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse, reverse_lazy
 from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
 from django.views.generic.base import RedirectView
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import FormView
 from django.views.generic.list import ListView
-
-from trustpoint_core.serializer import CertificateFormat
 from trustpoint_core.archiver import ArchiveFormat, Archiver
+from trustpoint_core.serializer import CertificateFormat
 
 from pki.forms import TruststoreAddForm
 from pki.models import DomainModel
@@ -78,6 +78,18 @@ class TruststoreCreateView(TruststoresContextMixin, FormView[TruststoreAddForm])
                     kwargs={'pk': domain_id, 'truststore_id': truststore.id},
                 )
             )
+
+        n_certificates = truststore.number_of_certificates
+        msg_str = ngettext(
+            'Successfully created the Truststore %(name)s with %(count)i certificate.',
+            'Successfully created the Truststore %(name)s with %(count)i certificates.',
+            n_certificates,
+        ) % {
+            'name': truststore.unique_name,
+            'count': n_certificates,
+        }
+
+        messages.success(self.request, msg_str)
 
         return HttpResponseRedirect(reverse('pki:truststores'))
 

--- a/trustpoint/templates/pki/devid_registration/add.html
+++ b/trustpoint/templates/pki/devid_registration/add.html
@@ -30,7 +30,7 @@
                     </div>
 
                     <div class="card mt-4">
-                        <div class="card-header bg-primary text-white">
+                        <div class="card-header">
                             <h5 class="mb-0">{% trans 'Regex Helper' %}</h5>
                         </div>
                         <div class="card-body">
@@ -48,7 +48,7 @@
                             <!-- Generated Regex Options -->
                             <div id="regex-options" class="mb-3" style="display: none;">
                                 <label class="form-label">{% trans 'Generated Regex Variations:' %}</label>
-                                <ul class="list-group" id="regex-list"></ul>
+                                <ul class="list-group cursor" id="regex-list"></ul>
                             </div>
                         </div>
                     </div>

--- a/trustpoint/templates/setup_wizard/tls_server_credential_apply.html
+++ b/trustpoint/templates/setup_wizard/tls_server_credential_apply.html
@@ -44,7 +44,7 @@
                 {% csrf_token %}
                 <div class="tp-form-btn-group tp-form-btn-group">
                     <a href="{% url 'setup_wizard:tls_server_credential_apply_cancel' %}" class="btn btn-secondary w-100 mt-1">{% trans "Cancel" %}</a>
-                    <button class="btn btn-primary w-100 mt-1" type="submit">{% trans 'Apply TLS-Configurations' %}</button>
+                    <button class="btn btn-primary w-100 mt-1" type="submit">{% trans 'Apply TLS configuration' %}</button>
                 </div>
             </form>
     </div>

--- a/trustpoint/trustpoint/locale/de/LC_MESSAGES/django.po
+++ b/trustpoint/trustpoint/locale/de/LC_MESSAGES/django.po
@@ -3262,7 +3262,7 @@ msgstr ""
 "oder Betriebssystems zu importieren."
 
 #: .\templates\setup_wizard\tls_server_credential_apply.html:47
-msgid "Apply TLS-Configurations"
+msgid "Apply TLS configuration"
 msgstr "TLS-Konfiguration anwenden"
 
 #: .\templates\trustpoint\base.html:40


### PR DESCRIPTION
**Description of changes**
- Added success messages to Truststore, Domain, and Issuing CA Create views
- Fixed failure on adding CA when the CA certificate was already in the database, but not as a CA
- Cursor change on Registration pattern creation template

**Notes** <!-- optional -->
NOT related to #376, the fix contained in this PR is for a separate issue

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.