### PR TITLE
Fix AOKI URL scheme

### DIFF
--- a/trustpoint/pki/models/credential.py
+++ b/trustpoint/pki/models/credential.py
@@ -627,8 +627,7 @@ class OwnerCredentialModel(LoggerMixin, CustomDeleteActionModel):
         for san in san_extension.value:
             if isinstance(san, x509.UniformResourceIdentifier):
                 san_uri_str = san.value
-                san_parts = san_uri_str.split('.')
-                if len(san_parts) == 5 and san_parts[1] == 'dev-owner' and san_parts[-1] == 'alt':
+                if san_uri_str.startswith('dev-owner:'):
                     idevid_refs.add(san_uri_str)
         if not idevid_refs:
             raise ValidationError(_('The provided certificate is not a valid DevOwnerID; it does not contain a valid IDevID reference in the SAN.'))


### PR DESCRIPTION
<!-- related issue number, remove if n/a -->
Related to #418 

**Description of changes**
Fixed: The check done when importing a DevOwnerID credential was not adapted to the new dev-owner: URI scheme, causing import of valid DevOwnerIDs to fail

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.