### PR TITLE
Truststore DER support

### DIFF
--- a/trustpoint/pki/forms.py
+++ b/trustpoint/pki/forms.py
@@ -202,7 +202,7 @@ class TruststoreAddForm(forms.Form):
 
         try:
             certificate_collection_serializer = CertificateCollectionSerializer.from_bytes(trust_store_file)
-        except Exception:
+        except Exception:  # noqa: BLE001
             # Try parsing as a single certificate (DER or PEM)
             try:
                 certificate_serializer = CertificateSerializer.from_bytes(trust_store_file)

--- a/trustpoint/pki/services/truststore.py
+++ b/trustpoint/pki/services/truststore.py
@@ -2,7 +2,7 @@
 
 from django.core.exceptions import ValidationError
 from django.db.models.query import QuerySet
-from trustpoint_core.serializer import CertificateCollectionSerializer
+from trustpoint_core.serializer import CertificateCollectionSerializer, CertificateSerializer
 
 from pki.forms import TruststoreAddForm
 from pki.models.truststore import TruststoreModel
@@ -25,9 +25,16 @@ class TruststoreService:
         try:
             certificate_collection_serializer = CertificateCollectionSerializer.from_bytes(trust_store_file)
             certs = certificate_collection_serializer.as_crypto()
-        except Exception as exception:
-            error_message = 'Unable to process the Truststore. May be malformed / corrupted.'
-            raise ValidationError(error_message) from exception
+        except Exception:
+            # Try parsing as a single certificate (DER or PEM)
+            try:
+                certificate_serializer = CertificateSerializer.from_bytes(trust_store_file)
+                der_bytes = certificate_serializer.as_der()
+                certificate_collection_serializer = CertificateCollectionSerializer.from_list_of_der([der_bytes])
+                certs = certificate_collection_serializer.as_crypto()
+            except Exception as exception:
+                error_message = 'Unable to process the Truststore. May be malformed / corrupted.'
+                raise ValidationError(error_message) from exception
 
         if not unique_name:
             unique_name = get_certificate_name(certs[0])

--- a/trustpoint/pki/services/truststore.py
+++ b/trustpoint/pki/services/truststore.py
@@ -25,8 +25,7 @@ class TruststoreService:
         try:
             certificate_collection_serializer = CertificateCollectionSerializer.from_bytes(trust_store_file)
             certs = certificate_collection_serializer.as_crypto()
-        except Exception:
-            # Try parsing as a single certificate (DER or PEM)
+        except Exception:  # noqa: BLE001
             try:
                 certificate_serializer = CertificateSerializer.from_bytes(trust_store_file)
                 der_bytes = certificate_serializer.as_der()

--- a/trustpoint/pki/tests/test_forms_extended.py
+++ b/trustpoint/pki/tests/test_forms_extended.py
@@ -426,7 +426,27 @@ class TestTruststoreAddForm:
         assert form.fields['unique_name'].required is False
 
 
-@pytest.mark.django_db  
+@pytest.mark.django_db
+class TestTruststoreAddFormValidation:
+    """Test TruststoreAddForm validation with actual files."""
+
+    def test_form_valid_der_certificate(self):
+        """Test that form accepts DER encoded certificate."""
+        der_file_path = 'tests/data/issuing_cas/ee0_valid.der'
+        with open(der_file_path, 'rb') as f:
+            der_data = f.read()
+        
+        uploaded_file = SimpleUploadedFile('certificate.der', der_data, content_type='application/x-x509-ca-cert')
+        
+        form_data = {
+            'intended_usage': TruststoreModel.IntendedUsage.GENERIC.value,
+        }
+        form = TruststoreAddForm(data=form_data, files={'trust_store_file': uploaded_file})
+        
+        assert form.is_valid(), f"Form should be valid but got errors: {form.errors}"
+        assert 'truststore' in form.cleaned_data
+        truststore = form.cleaned_data['truststore']
+        assert truststore.number_of_certificates == 1  
 class TestIssuingCaAddFileImportPkcs12Form:
     """Test IssuingCaAddFileImportPkcs12Form."""
 


### PR DESCRIPTION
Improve Truststore file handling to accept DER formatted certificates and refactor exception handling in Truststore forms and services. 


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.