### PR TITLE
Remove Domain Credential CN check

### DIFF
--- a/trustpoint/request/authentication.py
+++ b/trustpoint/request/authentication.py
@@ -1,6 +1,5 @@
 """Provides the `EstAuthentication` class using the Composite pattern for modular EST authentication."""
 
-import re
 from abc import ABC, abstractmethod
 from typing import Never
 
@@ -758,11 +757,6 @@ class CmpSignatureBasedCertificationAuthentication(AuthenticationComponent, Logg
 
             # Parse common name value
             common_name_value = common_name.decode() if isinstance(common_name, bytes) else common_name
-
-            # Verify this is a domain credential
-            if not common_name_value or re.sub(r'[^a-zA-Z0-9]', '', common_name_value) != 'TrustpointDomainCredential':
-                err_msg = 'Not a domain credential.'
-                self._raise_value_error(err_msg)
 
         except (IndexError, ValueError) as e:
             err_msg = f'Failed to extract device information from certificate: {e}'


### PR DESCRIPTION
Domain credential identification is handled via DB cert fingerprint check.
No mandatory requirement for certain names in a Domain credential subject.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.