### PR TITLE
Credential import form UX improvement

### DIFF
--- a/trustpoint/aoki/tests/client.py
+++ b/trustpoint/aoki/tests/client.py
@@ -230,14 +230,13 @@ class AokiClient:
             verify=False, # intentionally provisionally trusted  # noqa: S501
             timeout=5,
         )
+        # Step 2: Check server response, we are expecting a 200 OK response
         if response.status_code != HTTP_STATUS_OK:
             log.error('AOKI init request failed (%s): %s', response.status_code, response.text)
             return
-        # Step 2: Parse server response
-        # We are expecting a 200 OK response with a JSON body containing the aoki initialization data.
 
-        # Step 3: Parse the JSON body
-        # We are expecting a JSON body with the following structure:
+        # Step 3: Parse the response as JSON body containing the aoki initialization data
+        # We are expecting the response to contain a JSON body with the following structure:
         # {
         #   "aoki-init": {
         #     "version": "1.0",

--- a/trustpoint/pki/forms.py
+++ b/trustpoint/pki/forms.py
@@ -453,6 +453,8 @@ class IssuingCaAddFileImportSeparateFilesForm(LoggerMixin, forms.Form):
         widget=forms.TextInput(attrs={'autocomplete': 'nope'}),
         validators=[UniqueNameValidator()],
     )
+    ca_certificate = forms.FileField(label=_('Issuing CA Certificate (.cer, .der, .pem, .p7b, .p7c)'), required=True)
+    ca_certificate_chain = forms.FileField(label=_('[Optional] Certificate Chain (.pem, .p7b, .p7c).'), required=False)
     private_key_file = forms.FileField(label=_('Private Key File (.key, .pem)'), required=True)
     private_key_file_password = forms.CharField(
         # hack, force autocomplete off in chrome with: one-time-code
@@ -460,8 +462,6 @@ class IssuingCaAddFileImportSeparateFilesForm(LoggerMixin, forms.Form):
         label=_('[Optional] Private Key File Password'),
         required=False,
     )
-    ca_certificate = forms.FileField(label=_('Issuing CA Certificate (.cer, .der, .pem, .p7b, .p7c)'), required=True)
-    ca_certificate_chain = forms.FileField(label=_('[Optional] Certificate Chain (.pem, .p7b, .p7c).'), required=False)
 
     def clean_unique_name(self) -> str:
         """Validates the unique name to ensure it does not already exist in the database.
@@ -653,6 +653,8 @@ class OwnerCredentialFileImportForm(LoggerMixin, forms.Form):
         widget=forms.TextInput(attrs={'autocomplete': 'nope'}),
         validators=[UniqueNameValidator()],
     )
+    certificate = forms.FileField(label=_('DevOwnerID Certificate (.cer, .der, .pem, .p7b, .p7c)'), required=True)
+    certificate_chain = forms.FileField(label=_('[Optional] Certificate Chain (.pem, .p7b, .p7c).'), required=False)
     private_key_file = forms.FileField(label=_('Private Key File (.key, .pem)'), required=True)
     private_key_file_password = forms.CharField(
         # hack, force autocomplete off in chrome with: one-time-code
@@ -660,8 +662,6 @@ class OwnerCredentialFileImportForm(LoggerMixin, forms.Form):
         label=_('[Optional] Private Key File Password'),
         required=False,
     )
-    certificate = forms.FileField(label=_('DevOwnerID Certificate (.cer, .der, .pem, .p7b, .p7c)'), required=True)
-    certificate_chain = forms.FileField(label=_('[Optional] Certificate Chain (.pem, .p7b, .p7c).'), required=False)
 
     def clean_unique_name(self) -> str:
         """Validates the unique name to ensure it does not already exist in the database.

--- a/trustpoint/pki/management/commands/reset_db.py
+++ b/trustpoint/pki/management/commands/reset_db.py
@@ -92,7 +92,9 @@ class Command(BaseCommand):
             if 'migrations' in root:
                 for file in files:
                     if (file.endswith('.py') and file != '__init__.py') or file.endswith('.pyc'):
-                        if (keep_established and '_tp_v' in file and current_version_py_id not in file):
+                        if (keep_established and
+                            (('_tp_v' in file and current_version_py_id not in file) or '0001_initial' in file)
+                        ):
                             continue
                         try:
                             Path(Path(root) / file).unlink()


### PR DESCRIPTION
<!-- related issue number, remove if n/a -->
Related to #375 (review by @BytesWelder )

**Description of changes**
- In Issuing CA and DevOwnerID import forms, put certificates before private key fields
- Fix a bug in reset_db that would inadvertently delete initial migrations
- Change AOKI client step comments

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.