### PR TITLE
mypy and pytest configuration fixes

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,8 +2,8 @@
   "recommendations": [
     "charliermarsh.ruff",
     "ms-python.debugpy",
-    "ms-python.mypy-type-checker",
     "ms-python.python",
+    "matangover.mypy",
     "ms-python.vscode-pylance",
     "njpwerner.autodocstring",
     "tamasfe.even-better-toml",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,4 +6,5 @@
     // Interpreter configuration for Windows
     //"python.defaultInterpreterPath": "${workspaceFolder}/.venv/Scripts/python.exe",
     //"ruff.interpreter": ["${workspaceFolder}/.venv/Scripts/python.exe"]
+
 }

--- a/.vscode/trustpoint.code-workspace
+++ b/.vscode/trustpoint.code-workspace
@@ -10,9 +10,11 @@
         "ruff.importStrategy": "fromEnvironment",
 
         "mypy-type-checker.importStrategy": "fromEnvironment",
+        "mypy.runUsingActiveInterpreter": true,
         
         "ruff.interpreter": ["${workspaceFolder}/.venv/bin/python"],
         "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+        "mypy.dmypyExecutable": "${workspaceFolder}/.venv/bin/dmypy",
 
         "python.terminal.activateEnvironment": true
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,7 @@ dependencies = [
     "django~=5.1.8",
     "django-crispy-forms~=2.3",
     "django-filter~=25.1",
-    "django-stubs>=5.2.0",
-    "django-stubs-ext>=5.2.0",
+    "django-stubs[compatible-mypy]>=5.2.0",
     "django-taggit>=6.1.0,<7",
     "psycopg>=3.2.6",
     "psycopg-binary>=3.2.6",
@@ -44,7 +43,6 @@ dev = [
     "pyopenssl >= 25, < 26",
     "werkzeug >= 3.1.3, < 4",
     "beautifulsoup4 >= 4.13.4",
-    "mypy >= 1.15.0",
     "ruff>=0.11.9",
 ]
 # For building docs
@@ -96,6 +94,7 @@ convention = "google"
 [tool.mypy]
 strict = true
 plugins = ["mypy_django_plugin.main"]
+mypy_path = ["trustpoint"]
 # TODO(AlexHx8472): Are we sure to exclude the tests?
 exclude = "^(tests/|.*/tests/|migrations/|.*/migrations/)"
 
@@ -108,6 +107,7 @@ django_settings_module = "trustpoint.settings"
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = 'trustpoint.settings'
+pythonpath = ["trustpoint"]
 python_files = 'test_*.py'
 md_report = true
 md_report_output = 'md-report.md'

--- a/uv.lock
+++ b/uv.lock
@@ -357,6 +357,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/01/5913ba5514337f3896c7bcbff6075808184dd303cd0fc3ecc289ec7e0c96/django_stubs-5.2.0-py3-none-any.whl", hash = "sha256:cd52da033489afc1357d6245f49e3cc57bf49015877253fb8efc6722ea3d2d2b", size = 481836, upload-time = "2025-04-26T10:49:02.97Z" },
 ]
 
+[package.optional-dependencies]
+compatible-mypy = [
+    { name = "mypy" },
+]
+
 [[package]]
 name = "django-stubs-ext"
 version = "5.2.0"
@@ -1140,8 +1145,7 @@ dependencies = [
     { name = "django" },
     { name = "django-crispy-forms" },
     { name = "django-filter" },
-    { name = "django-stubs" },
-    { name = "django-stubs-ext" },
+    { name = "django-stubs", extra = ["compatible-mypy"] },
     { name = "django-taggit" },
     { name = "psycopg" },
     { name = "psycopg-binary" },
@@ -1160,7 +1164,6 @@ dev = [
     { name = "devtools" },
     { name = "django-extensions" },
     { name = "docutils-stubs" },
-    { name = "mypy" },
     { name = "pyopenssl" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1187,8 +1190,7 @@ requires-dist = [
     { name = "django", specifier = "~=5.1.8" },
     { name = "django-crispy-forms", specifier = "~=2.3" },
     { name = "django-filter", specifier = "~=25.1" },
-    { name = "django-stubs", specifier = ">=5.2.0" },
-    { name = "django-stubs-ext", specifier = ">=5.2.0" },
+    { name = "django-stubs", extras = ["compatible-mypy"], specifier = ">=5.2.0" },
     { name = "django-taggit", specifier = ">=6.1.0,<7" },
     { name = "psycopg", specifier = ">=3.2.6" },
     { name = "psycopg-binary", specifier = ">=3.2.6" },
@@ -1207,7 +1209,6 @@ dev = [
     { name = "devtools", specifier = ">=0.12.2,<0.13" },
     { name = "django-extensions", specifier = ">=4.1" },
     { name = "docutils-stubs", specifier = ">=0.0.22,<0.0.23" },
-    { name = "mypy", specifier = ">=1.15.0" },
     { name = "pyopenssl", specifier = ">=25,<26" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
@@ -1261,11 +1262,11 @@ datetime = [
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.20250402"
+version = "6.0.12.20250516"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/68/609eed7402f87c9874af39d35942744e39646d1ea9011765ec87b01b2a3c/types_pyyaml-6.0.12.20250402.tar.gz", hash = "sha256:d7c13c3e6d335b6af4b0122a01ff1d270aba84ab96d1a1a1063ecba3e13ec075", size = 17282, upload-time = "2025-04-02T02:56:00.235Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/22/59e2aeb48ceeee1f7cd4537db9568df80d62bdb44a7f9e743502ea8aab9c/types_pyyaml-6.0.12.20250516.tar.gz", hash = "sha256:9f21a70216fc0fa1b216a8176db5f9e0af6eb35d2f2932acb87689d03a5bf6ba", size = 17378, upload-time = "2025-05-16T03:08:04.897Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/56/1fe61db05685fbb512c07ea9323f06ea727125951f1eb4dff110b3311da3/types_pyyaml-6.0.12.20250402-py3-none-any.whl", hash = "sha256:652348fa9e7a203d4b0d21066dfb00760d3cbd5a15ebb7cf8d33c88a49546681", size = 20329, upload-time = "2025-04-02T02:55:59.382Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5f/e0af6f7f6a260d9af67e1db4f54d732abad514252a7a378a6c4d17dd1036/types_pyyaml-6.0.12.20250516-py3-none-any.whl", hash = "sha256:8478208feaeb53a34cb5d970c56a7cd76b72659442e733e268a94dc72b2d0530", size = 20312, upload-time = "2025-05-16T03:08:04.019Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Description of changes**
Fixes the mypy and pytest configuration.

Pytest:
Did not import the correct settings.py.

Mypy:
Missing dependencies due to wrong installation method. -> django-stubs[compatible-mypy] instead of django-stubs, django-stubs-ext, mypy separately.
Did not import the correct settings.py, but instead loaded the settings app, thus falling back to global defaults.
Thus, until now, the django plugin for mypy was loaded but no monkey patching occurred, so type inference with django generic types was not happening...


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ x ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.