### PR TITLE
Do not allow importing EE certificates as CA

### DIFF
--- a/trustpoint/pki/models/issuing_ca.py
+++ b/trustpoint/pki/models/issuing_ca.py
@@ -102,6 +102,16 @@ class IssuingCaModel(LoggerMixin, CustomDeleteActionModel):
         Returns:
             IssuingCaModel: The newly created Issuing CA model.
         """
+        ca_cert = credential_serializer.certificate
+        if not ca_cert:
+            raise ValidationError(_('The provided credential is not a valid CA; it does not contain a certificate.'))
+        try:
+            bc_extension = ca_cert.extensions.get_extension_for_class(x509.BasicConstraints)
+        except x509.ExtensionNotFound:
+            raise ValidationError(_('The provided certificate is not a valid CA certificate; it does not contain a Basic Constraints extension.'))
+        if not bc_extension.value.ca:
+            raise ValidationError(_('The provided certificate is not a valid CA certificate; it is an End Entity certificate.'))
+
         issuing_ca_types = (
             cls.IssuingCaTypeChoice.AUTOGEN_ROOT,
             cls.IssuingCaTypeChoice.AUTOGEN,


### PR DESCRIPTION
Related to #376

**Description of changes**
Adds validation to prevent creating an Issuing CA model with a certificate that do not have a BasicConstraints `cA=true` extension.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.