### PR TITLE
Change AOKI DevOwnerID device reference to a valid URI

### DIFF
--- a/docs/source/devices/aoki.rst
+++ b/docs/source/devices/aoki.rst
@@ -106,7 +106,7 @@ facilitate an arbitrary amount of device ownership transfers.
 The DevOwnerID MUST have a ``SubjectAltName`` extension that lists the
 IDevID certificate(s) the DevOwnerID is valid for. Each IDevID is listed
 as a ``UniformResourceIdentifier`` (URI) with the fixed format:
-``<IDevID_Subj_SN>.dev-owner.<IDevID_x509_SN>.<IDevID_SHA256_Fingerpr>.alt``,
+``dev-owner:<IDevID_Subj_SN>.<IDevID_x509_SN>.<IDevID_SHA256_Fingerpr>``,
 where: - ``IDevID_Subj_SN`` is the ``SerialNumber`` name attribute in
 the IDevID subject DN; or the character ``_`` (underscore) if this
 attribute is not present in the IDevID certificate - ``IDevID_x509_SN``

--- a/trustpoint/aoki/management/commands/aoki_gen_test_certs.py
+++ b/trustpoint/aoki/management/commands/aoki_gen_test_certs.py
@@ -106,9 +106,9 @@ class AokiTestCertGenerator:
 
         idevid_x509_sn = hex(idevid_cert.serial_number)[2:].zfill(16)
         idevid_sha256_fingerprint = idevid_cert.fingerprint(hashes.SHA256()).hex()
-        # Build URI string "<idevid_subj_sn>.dev-owner.<idevid_x509_sn>.<idevid_sha256_fingerprint>.alt"
+        # Build URI string "dev-owner:<idevid_subj_sn>.<idevid_x509_sn>.<idevid_sha256_fingerprint>"
         # If the IDevID Subject Serial Number is not present, '_' shall be used as a placeholder
