### PR TITLE
VS Code settings handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,9 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
+# VS Code
+.vscode/settings.json
+
 media/
 # A very verbose way to ensure git tracks the /media/log directory
 !trustpoint/media/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,12 +1,12 @@
 {
   "recommendations": [
     "charliermarsh.ruff",
-    "magicstack.magicpython",
     "ms-python.debugpy",
     "ms-python.mypy-type-checker",
     "ms-python.python",
     "ms-python.vscode-pylance",
     "njpwerner.autodocstring",
-    "tamasfe.even-better-toml"
+    "tamasfe.even-better-toml",
+    "cucumberopen.cucumber-official"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,21 +1,9 @@
 {
-    "behave-vsc.featuresPath": "${workspaceFolder}/trustpoint/features",
+    // Add user-specific settings here
 
-    "ruff.importStrategy": "fromEnvironment",
+    "behave-vsc.featuresPath": "trustpoint/features",
 
-    "mypy-type-checker.importStrategy": "fromEnvironment",
-    
-    "ruff.interpreter": [
-        "${workspaceFolder}/.venv/bin/python"
-    ],
-
-    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
-    "[windows]": {
-        "ruff.interpreter": [
-            "${workspaceFolder}/.venv/Scripts/python.exe"
-        ],
-        "python.defaultInterpreterPath": "${workspaceFolder}/.venv/Scripts/python.exe"
-    },
-
-    "python.terminal.activateEnvironment": true
+    // Interpreter configuration for Windows
+    //"python.defaultInterpreterPath": "${workspaceFolder}/.venv/Scripts/python.exe",
+    //"ruff.interpreter": ["${workspaceFolder}/.venv/Scripts/python.exe"]
 }

--- a/.vscode/trustpoint.code-workspace
+++ b/.vscode/trustpoint.code-workspace
@@ -1,0 +1,19 @@
+{
+    "folders": [
+        {
+            "path": ".."
+        }
+    ],
+    "settings": {
+        // Add global Trustpoint vscode settings here
+
+        "ruff.importStrategy": "fromEnvironment",
+
+        "mypy-type-checker.importStrategy": "fromEnvironment",
+        
+        "ruff.interpreter": ["${workspaceFolder}/.venv/bin/python"],
+        "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+
+        "python.terminal.activateEnvironment": true
+    }
+}

--- a/docs/source/development/development.rst
+++ b/docs/source/development/development.rst
@@ -234,3 +234,20 @@ Trustpoint uses behave to run BDD tests. The tests are located in the
 .. code:: shell
 
    uv run behave
+
+--------------------
+Editor configuration
+--------------------
+
+We recommend using Visual Studio Code as the editor for Trustpoint development.
+To ensure the recommended settings are correctly loaded,
+please ensure that you open the project via the ``.code-workspace`` file:
+
+.. code:: shell
+
+   code .vscode/trustpoint.code-workspace
+
+Alternatively, use "File -> Open Workspace from File..." in the menu bar.
+
+Please place project-specific settings in the ``trustpoint.code-workspace`` file.
+The ``.vscode/settings.json`` file is ignored by git and is intended for user-specific configuration.


### PR DESCRIPTION
**Description of changes**
Adds a new layer (workspace) to the VS Code configuration.
This allows for user-defined settings overrides (branch-persistent with .gitignore)

**Notes** <!-- optional -->
For general project configuration, please place all settings in `.vscode/trustpoint.code-workspace`.
In order for these settings to apply, please open this .code-workspace file in the editor instead of the project folder.

Open to feedback on this. An alternative would be to use just settings.json, .gitignore it and use `git add -f .vs-code/settings.json` when you want to make updates for everyone. Both methods are not perfect.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.