### PR TITLE
util/db.py rework for mypy

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+  "recommendations": [
+    "charliermarsh.ruff",
+    "magicstack.magicpython",
+    "ms-python.debugpy",
+    "ms-python.mypy-type-checker",
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "njpwerner.autodocstring",
+    "tamasfe.even-better-toml"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,15 @@
 {
-    "behave-vsc.featuresPath": "${workspaceFolder}/trustpoint/features"
+    "behave-vsc.featuresPath": "${workspaceFolder}/trustpoint/features",
+
+    // Tell ruff-vscode to prefer your environment over its bundle
+    "ruff.importStrategy": "fromEnvironment",
+
+    "mypy-type-checker.importStrategy": "fromEnvironment",
+    
+    "ruff.interpreter": [
+        "${workspaceFolder}/.venv/bin/python"  // on Unix/macOS
+    ],
+
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+    "python.terminal.activateEnvironment": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,15 +1,21 @@
 {
     "behave-vsc.featuresPath": "${workspaceFolder}/trustpoint/features",
 
-    // Tell ruff-vscode to prefer your environment over its bundle
     "ruff.importStrategy": "fromEnvironment",
 
     "mypy-type-checker.importStrategy": "fromEnvironment",
     
     "ruff.interpreter": [
-        "${workspaceFolder}/.venv/bin/python"  // on Unix/macOS
+        "${workspaceFolder}/.venv/bin/python"
     ],
 
     "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+    "[windows]": {
+        "ruff.interpreter": [
+            "${workspaceFolder}/.venv/Scripts/python.exe"
+        ],
+        "python.defaultInterpreterPath": "${workspaceFolder}/.venv/Scripts/python.exe"
+    },
+
     "python.terminal.activateEnvironment": true
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ ignore = [
     # TODO(AlexHx8472): We should use this in the future:
     "TD003",
 ]
-exclude = ["**/migrations/*"]
+exclude = ["**/migrations/*", "**/manage.py"]
 
 [tool.ruff.lint.per-file-ignores]
 "**/tests/**/**.py" = ["S101"]

--- a/trustpoint/pki/models/credential.py
+++ b/trustpoint/pki/models/credential.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from cryptography.hazmat.primitives import hashes
     from django.db.models import QuerySet
     from trustpoint_core.key_types import PrivateKey
+    from util.db import CustomDeleteActionManager
 
 
 __all__ = ['CertificateChainOrderModel', 'CredentialAlreadyExistsError', 'CredentialModel']
@@ -47,6 +48,8 @@ class CredentialModel(LoggerMixin, CustomDeleteActionModel):
 
     PKCS#11 credentials are not yet supported.
     """
+
+    objects: CustomDeleteActionManager[CredentialModel]
 
     class CredentialTypeChoice(models.IntegerChoices):
         """The CredentialTypeChoice defines the type of the credential and thus implicitly restricts its usage.

--- a/trustpoint/pki/models/issuing_ca.py
+++ b/trustpoint/pki/models/issuing_ca.py
@@ -23,6 +23,7 @@ from trustpoint.logger import LoggerMixin
 if TYPE_CHECKING:
     from django.db.models.query import QuerySet
     from trustpoint_core.serializer import CredentialSerializer
+    from util.db import CustomDeleteActionManager
 
 
 class IssuingCaModel(LoggerMixin, CustomDeleteActionModel):
@@ -30,6 +31,8 @@ class IssuingCaModel(LoggerMixin, CustomDeleteActionModel):
 
     This model contains the configurations of all Issuing CAs available within the Trustpoint.
     """
+
+    objects: CustomDeleteActionManager[IssuingCaModel]
 
     class IssuingCaTypeChoice(models.IntegerChoices):
         """The IssuingCaTypeChoice defines the type of Issuing CA.

--- a/trustpoint/util/__init__.py
+++ b/trustpoint/util/__init__.py
@@ -1,0 +1,1 @@
+"""This package contains utility functions for the trustpoint project."""

--- a/trustpoint/util/field.py
+++ b/trustpoint/util/field.py
@@ -1,3 +1,5 @@
+"""This module contains validators that are used in several different apps in the trustpoint project."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -10,11 +12,23 @@ if TYPE_CHECKING:
 
 
 class UniqueNameValidator(RegexValidator):
+    """Validates unique names used in the trustpoint."""
+
     form_label = _('(Must start with a letter. Can only contain letters, digits, underscores and hyphens)')
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initializes a UniqueNameValidator object.
+
+        Args:
+            args: Positional arguments are discarded.
+            kwargs: Keyword arguments are discarded._
+        """
+        del args
+        del kwargs
+        msg = f'Enter a valid unique name. {self.form_label}.'
+        trans_msg = _(msg)
         super().__init__(
             regex=r'^[a-zA-Z]+[a-zA-Z0-9_-]+$',
-            message=_(f'Enter a valid unique name. {self.form_label}.'),
+            message=trans_msg,
             code='invalid_unique_name',
         )


### PR DESCRIPTION
**Description of changes**
Makes use of Python 3.12 typing syntax to properly type the util/dp.py file.
Again possible to use Model.objects to perform queries.

Also added the .vscode settings file.


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ x ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.