### PR TITLE
Unique name optional

### DIFF
--- a/trustpoint/util/field.py
+++ b/trustpoint/util/field.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from cryptography import x509
-from cryptography.hazmat.backends import default_backend
 from cryptography.x509.oid import NameOID
 from django.core.validators import RegexValidator
 from django.utils.translation import gettext_lazy as _


### PR DESCRIPTION
<!-- related issue number, remove if n/a -->
Related to TP-123

**Description of changes**
Make the Unique name field optional when creating certain models manually.

If left empty, an appropriate name is set automatically, e.g. from the subject name of an uploaded certificate. 

**Notes** <!-- optional -->


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.