### PR TITLE
Update outdated and wrong documentation

### DIFF
--- a/docs/source/development/architecture/credentials.rst
+++ b/docs/source/development/architecture/credentials.rst
@@ -2,175 +2,202 @@
 Credentials - Architecture
 ==========================
 
+Overview
+--------
+
+The **CredentialModel** is the central abstraction for managing certificates and private keys in Trustpoint. It supports multiple credential types (TLS Server, Root CA, Issuing CA, Issued Credentials, DevOwnerID, Signer) and can store keys either directly in the database or in hardware security modules (HSM) via PKCS#11.
+
+The credential architecture manages the lifecycle from issuance through validation, storage, and deployment to devices.
 
 
-General Message Flow
---------------------
+CredentialModel Types
+---------------------
 
-.. uml::
+The ``CredentialTypeChoice`` enum defines the purpose and restrictions of each credential:
 
-   :Message;
-   :Http validation - HttpRequestValidator;
-   :Message parsing - RequestMessageParser -> parsed message;
-   :Request Authentication - Authenticator -> DeviceModel object;
-   :Request Authorization - Authorizer;
-   :Message normalization, if required - CsrAdapter;
-   :Certificate profile handling - JsonProfileValidator;
-   :Message processing - OperationProcessor -> PKI result (e.g., issued certificate);
-   :Response generation - MessageResponder -> HttpResponse;
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
 
-
-HttpRequestValidator
---------------------
-
-These classes validate the http attributes for requests, e.g. content-types, body size etc.
-
-
-.. uml::
-
-   HttpRequestValidator <|-- EstHttpRequestValidator
-   HttpRequestValidator <|-- CmpHttpRequestValidator
-
-   abstract HttpRequestValidator {
-      +<<validate>>(request : HttpRequest) : Boolean
-   }
-
-   class EstHttpRequestValidator {
-      +validate(request : HttpRequest) : Boolean
-   }
-
-   class CmpHttpRequestValidator {
-      +validate(request : HttpRequest) : Boolean
-   }
+   * - Type
+     - Purpose
+   * - **TRUSTPOINT_TLS_SERVER**
+     - Trustpoint's own TLS server certificate for HTTPS
+   * - **ROOT_CA**
+     - Root certificate authority (self-signed, trusted anchor)
+   * - **ISSUING_CA**
+     - Intermediate issuing CA (signed by root, issues device credentials)
+   * - **ISSUED_CREDENTIAL**
+     - Device credentials issued by Trustpoint (LDevID, application certificates)
+   * - **DEV_OWNER_ID**
+     - Device Owner ID certificates (IEEE 802.1AR DevOwnerID)
+   * - **SIGNER**
+     - Signing authority for hash-and-sign operations
 
 
+Core Storage Model
+------------------
 
-RequestMessageParser
---------------------
+CredentialModel stores:
 
-These classes parse PKI messages, e.g., CSRs and CMP messages.
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
 
