### PR TITLE
Details of Issuing CA can be reached from Domians table of repective …

### DIFF
--- a/trustpoint/templates/pki/domains/domain.html
+++ b/trustpoint/templates/pki/domains/domain.html
@@ -42,7 +42,9 @@
                     <input type="checkbox" name="row_checkbox" value="{{ domain.id }}"/>
                 </td>
                 <td>{{ domain.unique_name }}</td>
-                <td>{{ domain.issuing_ca.unique_name }}</td>
+                <td>
+                    <a href="{% url 'pki:issuing_cas-detail' domain.issuing_ca.pk %}">{{ domain.issuing_ca.unique_name }}</a>
+                </td>
                 <td>{{ domain.devices.count }}</td>
                 <td>{{ domain.signature_suite }}</td>
                 <td>{{ domain.created_at }}</td>


### PR DESCRIPTION
…issuing CA

<!-- related issue number, remove if n/a -->
Related to #

**Description of changes**
Now details of respective issuing CA can be reached by clicking on the names of the issuing CA in Domain list/Table

**Notes** <!-- optional -->


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.