### PR TITLE
Clm ux optimization

### DIFF
--- a/trustpoint/templates/devices/credentials/certificate_lifecycle_management.html
+++ b/trustpoint/templates/devices/credentials/certificate_lifecycle_management.html
@@ -3,211 +3,215 @@
 {% load crispy_forms_filters %}
 {% block content %}
 
-    <div class="card">
-        <div class="card-header">
-            <h1>{% trans "Certificate Lifecycle Management" %}</h1>
-        </div>
-        <div class="card-body">
+<div class="card">
+    <div class="card-header">
+        <h1>{% trans "Certificate Lifecycle Management" %}</h1>
+    </div>
+    <div class="card-body">
 
-            <div class="row">
+        <div class="row">
 
-                <div class="col-md-6">
-                    <div class="card h-100">
-                        <div class="card-header">
-                            <h2>{% trans "Device Configuration" %}</h2>
-                        </div>
-                        <div class="card-body">
-                            <form method="post">
-                                {% csrf_token %}
-                                {% crispy device_form %}
-                            </form>
-                        </div>
+            <div class="col-md-6">
+                <div class="card h-100">
+                    <div class="card-header">
+                        <h2>{% trans "Device Configuration" %}</h2>
                     </div>
-                </div>
-
-
-                <div class="col-md-6">
-                    <div class="card h-100">
-                        <div class="card-header">
-                            <h2>{% trans "Device Information" %}</h2>
-                        </div>
-                        <div class="card-body">
-                            {% if device.domain %}
-    <p><strong>{% trans "Domain" %}:</strong>
-        <a href="{% url 'pki:domains-detail' device.domain.pk %}">{{ device.domain }}</a>
-    </p>
-
-    {% if device.domain.issuing_ca %}
-        <p><strong>{% trans "Issuing CA" %}:</strong>
-            <a href="{% url 'pki:issuing_cas-detail' device.domain.issuing_ca.pk %}">{{ device.domain.issuing_ca }}</a>
-        </p>
-
-        {% with cert=device.domain.issuing_ca.credential.certificate %}
-            {% if cert %}
-                <div class="mb-3">
-                    <strong>{% trans 'Key Algorithm' %}:</strong>
-                    {{ cert.spki_algorithm }}
-                </div>
-                {% if cert.spki_algorithm == "ECC" and cert.spki_ec_curve %}
-                    <div class="mb-3">
-                        <strong>{% trans 'Curve' %}:</strong>
-                        {{ cert.spki_ec_curve }}
-                    </div>
-                {% endif %}
-                {% if cert.spki_key_size %}
-                    <div class="mb-3">
-                        <strong>{% trans 'Key Size' %}:</strong>
-                        {{ cert.spki_key_size }} bits
-                    </div>
-                {% endif %}
-            {% endif %}
-        {% endwith %}
-    {% else %}
-        <p class="text-muted">{% trans "No issuing CA configured" %}</p>
-    {% endif %}
-{% else %}
-    <p class="text-muted">{% trans "No domain configured" %}</p>
-{% endif %}
-
-                            <hr>
-
-                            <p><strong>{% trans "Device Type" %}:</strong> {{ device.get_device_type_display }}</p>
-                            <p><strong>{% trans "Created" %}:</strong> {{ device.created_at|date:"Y-m-d H:i" }}</p>
-
-                            {% if device.no_onboarding_config %}
-                                <p><strong>{% trans "Configuration Type" %}:</strong> {% trans "No Onboarding" %}</p>
-
-                            {% endif %}
-                        </div>
+                    <div class="card-body">
+                        <form method="post">
+                            {% csrf_token %}
+                            {% crispy device_form %}
+                        </form>
                     </div>
                 </div>
             </div>
 