-.. uml::
-
-   RequestMessageParser <|-- EstMessageParser
-   RequestMessageParser <|-- CmpMessageParser
-   
-   abstract RequestMessageParser<M> {
-      +<<parse>>(message : Bytes) : M
-   }
-
-   class EstMessageParser<CertificateSigningRequest> {
-      +parse(message : Bytes) : CertificateSigningRequest
-   }
-
-   class CmpMessageParser<rfc4210.PKIMessage> {
-      +parse(message : Bytes) : rfc4210.PKIMessage
-   }
+   * - Field
+     - Purpose
+   * - **credential_type**
+     - One of the CredentialTypeChoice values above
+   * - **private_key** (PEM)
+     - Encrypted private key stored in database (for software keys)
+   * - **pkcs11_private_key**
+     - Reference to private key in HSM/token (for PKCS#11 keys)
+   * - **certificate**
+     - Primary certificate (ForeignKey to CertificateModel)
+   * - **certificates**
+     - All certificates in the credential (ManyToMany via PrimaryCredentialCertificate)
+   * - **certificate_chain**
+     - Ordered chain of issuing CA certificates (ManyToMany via CertificateChainOrderModel)
 
 
-Authentication
---------------
+Primary Certificate vs Certificate Chain
+-----------------------------------------
 
-The Authentication classes explicitly only handle the authentication, that is, they check if the authentication method applied to the request is
-allowed and validate it. If all checks were successfull, the corresponding DeviceModel is returned.
+Each credential has a **primary certificate** (the leaf/end-entity certificate) and an optional **certificate chain** (issuing CA certificates up the trust path):
 
 .. uml::
 
-   Authenticator <|-- EstAuthenticator
-   Authenticator <|-- CmpAuthenticator
-
-   abstract Authenticator<M, A> {
-      +<<Authenticator>>(allowed_methods : List[A]) : Authenticator
-      +<<authenticate>>(message : M, request : HttpRequest) : DeviceModel
+   CredentialModel {
+      + certificate: CertificateModel (primary/leaf)
+      + certificates: [CertificateModel] (via PrimaryCredentialCertificate)
+      + certificate_chain: [CertificateModel] (ordered, via CertificateChainOrderModel)
    }
 
-   class EstAuthenticator<Csr, EstAuthMethods> {
-      +EstAuthentictor(allowed_methods : List[EstAuthMethods])
-      +authenticate(message : Csr, request : HttpRequest) : DeviceModel
+   PrimaryCredentialCertificate {
+      + credential: CredentialModel
+      + certificate: CertificateModel (OneToOne)
+      + is_primary: bool
    }
 
-   enum EstAuthMethods {
-      USERNAME_AND_PASSWORD
-      CLIENT_CERTIFICATE
+   CertificateChainOrderModel {
+      + credential: CredentialModel
+      + certificate: CertificateModel
+      + order: int
    }
 
-   class CmpAuthenticator<rfc4210.PKIMessage, CmpAuthMethods> {
-      +CmpAuthenticator(allowed_methods : List[CmpAuthMethods])
-      +authenticate(message : rfc4210.PKIMessage, request: HttpRequest) : DeviceModel
-   }
+The **primary certificate** (``certificate`` field) is the credential's active end-entity certificate. When a new certificate is issued or renewed, it becomes the new primary, and the old one is retained for revocation handling.
 
-   Enum CmpAuthMethods {
-      SHARED_SECRET
-      CLIENT_CERTIFICATE
-   }
+The **certificate chain** preserves issuing CA certificates in order, enabling certificate chain construction for protocols like EST (which require the full chain in PKCS#7 format).
 
 
-Authorization
--------------
+IssuedCredentialModel - Device Credentials
+--------------------------------------------
 
-The Authorizers will determine if the requested action is generally allowed to be performed by the DeviceModel object. This will not include any template checks etc.
-The is_authorized method shall return true if the operation is allowed, and it shall raise an exception with an appropriate error message if not rather then just
-return a plain false value.
+The ``IssuedCredentialModel`` bridges credentials to devices. It represents a credential issued to a specific device within a specific domain:
 
-.. note::
+.. code-block:: python
 
-   Depending on the operation, multiple Authenticators may be invoked and used for the same request.
-
-.. uml::
-
-   Authorizer <|-- EstAuthorizer
-   Authorizer <|-- CmpAuthorizer
-   Authorizer <|-- CertTemplateAuthorizer
-
-   abstract Authorizer<O> {
-      +<<is_authorized>>(cls, device : DeviceModel, operation : O) : Boolean
-   }
-
-   class EstAuthorizer<EstOperation> {
-      +<<is_authorized>>(cls, device : DeviceModel, operation : EstOperation) : Boolean
-   }
-
-   enum EstOperation {
-      SIMPLE_ENROLL
-      SIMPLE_RE_ENROLL
-   }
-
-   class CmpAuthorizer<CmpOperation> {
-      +<<is_authorized>>(cls, device : DeviceModel, operation : CmpOperation) : Boolean
-   }
-
-   enum CmpOperation {
-      IR
-      CR
-   }
-
-   class CertTemplateAuthorizer<CertTemplate> {
-      +<<is_authorized>>(cls, device : DeviceModel, template : CertTemplate) : Boolean
-   }
-
-   enum CertTemplate {
-      HTTPS_CLIENT
-      HTTPS_SERVER
-      OPC_UA_CLIENT
-      OPC_UA_SERVER
-   }
+   class IssuedCredentialModel(models.Model):
+       # Link to the credential (OneToOne)
+       credential = OneToOneField(CredentialModel)
+       
+       # Link to the device (ForeignKey)
+       device = ForeignKey(DeviceModel)
+       
+       # Link to the domain
+       domain = ForeignKey(DomainModel)
+       
+       # Metadata
+       common_name: str
+       issued_credential_type: DOMAIN_CREDENTIAL | APPLICATION_CREDENTIAL
+       issued_using_cert_profile: str
+       created_at: DateTimeField
 
 
-CsrAdapter
-----------
+Credential Types - IssuedCredentialModel
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This class is an implementation of the adapter pattern so that the same code for handling certificate requests can be used.
+**DOMAIN_CREDENTIAL**
+   The device's identity credential (LDevID) used to authenticate and enroll for application credentials. Typically the first credential issued during device onboarding. Used for EST client-certificate authentication or CMP authentication.
+
+**APPLICATION_CREDENTIAL**
+   Operational credentials for specific use cases (TLS Client, TLS Server, OPC UA). Issued after device authentication with a domain credential. Multiple application credentials can be issued to the same device.
 
 
-.. uml::
+Lifecycle: From Issuance to Deployment
+--------------------------------------
 
-   class CsrAdapter {
-      +not_valid_after
-      +not_valid_before
-      +subject
-      +<and so on>
-      
-      +get_extensions() -> List
-   }
+1. **Credential Issuance** → Certificate is generated/signed by the issuing CA
+2. **Database Storage** → ``CredentialModel`` created with primary certificate
+3. **Issued Credential Record** → ``IssuedCredentialModel`` links credential to device/domain
+4. **Device Retrieval** → Device downloads credential via EST, CMP, or manual download
+5. **Renewal/Rekeying** → New certificate becomes primary, old retained for transition
+6. **Revocation** → Certificate marked as revoked in CRL, old credentials cleaned up
+
+
+PrimaryCredentialCertificate - Chain Management
+------------------------------------------------
+
+The ``PrimaryCredentialCertificate`` model manages which certificates belong to a credential:
+
+- One credential can have **multiple certificates** (e.g., during renewal)
+- The **primary** flag identifies the active/current certificate
+- When a new certificate is added, it automatically becomes primary
+- Old certificates are retained for validation of client certificates during transitions
+
+
+CertificateChainOrderModel - CA Chain Ordering
+-----------------------------------------------
+
+The ``CertificateChainOrderModel`` preserves the order of issuing CA certificates:
+
+- Ordered as: leaf certificate → intermediate CAs → root CA
+- Required for EST `/cacerts` responses (PKCS#7 chain format)
+- Prevents ambiguity when multiple possible chains exist
+
+
+Credential Validation
+---------------------
+
+CredentialModel provides validation methods:
+
+**is_valid_issued_credential()**
+   Checks if credential meets requirements for deployment:
+   - Type must be ISSUED_CREDENTIAL
+   - Primary certificate must exist
+   - Primary certificate status must be OK (not expired, revoked, etc.)
+
+**IssuedCredentialModel.is_valid_domain_credential()**
+   Checks if a domain credential is valid for issuing application credentials:
+   - Must be DOMAIN_CREDENTIAL type
+   - Underlying credential must pass ``is_valid_issued_credential()``
+   - Certificate must be OK status
+
+
+Private Key Storage Options
+----------------------------
+
+**Database Storage (Software Keys)**
+   - Private key stored as encrypted PEM in ``private_key`` field
+   - Fast, suitable for CA credentials
+   - Encrypted using Trustpoint's key encryption mechanism
+
+**HSM/PKCS#11 Storage**
+   - Private key stored in hardware security module (TPM, SoftHSM, etc.)
+   - ``pkcs11_private_key`` field references the ``PKCS11Key`` model
+   - Higher security for sensitive credentials
+   - Requires HSM configuration and PIN management
+
+The ``PKCS11Key`` model stores references:
+
+.. code-block:: python
+
+   class PKCS11Key(models.Model):
+       token_label: str  # HSM token identifier
+       key_label: str    # Key identifier within token
+       key_type: RSA | EC | AES
+       created_at: DateTimeField
+
+For request pipeline details and component architecture, see :doc:`../workflow`.
 
 

--- a/docs/source/development/architecture/credentials.rst
+++ b/docs/source/development/architecture/credentials.rst
@@ -30,7 +30,7 @@ The ``CredentialTypeChoice`` enum defines the purpose and restrictions of each c
    * - **ISSUED_CREDENTIAL**
      - Device credentials issued by Trustpoint (LDevID, application certificates)
    * - **DEV_OWNER_ID**
-     - Device Owner ID certificates (IEEE 802.1AR DevOwnerID)
+     - Device Owner ID certificates (see :doc:`../../devices/aoki`)
    * - **SIGNER**
      - Signing authority for hash-and-sign operations
 

--- a/docs/source/development/development.rst
+++ b/docs/source/development/development.rst
@@ -104,26 +104,36 @@ Running the development server
 
 You can then access the GUI through localhost:8000.
 
+You can also specify a different port by appending it to the command, e.g.:
+
+.. code:: bash
+
+   uv run manage.py runserver 0.0.0.0:8080
+
 Alternatively, use the following command to run a development HTTPS
 server (self-signed certificate).
 
 .. code:: bash
 
-   python manage.py runserver_plus 0.0.0.0:443 --cert-file ../tests/data/x509/https_server.crt --key-file ../tests/data/x509/https_server.pem
+   uv run manage.py runserver_plus 0.0.0.0:443 --cert-file ../tests/data/x509/https_server.crt --key-file ../tests/data/x509/https_server.pem
 
-Use the following command to automatically generate a self-signed TLS
-server certificate for your current IP addresses:
+A self-signed TLS server certificate is already provided in the test data directory.
+If you need to regenerate it (e.g., with different IP addresses or hostnames),
+use the following command:
 
 .. code:: bash
 
-   python manage.py create_tls_certs
+   uv run manage.py create_tls_certs
+
+Note: The command generates a certificate with predefined IP addresses (127.0.0.1, 192.168.88.10)
+and hostnames (localhost, trustpoint.local). Modify the command source code to customize these values.
 
 ^^^^^^^^^^
 Logging in
 ^^^^^^^^^^
 
 Browsing to any page should redirect you to the login page. The login
-page can be accessed directly via /users/login/.
+page can be accessed directly via `/users/login/`.
 
 Use the username and password which you previously provided through the
 **createsuperuser** command.
@@ -236,6 +246,61 @@ Trustpoint uses behave to run BDD tests. The tests are located in the
 .. code:: shell
 
    uv run manage.py behave
+
+---------------------
+Before committing checklist
+---------------------
+
+Before pushing your changes, ensure the following:
+
+1. **Format your code** with ruff:
+
+   .. code:: shell
+
+      uv run ruff format .
+
+2. **Lint your code** with ruff:
+
+   .. code:: shell
+
+      uv run ruff check . --output-format=concise
+
+3. **Check type annotations** with mypy:
+
+   .. code:: shell
+
+      uv run mypy .
+
+4. **Run all tests**:
+
+   .. code:: shell
+
+      uv run pytest
+
+5. **Run migrations** if you modified models:
+
+   .. code:: shell
+
+      cd trustpoint
+      uv run manage.py makemigrations
+
+6. **Check for merge conflicts** in migration files:
+
+   .. code:: shell
+
+      git status
+
+   If there are duplicate migrations (e.g., multiple ``0003_tp_v0_5_0_dev1.py`` files),
+   combine them before committing.
+
+7. **Verify database state** by running:
+
+   .. code:: shell
+
+      cd trustpoint
+      uv run manage.py reset_db
+
+   This ensures your changes work with a fresh database.
 
 --------------------
 Editor configuration

--- a/docs/source/development/pipeline.rst
+++ b/docs/source/development/pipeline.rst
@@ -458,52 +458,6 @@ Authorization Module Diagram
     @enduml
 
 
-Request Pipeline Flow
-=====================
-
-The following diagram shows how requests flow through the entire pipeline:
-
-.. plantuml::
-
-    @startuml
-    start
-    :Receive HTTP Request;
-    :HTTP Validation;
-    if (Valid?) then (yes)
-    else (no)
-        :Return HTTP Error;
-        stop
-    endif
-    :Message Parsing;
-    if (Valid?) then (yes)
-    else (no)
-        :Return Parse Error;
-        stop
-    endif
-    :Authentication;
-    if (Authentic?) then (yes)
-    else (no)
-        :Return Auth Error;
-        stop
-    endif
-    :Authorization;
-    if (Authorized?) then (yes)
-    else (no)
-        :Return Auth Error;
-        stop
-    endif
-    :Process Request;
-    if (Success?) then (yes)
-    else (no)
-        :Return Processing Error;
-        stop
-    endif
-    :Generate Response;
-    :Return Response;
-    stop
-    @enduml
-
-
 Key Concepts
 ============
 

--- a/docs/source/development/workflow.rst
+++ b/docs/source/development/workflow.rst
@@ -2,58 +2,128 @@
 Request Pipeline
 ================
 
+Overview
+========
 
-Request Context Module Diagram
-==============================
+The request pipeline processes incoming PKI requests (EST, CMP) through a series of composable stages, each responsible for a specific aspect of request handling. The architecture uses the **Composite Pattern** throughout to allow flexible composition of validation, parsing, authentication, and authorization logic.
 
-This diagram illustrates the `RequestContext` class, its attributes, and its methods for managing request-specific data within the system.
+For a comprehensive overview of the credential architecture and component organization, see :doc:`./architecture/credentials`.
 
-### UML Diagram:
+**Pipeline Stages:**
+
+1. **HTTP Request Validation** - Validates HTTP-level attributes (headers, content-type, payload size)
+2. **Message Parsing** - Parses and validates protocol-specific message content
+3. **Authentication** - Verifies the authenticity of credentials presented by the client
+4. **Authorization** - Determines what operations are permitted for the authenticated request
+5. **Request Processing** - Processes the request to issue certificates or perform other PKI operations
+6. **Response Generation** - Generates a protocol-specific response
+
+Each stage uses the Composite Pattern with a base component interface, allowing individual components to be composed into more complex operations.
+
+
+Request Pipeline Flow
+=====================
+
+The following diagram shows how requests flow through the entire pipeline:
 
 .. plantuml::
 
     @startuml
-    ' Representation of the RequestContext class.
-    class RequestContext {
-        + raw_message: HttpRequest | None
-        + parsed_message: CertificateSigningRequest | PKIMessage | None
-        + operation: str | None
-        + protocol: str | None
-        + cert_profile_str: str | None
-        + est_encoding: str | None
-        + domain_str: str | None
-        + domain: DomainModel | None
-        + device: DeviceModel | None
-        + cert_requested: CertificateSigningRequest | None
-        + est_username: str | None
-        + est_password: str | None
-        + cmp_shared_secret: str | None
-        + client_certificate: x509.Certificate | None
-        + client_intermediate_certificate: list[x509.Certificate] | None
-        --
-        + to_dict(): dict[str, Any]
-        + clear(): None
-    }
-
-    ' Dependencies and related models.
-    class HttpRequest
-    class CertificateSigningRequest
-    class PKIMessage
-    class DomainModel
-    class DeviceModel
-    class x509.Certificate
-
-    ' Relationships.
-    RequestContext --> HttpRequest : "raw_message"
-    RequestContext --> CertificateSigningRequest : "parsed_message/cert_requested"
-    RequestContext --> PKIMessage : "parsed_message"
-    RequestContext --> DomainModel : "domain"
-    RequestContext --> DeviceModel : "device"
-    RequestContext --> x509.Certificate : "client_certificate"
-    RequestContext --> x509.Certificate : "client_intermediate_certificate"
-
+    start
+    :Receive HTTP Request;
+    :HTTP Validation;
+    if (Valid?) then (yes)
+    else (no)
+        :Return HTTP Error;
+        stop
+    endif
+    :Message Parsing;
+    if (Valid?) then (yes)
+    else (no)
+        :Return Parse Error;
+        stop
+    endif
+    :Authentication;
+    if (Authentic?) then (yes)
+    else (no)
+        :Return Auth Error;
+        stop
+    endif
+    :Authorization;
+    if (Authorized?) then (yes)
+    else (no)
+        :Return Auth Error;
+        stop
+    endif
+    :Process Request;
+    if (Success?) then (yes)
+    else (no)
+        :Return Processing Error;
+        stop
+    endif
+    :Generate Response;
+    :Return Response;
+    stop
     @enduml
 
+
+Request Context Hierarchy
+=========================
+
+The RequestContext hierarchy carries state through the entire pipeline:
+
+.. plantuml::
+
+    @startuml
+    ' Base context for all request types.
+    class BaseRequestContext {
+        + raw_message: HttpRequest
+        + protocol: str
+        + operation: str
+        + domain_str: str
+        + cert_profile_str: str
+        --
+        + domain: DomainModel | None
+        + device: DeviceModel | None
+    }
+
+    ' Validation request contexts.
+    class EstBaseRequestContext {
+        + est_username: str | None
+        + est_password: str | None
+        + client_certificate: x509.Certificate | None
+        + client_intermediate_certificate: list[x509.Certificate] | None
+    }
+
+    class CmpBaseRequestContext {
+        + parsed_message: rfc4210.PKIMessage | None
+        + cmp_shared_secret: str | None
+        + client_certificate: x509.Certificate | None
+    }
+
+    ' Certificate request contexts.
+    class EstCertificateRequestContext {
+        + cert_requested: x509.CertificateSigningRequest | None
+        + est_encoding: str | None
+    }
+
+    class CmpCertificateRequestContext {
+        + parsed_message: rfc4210.PKIMessage
+    }
+
+    ' Revocation request contexts.
+    class CmpRevocationRequestContext {
+        + parsed_message: rfc4210.PKIMessage
+    }
+
+    ' Relationships.
+    BaseRequestContext <|-- EstBaseRequestContext
+    BaseRequestContext <|-- CmpBaseRequestContext
+    EstBaseRequestContext <|-- EstCertificateRequestContext
+    CmpBaseRequestContext <|-- CmpCertificateRequestContext
+    CmpBaseRequestContext <|-- CmpRevocationRequestContext
+
+    @enduml
 
 
 HTTP Request Validator Module Diagram
@@ -387,3 +457,76 @@ Authorization Module Diagram
 
     @enduml
 
+
+Request Pipeline Flow
+=====================
+
+The following diagram shows how requests flow through the entire pipeline:
+
+.. plantuml::
+
+    @startuml
+    start
+    :Receive HTTP Request;
+    :HTTP Validation;
+    if (Valid?) then (yes)
+    else (no)
+        :Return HTTP Error;
+        stop
+    endif
+    :Message Parsing;
+    if (Valid?) then (yes)
+    else (no)
+        :Return Parse Error;
+        stop
+    endif
+    :Authentication;
+    if (Authentic?) then (yes)
+    else (no)
+        :Return Auth Error;
+        stop
+    endif
+    :Authorization;
+    if (Authorized?) then (yes)
+    else (no)
+        :Return Auth Error;
+        stop
+    endif
+    :Process Request;
+    if (Success?) then (yes)
+    else (no)
+        :Return Processing Error;
+        stop
+    endif
+    :Generate Response;
+    :Return Response;
+    stop
+    @enduml
+
+
+Key Concepts
+============
+
+**Composite Pattern**
+    Each pipeline stage (validation, parsing, authentication, authorization) uses the Composite Pattern with a base component interface. This allows individual components to be composed into more complex operations, enabling flexible configuration of what rules apply to each protocol and operation.
+
+**Request Context**
+    The RequestContext object carries state through the entire pipeline. Different context types (EstCertificateRequestContext, CmpBaseRequestContext, etc.) extend BaseRequestContext to provide protocol-specific attributes while maintaining a consistent interface.
+
+**ParsingComponent**
+    Parsing components sequentially process the request context, extracting and validating message content. Examples include:
+
+    - EstAuthorizationHeaderParsing: Extracts HTTP Basic Auth credentials
+    - EstPkiMessageParsing: Parses PKCS#10 CSR
+    - CmpPkiMessageParsing: Parses CMP PKIMessage
+    - DomainParsing: Resolves domain identifier to DomainModel
+    - CertProfileParsing: Resolves certificate profile
+
+**AuthenticationComponent**
+    Authentication components verify the authenticity of credentials. Unlike authorization, authentication does NOT determine device identity; that happens during authorization. Authentication simply validates that the provided credentials are valid.
+
+**AuthorizationComponent**
+    Authorization components determine what operations are allowed. They access the fully populated RequestContext (including domain and device information) to make authorization decisions.
+
+**Error Handling**
+    Each stage can raise exceptions with appropriate error messages. Errors are caught at the view level and converted to protocol-specific error responses (EST error messages or CMP PKIFailureInfo).

--- a/docs/source/devices/onboarding.rst
+++ b/docs/source/devices/onboarding.rst
@@ -152,6 +152,32 @@ Requirements:
 - Trustpoint-Client installed on the device (via `pip install trustpoint-client`).
 - A connection to communicate with Trustpoint services.
 
+^^^^^^^^^^^^^^^^^^^^^^^^^
+OPC UA GDS Push Onboarding
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+OPC UA Global Discovery Server (GDS) Push is a standardized mechanism for distributing and updating certificates, trust anchors, and Certificate Revocation Lists (CRLs) to OPC UA servers.
+This method is particularly suited for industrial automation environments using OPC UA.
+
+How It Works:
+
+- OPC UA servers are registered with Trustpoint
+- Trustpoint manages certificates and trust anchors for the servers
+- Trustpoint uses the OPC UA GDS Push protocol to securely deliver certificates, trust anchors, and CRLs to registered servers
+
+Requirements:
+
+- OPC UA server(s) configured to support GDS Push
+- Network connectivity between Trustpoint and the OPC UA servers
+- Proper firewall rules to allow OPC UA GDS Push communication
+
+Trustpoint Integration:
+
+- Add OPC UA servers as devices in Trustpoint with protocol **OPC UA GDS Push**
+- Configure the server's connection details (hostname, port)
+- Add the servers initial server certificate as a truststore
+- Finish onboarding by pushing the initial (Trustpoint) issued server certificate to the OPC UA server
+
 ----------------------------------------
 Zero-Touch Onboarding (Work in Progress)
 ----------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -67,8 +67,7 @@ Welcome to Trustpoint's documentation!
    development/architecture/credentials
    development/auto_restore
    development/sbom
-   development/workflow
+   development/pipeline
    release-checklist
-   devices/workflow
    development/rest_api
 

--- a/docs/source/indices_and_tables/glossary.rst
+++ b/docs/source/indices_and_tables/glossary.rst
@@ -29,6 +29,16 @@ Glossary
         This credential is then used to authenticate itself against the Trustpoint and thus allows the device to
         request application certificates corresponding to that domain.
 
+    IDevID
+        Initial Device Identifier is a certificate issued by the device manufacturer per IEEE 802.1AR.
+        It serves as a permanent identity of the device and can be used to authenticate the device during onboarding
+        to establish trust with Trustpoint or other PKI systems.
+
+    LDevID
+        Locally-significant Device Identifier is a certificate issued by Trustpoint or a local PKI to a device
+        during the onboarding process. Unlike IDevID, LDevID is domain-specific and is used for authentication
+        within a particular industrial environment or domain.
+
     Root CA
         A trusted Certificate Authority that is the anchor of trust in a PKI.
         It is used to sign Issuing CAs and other subordinate certificates, establishing the basis for the certificate chain.
@@ -106,6 +116,15 @@ Glossary
         The Certificate Management Protocol is used for managing digital certificates within a Public Key Infrastructure (PKI),
         including certificate issuance, renewal, and revocation.
 
+    OPC UA GDS Push
+        OPC UA Global Discovery Server Push is a standardized protocol for distributing and updating certificates,
+        trust anchors, and Certificate Revocation Lists (CRLs) to OPC UA servers.
+        This allows centralized management of credentials for OPC UA-based industrial automation infrastructure.
+
+    AOKI
+        Automated Onboarding for Keyless Infrastructure is a zero-touch onboarding protocol designed specifically for industrial environments.
+        It uses mDNS for server discovery and REST APIs for mutual trust establishment before transitioning to standard PKI protocols (CMP or EST).
+
     Application Certificates
         Digital certificates issued by Trustpoint for specific applications or systems (like TLS server/client, OPC UA server/client),
         enabling secure communication and authentication for those applications within the Trustpoint-managed environment.
@@ -147,6 +166,29 @@ Glossary
         Astrals ruff ist a really fast python linter and code formatter.
         See also: `ruff <https://docs.astral.sh/ruff/>`_.
 
+    Composite Pattern
+        A structural design pattern that allows you to compose objects into tree structures to represent part-whole hierarchies.
+        Composite lets clients treat individual objects and compositions of objects uniformly.
+        Trustpoint uses this pattern extensively for composing validation, parsing, authentication, and authorization components.
+
+    Request Context
+        An object that carries state through the entire request pipeline in Trustpoint.
+        It includes raw HTTP request data, parsed messages, extracted credentials, domain information, and device identity.
+        Different context types (EstCertificateRequestContext, CmpBaseRequestContext, etc.) extend BaseRequestContext for protocol-specific attributes.
+
+    ParsingComponent
+        A component in the Trustpoint request pipeline responsible for parsing and validating a specific aspect of the request.
+        Examples include EstPkiMessageParsing (parses CSR), CmpPkiMessageParsing (parses CMP messages), and DomainParsing (resolves domain).
+
+    AuthenticationComponent
+        A component responsible for verifying the authenticity of credentials provided in the request
+        (e.g., HTTP Basic Auth, shared secret, client certificate).
+        Does not determine which device is making the request; that is the role of authorization.
+
+    AuthorizationComponent
+        A component responsible for determining what operations are allowed for an authenticated request.
+        Examples include DomainScopeValidation, CertificateProfileAuthorization, and ProtocolAuthorization.
+
     TM
         Test Manager
 
@@ -158,3 +200,4 @@ Glossary
 
     Client
         Stakeholders or End Users
+


### PR DESCRIPTION
- credentials.rst - Refactored: credential model architecture (removed request pipeline details)
- development.rst - Added: port customization hint, before-committing checklist
- workflow.rst - Added: pipeline overview, flow diagrams, request context hierarchy
- onboarding.rst - Added: OPC UA GDS Push section
- usage_guide.rst - Restructured: 5 CA modes, separated import/request, added OPC UA GDS Push
- glossary.rst - Added: 11 new terms (Remote CA, AOKI, IDevID/LDevID, architecture patterns)

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.