### PR TITLE
remove signature suite

### DIFF
--- a/trustpoint/devices/models.py
+++ b/trustpoint/devices/models.py
@@ -405,22 +405,6 @@ class DeviceModel(CustomDeleteActionModel):
         """Gets the EST username."""
         return self.common_name
 
-    @property
-    def signature_suite(self) -> oid.SignatureSuite | None:
-        """Gets the corresponding SignatureSuite object."""
-        if self.domain is None:
-            return None
-        return oid.SignatureSuite.from_certificate(
-            self.domain.get_issuing_ca_or_value_error().credential.get_certificate_serializer().as_crypto()
-        )
-
-    @property
-    def public_key_info(self) -> oid.PublicKeyInfo | None:
-        """Gets the corresponding PublicKeyInfo object."""
-        if self.signature_suite is None:
-            return None
-        return self.signature_suite.public_key_info
-
     def clean(self) -> None:
         """Validation before saving the model."""
         if not (self.onboarding_config or self.no_onboarding_config):


### PR DESCRIPTION
Related to our discord exchange

**Description of changes**
Removed signature suite of the device.


**Notes**
Scanned through the code. Looks like only the help pages used the public_key_info/signature_suite of the ca from the decives.
I simply redirected them to use from the domain.

Later if we support an onboarding to multiple domains we need to add a mechanism to select the correct ca and so forth the correct signature_suite.
However it is something for the future.


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ x ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.