-            {% if device.onboarding_config %}
-            <div class="card-body p-3">
-                <h2 class="d-flex justify-content-between align-items-center">
-                    <span>{% trans "Issued Domain Credentials" %}</span>
-                    {% if issue_domain_cred_onboarding_url %}
-                        <a href="{% url issue_domain_cred_onboarding_url pk=device.pk %}" class="btn btn-primary" style="width: 25rem;">
-                    {% else %}
-                        <a href="" class="btn btn-secondary disabled" style="width: 25rem;" disabled>
-                    {% endif %}
-                            {% trans "Issue new Domain Credential" %}
-                        </a>
-                </h2>
-    </div><hr>
-                <div class="mb-5">
-                    <table class="table">
-                        <thead>
-                        <tr>
-                            <th>
-                                <a href="#" onclick="updateQueryParam(event, 'sort', 'domain')">
-                                    {% trans 'Domain' %}
-                                </a>
-                            </th>
-                            <th>
-                                <a href="#" onclick="updateQueryParam(event, 'sort', 'common_name')">
-                                    {% trans 'Common Name (CN)' %}
-                                </a>
-                            </th>
-                            <th>
-                                <a href="#" onclick="updateQueryParam(event, 'sort', 'created_at')">
-                                    {% trans 'Issued at' %}
-                                </a>
-                            </th>
-                            <th>
-                                <a href="#" onclick="updateQueryParam(event, 'sort', 'expiration_date')">
-                                    {% trans 'Expiration date' %}
-                                </a>
-                            </th>
-                            <th>
-                                <a href="#" onclick="updateQueryParam(event, 'sort', 'expires_in')">
-                                    {% trans 'Expires in' %}
-                                </a>
-                            </th>
-                            <th>{% trans 'Download' %}</th>
-                            <th>{% trans 'Revoke' %}</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {% for cred in domain_credentials %}
-                            <tr>
-                                <td>{{ cred.domain }}</td>
-                                <td>{{ cred.common_name }}</td>
-                                <td>{{ cred.created_at }}</td>
-                                <td>{{ cred.expiration_date }}</td>
-                                <td>{{ cred.expires_in }}</td>
-                                <td><a href="{% url download_url cred.id %}" class="btn btn-primary tp-table-btn">
-                                    {% trans 'Download' %}
-                                </a></td>
-                                <td>{{ cred.revoke }}</td>
-                            </tr>
-                        {% empty %}
-                            <tr>
-                                <td colspan="7"
-                                    class="middle">{% trans 'No domain credential is issued to this device yet.' %}</td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-                {% include 'trustpoint/pagination.html' with page_obj=domain_credentials %}
-            {% endif %}
 
-<div class="card-body ">
-            {% if device.onboarding_config %}
-                {% if device.onboarding_config.get_pki_protocols %}
-                    <h2 class="d-flex justify-content-between align-items-center">
-                        <span>{% trans "Issued Application Credentials" %}</span>
+            <div class="col-md-6">
+                <div class="card h-100">
+                    <div class="card-header">
+                        <h2>{% trans "Device Information" %}</h2>
+                    </div>
+                    <div class="card-body">
+                        {% if device.domain %}
+                        <p><strong>{% trans "Domain" %}:</strong>
+                            <a href="{% url 'pki:domains-detail' device.domain.pk %}">{{ device.domain }}</a>
+                        </p>
 
-                        {% if device.onboarding_config.onboarding_status == 1 %}
-                            <a href=""
-                               class="btn btn-secondary disabled"
-                               style="width: 25rem;" disabled>
-                                {% trans "Issue new Application Credential" %}
-                            </a>
+                        {% if device.domain.issuing_ca %}
+                        <p><strong>{% trans "Issuing CA" %}:</strong>
+                            <a href="{% url 'pki:issuing_cas-detail' device.domain.issuing_ca.pk %}">{{
+                                device.domain.issuing_ca }}</a>
+                        </p>
+
+                        {% with cert=device.domain.issuing_ca.credential.certificate %}
+                        {% if cert %}
+                        <div class="mb-3">
+                            <strong>{% trans 'Key Algorithm' %}:</strong>
+                            {{ cert.spki_algorithm }}
+                        </div>
+                        {% if cert.spki_algorithm == "ECC" and cert.spki_ec_curve %}
+                        <div class="mb-3">
+                            <strong>{% trans 'Curve' %}:</strong>
+                            {{ cert.spki_ec_curve }}
+                        </div>
+                        {% endif %}
+                        {% if cert.spki_key_size %}
+                        <div class="mb-3">
+                            <strong>{% trans 'Key Size' %}:</strong>
+                            {{ cert.spki_key_size }} bits
+                        </div>
+                        {% endif %}
+                        {% endif %}
+                        {% endwith %}
                         {% else %}
-                            {% if issue_app_cred_onboarding_url %}
-                                <a href="{% url issue_app_cred_onboarding_url pk=device.pk %}" class="btn btn-primary" style="width: 25rem;">
-                            {% else %}
-                                <a href="" class="btn btn-secondary disabled" style="width: 25rem;" disabled>
-                            {% endif %}
-                                    {% trans 'Issue New Application Credential' %}
-                                </a>
+                        <p class="text-muted">{% trans "No issuing CA configured" %}</p>
+                        {% endif %}
+                        {% else %}
+                        <p class="text-muted">{% trans "No domain configured" %}</p>
                         {% endif %}
 
-                    </h2>
-                {% else %}
-                    <h2>{% trans "Issued Application Credentials" %}</h2>
-                    <div class="alert alert-info" role="alert">
-                        {% trans "No PKI protocols are configured for this device. Configure PKI protocols to enable application credential issuance." %}
-                    </div>
+                        <hr>
 
