### PR TITLE
Run all CI/CD pipelines on pushes to main

### DIFF
--- a/.github/workflows/codecov-upload.yml
+++ b/.github/workflows/codecov-upload.yml
@@ -1,7 +1,11 @@
 name: Codecov upload
 
 # Trigger this workflow on pull requests to ensure tests are executed before merging.
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   codecov-upload:

--- a/.github/workflows/docker-test-compose.yml
+++ b/.github/workflows/docker-test-compose.yml
@@ -1,6 +1,10 @@
 name: Docker Compose Test
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/f_001_feature_test.yml
+++ b/.github/workflows/f_001_feature_test.yml
@@ -1,6 +1,10 @@
 name: F_001
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,7 +1,11 @@
 name: MyPy
 
 # Trigger this workflow on pull requests, ensuring type checks are performed before merging.
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   mypy:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,7 +1,11 @@
 name: Pytest
 
 # Trigger this workflow on pull requests to ensure tests are executed before merging.
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   pytest:

--- a/.github/workflows/r_001_feature_test.yml
+++ b/.github/workflows/r_001_feature_test.yml
@@ -1,6 +1,10 @@
 name: R_001
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/r_003_feature_test.yml
+++ b/.github/workflows/r_003_feature_test.yml
@@ -1,6 +1,10 @@
 name: R_003
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/r_004_feature_test.yml
+++ b/.github/workflows/r_004_feature_test.yml
@@ -1,6 +1,10 @@
 name: R_004
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/r_006_feature_test.yml
+++ b/.github/workflows/r_006_feature_test.yml
@@ -1,6 +1,10 @@
 name: R_006
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/r_007_feature_test.yml
+++ b/.github/workflows/r_007_feature_test.yml
@@ -1,6 +1,10 @@
 name: R_007
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/r_008_feature_test.yml
+++ b/.github/workflows/r_008_feature_test.yml
@@ -1,6 +1,10 @@
 name: R_008
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/r_010_feature_test.yml
+++ b/.github/workflows/r_010_feature_test.yml
@@ -1,6 +1,10 @@
 name: R_010
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/r_011_feature_test.yml
+++ b/.github/workflows/r_011_feature_test.yml
@@ -1,6 +1,10 @@
 name: R_011
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/r_012_feature_test.yml
+++ b/.github/workflows/r_012_feature_test.yml
@@ -1,6 +1,10 @@
 name: R_012
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/r_013_feature_test.yml
+++ b/.github/workflows/r_013_feature_test.yml
@@ -1,6 +1,10 @@
 name: R_013
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/r_101_feature_test.yml
+++ b/.github/workflows/r_101_feature_test.yml
@@ -1,6 +1,10 @@
 name: R_101
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/r_102_feature_test.yml
+++ b/.github/workflows/r_102_feature_test.yml
@@ -1,6 +1,10 @@
 name: R_102
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,7 +1,11 @@
 name: Ruff
 
 # Trigger this workflow on pull requests to ensure tests are executed before merging.
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   ruff:


### PR DESCRIPTION
**Description of changes**
Changes workflow files to run GitHub Actions CI/CD pipelines both on pull requests and pushes to main.

**Notes** <!-- optional -->
This is intended to make status labels work by running pipelines on (merge) commits to main, e.g. https://github.com/Trustpoint-Project/trustpoint/commit/c0e46a04253b9f347e87c886d8ae05f43a652551

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.