### PR TITLE
Domain detail can be reached from devices table

### DIFF
--- a/trustpoint/templates/devices/devices_table.html
+++ b/trustpoint/templates/devices/devices_table.html
@@ -1,77 +1,83 @@
 {% load i18n %}
 {% load sort_tags %}
 {% block devices_table %}
-    <table class="table">
-        <thead>
-        <tr>
-            <th id="checkbox-column"><input type="checkbox"/></th>
-            <th class="text-nowrap">
-                <a href="{% url_sort 'common_name' %}">
-                    {% trans 'Name' %} {{ request|sort_icon:'common_name' }}
-                </a>
-            </th>
-            <th class="text-nowrap">
-                <a href="{% url_sort 'domain' %}">
-                    {% trans 'Domain' %} {{ request|sort_icon:'domain' }}
-                </a>
-            </th>
-            {% if page_name != 'opc_ua_gds' %}
-            <th class="text-nowrap">
-                <a href="{% url_sort 'serial_number' %}">
-                    {% trans 'Serial Number' %} {{ request|sort_icon:'serial_number' }}
-                </a>
-            </th>
+<table class="table">
+    <thead>
+    <tr>
+        <th id="checkbox-column"><input type="checkbox"/></th>
+        <th class="text-nowrap">
+            <a href="{% url_sort 'common_name' %}">
+                {% trans 'Name' %} {{ request|sort_icon:'common_name' }}
+            </a>
+        </th>
+        <th class="text-nowrap">
+            <a href="{% url_sort 'domain' %}">
+                {% trans 'Domain' %} {{ request|sort_icon:'domain' }}
+            </a>
+        </th>
+        {% if page_name != 'opc_ua_gds' %}
+        <th class="text-nowrap">
+            <a href="{% url_sort 'serial_number' %}">
+                {% trans 'Serial Number' %} {{ request|sort_icon:'serial_number' }}
+            </a>
+        </th>
+        {% endif %}
+        <th class="text-nowrap">
+            <a href="{% url_sort 'created_at' %}">
+                {% trans 'Created at' %} {{ request|sort_icon:'created_at' }}
+            </a>
+        </th>
+        <th class="text-nowrap">
+            <a href="{% url_sort 'onboarding_status' %}">
+                {% trans 'Onboarding Status' %} {{ request|sort_icon:'onboarding_status' }}
+            </a>
+        </th>
+        <th class="text-nowrap">
+            <a href="{% url_sort 'onboarding_protocol' %}">
+                {% trans 'Onboarding Protocol' %} {{ request|sort_icon:'onboarding_protocol' }}
+            </a>
+        </th>
+        <th class="text-nowrap">
+            <a href="{% url_sort 'pki_protocol' %}">
+                {% trans 'PKI Protocol' %} {{ request|sort_icon:'pki_protocol' }}
+            </a>
+        </th>
+        <th class="text-nowrap">{% trans 'Certificate Management' %}</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for device in page_obj %}
+    <tr>
+        <td class="row_checkbox">
+            <input type="checkbox" name="row_checkbox" value="{{ device.id }}"/>
+        </td>
+        <td>{{ device.common_name }}</td>
+        <td>
+            {% if device.domain %}
+            <a href="{% url 'pki:domains-detail' device.domain.pk %}">{{ device.domain }}</a>
+            {% else %}
+            No domain
             {% endif %}
-            <th class="text-nowrap">
-                <a href="{% url_sort 'created_at' %}">
-                    {% trans 'Created at' %} {{ request|sort_icon:'created_at' }}
-                </a>
-            </th>
-            <th class="text-nowrap">
-                <a href="{% url_sort 'onboarding_status' %}">
-                    {% trans 'Onboarding Status' %} {{ request|sort_icon:'onboarding_status' }}
-                </a>
-            </th>
-            <th class="text-nowrap">
-                <a href="{% url_sort 'onboarding_protocol' %}">
-                    {% trans 'Onboarding Protocol' %} {{ request|sort_icon:'onboarding_protocol' }}
-                </a>
-            </th>
-            <th class="text-nowrap">
-                <a href="{% url_sort 'pki_protocol' %}">
-                    {% trans 'PKI Protocol' %} {{ request|sort_icon:'pki_protocol' }}
-                </a>
-            </th>
-            <th class="text-nowrap">{% trans 'Certificate Management' %}</th>
-        </tr>
-        </thead>
-        <tbody>
-        {% for device in page_obj %}
-            <tr>
-                <td class="row_checkbox">
-                    <input type="checkbox" name="row_checkbox" value="{{ device.id }}"/>
-                </td>
-                <td>{{ device.common_name }}</td>
-                <td>{{ device.domain }}</td>
-                {% if page_name != 'opc_ua_gds' %}
-                    <td>{{ device.serial_number }}</td>
-                {% endif %}
-                <td>{{ device.created_at }}</td>
-                <td>
-                    {{ device.onboarding_config.get_onboarding_status_display }}
-                </td>
-                <td>
-                    {{ device.onboarding_config.get_onboarding_protocol_display }}
-                </td>
-                <td>{{ device.pki_protocols| safe }}</td>
-                <td>{{ device.clm_button| safe }}</td>
-            </tr>
-        {% empty %}
-            <tr>
-                <td colspan="12" class="middle">{% trans 'No devices have been added yet.' %}</td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table>
+        </td>
+        {% if page_name != 'opc_ua_gds' %}
+        <td>{{ device.serial_number }}</td>
+        {% endif %}
+        <td>{{ device.created_at }}</td>
+        <td>
+            {{ device.onboarding_config.get_onboarding_status_display }}
+        </td>
+        <td>
+            {{ device.onboarding_config.get_onboarding_protocol_display }}
+        </td>
+        <td>{{ device.pki_protocols| safe }}</td>
+        <td>{{ device.clm_button| safe }}</td>
+    </tr>
+    {% empty %}
+    <tr>
+        <td colspan="12" class="middle">{% trans 'No devices have been added yet.' %}</td>
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>
 
 {% endblock devices_table %}


### PR DESCRIPTION
<!-- related issue number, remove if n/a -->
Related to #

**Description of changes**
Now Domain names in device table are clickable and direct you to details of the respective domain assigned to the device.

**Notes** <!-- optional -->


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.