-                {% endif %}
+                        <p><strong>{% trans "Device Type" %}:</strong> {{ device.get_device_type_display }}</p>
+                        <p><strong>{% trans "Created" %}:</strong> {{ device.created_at|date:"Y-m-d H:i" }}</p>
+
+                        {% if device.no_onboarding_config %}
+                        <p><strong>{% trans "Configuration Type" %}:</strong> {% trans "No Onboarding" %}</p>
+
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        {% if device.onboarding_config %}
+        <div class="card-body p-3">
+            <h2 class="d-flex justify-content-between align-items-center">
+                <span>{% trans "Issued Domain Credentials" %}</span>
+                {% if issue_domain_cred_onboarding_url %}
+                <a href="{% url issue_domain_cred_onboarding_url pk=device.pk %}" class="btn btn-primary"
+                    style="width: 25rem;">
+                    {% else %}
+                    <a href="" class="btn btn-secondary disabled" style="width: 25rem;" disabled>
+                        {% endif %}
+                        {% trans "Issue new Domain Credential" %}
+                    </a>
+            </h2>
+        </div>
+        <hr>
+        <div class="mb-5">
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>
+                            <a href="#" onclick="updateQueryParam(event, 'sort', 'domain')">
+                                {% trans 'Domain' %}
+                            </a>
+                        </th>
+                        <th>
+                            <a href="#" onclick="updateQueryParam(event, 'sort', 'common_name')">
+                                {% trans 'Common Name (CN)' %}
+                            </a>
+                        </th>
+                        <th>
+                            <a href="#" onclick="updateQueryParam(event, 'sort', 'created_at')">
+                                {% trans 'Issued at' %}
+                            </a>
+                        </th>
+                        <th>
+                            <a href="#" onclick="updateQueryParam(event, 'sort', 'expiration_date')">
+                                {% trans 'Expiration date' %}
+                            </a>
+                        </th>
+                        <th>
+                            <a href="#" onclick="updateQueryParam(event, 'sort', 'expires_in')">
+                                {% trans 'Expires in' %}
+                            </a>
+                        </th>
+                        <th>{% trans 'Download' %}</th>
+                        <th>{% trans 'Revoke' %}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for cred in domain_credentials %}
+                    <tr>
+                        <td>{{ cred.domain }}</td>
+                        <td>{{ cred.common_name }}</td>
+                        <td>{{ cred.created_at }}</td>
+                        <td>{{ cred.expiration_date }}</td>
+                        <td>{{ cred.expires_in }}</td>
+                        <td><a href="{% url download_url cred.id %}" class="btn btn-primary tp-table-btn">
+                                {% trans 'Download' %}
+                            </a></td>
+                        <td>{{ cred.revoke }}</td>
+                    </tr>
+                    {% empty %}
+                    <tr>
+                        <td colspan="7" class="middle">{% trans 'No domain credential is issued to this device yet.' %}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% include 'trustpoint/pagination.html' with page_obj=domain_credentials %}
+        {% endif %}
+
+        <div class="card-body ">
+            {% if device.onboarding_config %}
+            {% if device.onboarding_config.get_pki_protocols %}
+            <h2 class="d-flex justify-content-between align-items-center">
+                <span>{% trans "Issued Application Credentials" %}</span>
+
+                {% if device.onboarding_config.onboarding_status == 1 %}
+                <a href="" class="btn btn-secondary disabled" style="width: 25rem;" disabled>
+                    {% trans "Issue new Application Credential" %}
+                </a>
+                {% else %}
+                {% if issue_app_cred_onboarding_url %}
+                <a href="{% url issue_app_cred_onboarding_url pk=device.pk %}" class="btn btn-primary"
+                    style="width: 25rem;">
+                    {% else %}
+                    <a href="" class="btn btn-secondary disabled" style="width: 25rem;" disabled>
+                        {% endif %}
+                        {% trans 'Issue New Application Credential' %}
+                    </a>
+                    {% endif %}
+
+            </h2>
+            {% else %}
+            <h2>{% trans "Issued Application Credentials" %}</h2>
+            <div class="alert alert-info" role="alert">
+                {% trans "No PKI protocols are configured for this device. Configure PKI protocols to enable application
+                credential issuance." %}
+            </div>
+
+            {% endif %}
 
             {% elif device.no_onboarding_config %}
 
-                    <h2 class="d-flex justify-content-between align-items-center">
-                        <span>{% trans "Issued Application Credentials" %}</span>
-                            {% if issue_app_cred_no_onboarding_url %}
-                                <a href="{% url issue_app_cred_no_onboarding_url pk=device.pk %}" class="btn btn-primary" style="width: 25rem;">
-                            {% else %}
-                                <a href="" class="btn btn-secondary disabled" style="width: 25rem;">
-                            {% endif %}
-                                    {% trans 'Issue New Application Credential' %}
-                                </a>
-                    </h2>
+            <h2 class="d-flex justify-content-between align-items-center">
+                <span>{% trans "Issued Application Credentials" %}</span>
+                {% if issue_app_cred_no_onboarding_url %}
+                <a href="{% url issue_app_cred_no_onboarding_url pk=device.pk %}" class="btn btn-primary"
+                    style="width: 25rem;">
+                    {% else %}
+                    <a href="" class="btn btn-secondary disabled" style="width: 25rem;">
+                        {% endif %}
+                        {% trans 'Issue New Application Credential' %}
+                    </a>
+            </h2>
 
             {% else %}
-                <h2>{% trans "Issued Application Credentials" %}</h2>
+            <h2>{% trans "Issued Application Credentials" %}</h2>
             {% endif %}
 
-</div>
-            <hr>
+        </div>
+        <hr>
 
-            <div>
-                <table class="table mb-0">
-                    <thead>
+        <div>
+            <table class="table mb-0">
+                <thead>
                     <tr>
                         <th>
                             <a href="#" onclick="updateQueryParam(event, 'sort', 'domain')">
@@ -238,45 +242,45 @@
                         <th>{% trans 'Download' %}</th>
                         <th>{% trans 'Revoke' %}</th>
                     </tr>
-                    </thead>
-                    <tbody>
+                </thead>
+                <tbody>
                     {% for cred in application_credentials %}
-                        <tr>
-                            <td>
-  <a href="{% url 'pki:domains-detail' cred.domain.pk %}">
-    {{ cred.domain }}
-  </a>
-</td>
+                    <tr>
+                        <td>
+                            <a href="{% url 'pki:domains-detail' cred.domain.pk %}">
+                                {{ cred.domain }}
+                            </a>
+                        </td>
 
-                            <td>
-  <a href="{% url 'pki:certificate-detail' cred.credential.certificate.pk %}">
-    {{ cred.common_name }}
-  </a>
-</td>
-                            <td>{{ cred.get_issued_credential_purpose_display }}</td>
-                            <td>{{ cred.created_at }}</td>
-                            <td>{{ cred.expiration_date }}</td>
-                            <td>{{ cred.expires_in }}</td>
-                            <td><a href="{% url download_url cred.id %}" class="btn btn-primary tp-table-btn">
+                        <td>
+                            <a href="{% url 'pki:certificate-detail' cred.credential.certificate.pk %}">
+                                {{ cred.common_name }}
+                            </a>
+                        </td>
+                        <td>{{ cred.get_issued_credential_purpose_display }}</td>
+                        <td>{{ cred.created_at }}</td>
+                        <td>{{ cred.expiration_date }}</td>
+                        <td>{{ cred.expires_in }}</td>
+                        <td><a href="{% url download_url cred.id %}" class="btn btn-primary tp-table-btn">
                                 {% trans 'Download' %}
                             </a></td>
-                            <td>{{ cred.revoke }}</td>
-                        </tr>
+                        <td>{{ cred.revoke }}</td>
+                    </tr>
                     {% empty %}
-                        <tr>
-                            <td colspan="8"
-                                class="middle">{% trans 'No application credentials are issued to this device yet.' %}</td>
-                        </tr>
+                    <tr>
+                        <td colspan="8" class="middle">{% trans 'No application credentials are issued to this device
+                            yet.' %}</td>
+                    </tr>
                     {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-        <div class="card-footer d-flex justify-content-between align-items-center mt-5">
-            <div class="tp-card-btn-footer m-1">
-                <a href="{% url main_url %}" class="btn btn-secondary">{% trans 'Back' %}</a>
-            </div>
+                </tbody>
+            </table>
         </div>
     </div>
+    <div class="card-footer d-flex justify-content-between align-items-center mt-5">
+        <div class="tp-card-btn-footer m-1">
+            <a href="{% url main_url %}" class="btn btn-secondary">{% trans 'Back' %}</a>
+        </div>
+    </div>
+</div>
 
 {% endblock content %}


### PR DESCRIPTION
<!-- related issue number, remove if n/a -->
Related to #

**Description of changes**
Added more information on CLM page without crowding the space and overwhelming the user. User can see basic info about device on the CLM page itself. Also Can be redirected to detail pages of domain as well as issuing CA.

**Notes** <!-- optional -->


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.