-        idevid_san_uri = f'{TEST_SERIAL_NUMBER}.dev-owner.{idevid_x509_sn}.{idevid_sha256_fingerprint}.alt'
+        idevid_san_uri = f'dev-owner:{TEST_SERIAL_NUMBER}.{idevid_x509_sn}.{idevid_sha256_fingerprint}'
         print(f'DeviceOwnerID SAN URI: {idevid_san_uri}')
         ownerid_cert, ownerid_key = CertificateGenerator.create_ee(
             issuer_private_key=owner_ca_key,

--- a/trustpoint/aoki/tests/client.py
+++ b/trustpoint/aoki/tests/client.py
@@ -84,7 +84,7 @@ class AokiClient:
     def _get_idevid_owner_san_uri(self, idevid_cert: x509.Certificate) -> str:
         """Get the Owner ID SAN URI corresponding to a IDevID certificate.
 
-        Formatted as "<idevid_subj_sn>.dev-owner.<idevid_x509_sn>.<idevid_sha256_fingerprint>.alt
+        Formatted as "dev-owner:<idevid_subj_sn>.<idevid_x509_sn>.<idevid_sha256_fingerprint>"
         """
         try:
             sn_b = idevid_cert.subject.get_attributes_for_oid(x509.NameOID.SERIAL_NUMBER)[0].value
@@ -94,7 +94,7 @@ class AokiClient:
         self.idevid_subj_sn = idevid_subj_sn
         idevid_x509_sn = hex(idevid_cert.serial_number)[2:].zfill(16)
         idevid_sha256_fingerprint = idevid_cert.fingerprint(hashes.SHA256()).hex()
-        return f'{idevid_subj_sn}.dev-owner.{idevid_x509_sn}.{idevid_sha256_fingerprint}.alt'
+        return f'dev-owner:{idevid_subj_sn}.{idevid_x509_sn}.{idevid_sha256_fingerprint}'
 
     def _verify_matches_idevid_cert(self, owner_id_cert: x509.Certificate, idevid_cert: x509.Certificate) -> None:
         """Verify the Owner ID certificate is valid for the device IDevID."""

--- a/trustpoint/aoki/tests/cmp_client.py
+++ b/trustpoint/aoki/tests/cmp_client.py
@@ -58,7 +58,7 @@ class AokiCmpClient:
     def _get_idevid_owner_san_uri(self, idevid_cert: x509.Certificate) -> str:
         """Get the Owner ID SAN URI corresponding to a IDevID certificate.
 
-        Formatted as "<idevid_subj_sn>.dev-owner.<idevid_x509_sn>.<idevid_sha256_fingerprint>.alt
+        Formatted as "dev-owner:<idevid_subj_sn>.<idevid_x509_sn>.<idevid_sha256_fingerprint>"
         """
         try:
             sn_b = idevid_cert.subject.get_attributes_for_oid(x509.NameOID.SERIAL_NUMBER)[0].value
@@ -68,7 +68,7 @@ class AokiCmpClient:
         self.idevid_subj_sn = idevid_subj_sn
         idevid_x509_sn = hex(idevid_cert.serial_number)[2:].zfill(16)
         idevid_sha256_fingerprint = idevid_cert.fingerprint(hashes.SHA256()).hex()
-        return f'{idevid_subj_sn}.dev-owner.{idevid_x509_sn}.{idevid_sha256_fingerprint}.alt'
+        return f'dev-owner:{idevid_subj_sn}.{idevid_x509_sn}.{idevid_sha256_fingerprint}'
 
     def _verify_matches_idevid_cert(self, owner_id_cert: x509.Certificate, idevid_cert: x509.Certificate) -> None:
         """Verify the Owner ID certificate is valid for the device IDevID."""

--- a/trustpoint/aoki/views.py
+++ b/trustpoint/aoki/views.py
@@ -29,7 +29,7 @@ class AokiServiceMixin:
     def get_idevid_owner_san_uri(idevid_cert: x509.Certificate) -> str:
         """Get the Owner ID SAN URI corresponding to a IDevID certificate.
 
-        Formatted as '<IDevID_Subj_SN>.dev-owner.<IDevID_x509_SN>.<IDevID_SHA256_Fingerpr>.alt'
+        Formatted as 'dev-owner:<IDevID_Subj_SN>.<IDevID_x509_SN>.<IDevID_SHA256_Fingerpr>'
         """
         try:
             sn_b = idevid_cert.subject.get_attributes_for_oid(x509.NameOID.SERIAL_NUMBER)[0].value
@@ -38,7 +38,7 @@ class AokiServiceMixin:
             idevid_subj_sn = '_'
         idevid_x509_sn = hex(idevid_cert.serial_number)[2:].zfill(16)
         idevid_sha256_fingerprint = idevid_cert.fingerprint(hashes.SHA256()).hex()
-        return f'{idevid_subj_sn}.dev-owner.{idevid_x509_sn}.{idevid_sha256_fingerprint}.alt'
+        return f'dev-owner:{idevid_subj_sn}.{idevid_x509_sn}.{idevid_sha256_fingerprint}'
 
     @staticmethod
     def get_owner_credential(idevid_cert: x509.Certificate) -> CredentialModel | None:

--- a/trustpoint/pki/models/credential.py
+++ b/trustpoint/pki/models/credential.py
@@ -599,7 +599,7 @@ class OwnerCredentialModel(LoggerMixin, CustomDeleteActionModel):
             OwnerCredentialModel: The newly created owner credential model.
         """
         # Extract the IDevID references from the SAN of the DevOwnerID certificate
-        # Reference URI format: '<IDevID_Subj_SN>.dev-owner.<IDevID_x509_SN>.<IDevID_SHA256_Fingerpr>.alt'
+        # Reference URI format: 'dev-owner:<IDevID_Subj_SN>.<IDevID_x509_SN>.<IDevID_SHA256_Fingerpr>'
         idevid_refs: set[str] = set()
         owner_cert = credential_serializer.certificate
         if not owner_cert:


### PR DESCRIPTION
**Description of changes**
This changes the format the IDevID is referenced in an AOKI DevOwnerID certificate from
`<IDevID_Subj_SN>.dev-owner.<IDevID_x509_SN>.<IDevID_SHA256_Fingerprint>.alt`
to
`dev-owner:<IDevID_Subj_SN>.<IDevID_x509_SN>.<IDevID_SHA256_Fingerprint>`

The reason for this change is that we are using the `UniformResourceIdentifier` (URI) GeneralName type in the DevOwnerID SAN extension (as opposed to the `DNSName` type - which would not be the best fit as the device IDevID reference is not a valid DNS-resolvable hostname)

With this change, the SAN entry is a valid URI since it is no longer missing a scheme - in our case, `dev-owner:`. As it is now clearly no longer a hostname, the `.alt` TLD suffix can also be omitted.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.