### PR TITLE
always runs PR report render

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -45,9 +45,9 @@ jobs:
           name: pytest-reports
           path: reports/
 
-      - name: Render the report to the PR when tests fail
+      - name: Render the report to the PR
         uses: marocchino/sticky-pull-request-comment@v2  # Posts test results as a comment on PRs.
-        if: failure()  # Only runs if tests fail.
+        if: always()  # Always runs.
         with:
           header: test-report
           recreate: true  # Replaces previous test reports to keep PR comments clean.


### PR DESCRIPTION
**Description of changes**
Now, always runs PR report render.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ x ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.