### PR TITLE
Setup wizard: Ensure seamless server reload when applying new TLS credentials

### DIFF
--- a/docker/trustpoint/wizard/transition/update_tls.sh
+++ b/docker/trustpoint/wizard/transition/update_tls.sh
@@ -2,7 +2,9 @@
 # /etc/trustpoint/wizard/transition/update_tls_nginx.sh
 NGINX_TLS_DIR="/etc/trustpoint/tls/"
 LOGFILE=/var/www/html/trustpoint/trustpoint/media/log/trustpoint.log
-
+MAX_RETRIES=3
+DELAY=2  # seconds
+RETRY_COUNT=0
 
 set -eE -o pipefail
 
@@ -40,17 +42,28 @@ else
     exit 2
 fi
 
-# Check if nginx is actually running (not just processes exist)
-if [ -f /run/nginx.pid ] && [ -s /run/nginx.pid ] && kill -0 "$(cat /run/nginx.pid)" 2>/dev/null; then
-    log INFO "Nginx is running - reloading configuration (graceful)"
-    if nginx -s reload; then
-        log INFO "Nginx successfully reloaded with new TLS certificates"
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+    # Check if nginx is actually running (not just processes exist)
+    if [ -f /run/nginx.pid ] && [ -s /run/nginx.pid ] && kill -0 "$(cat /run/nginx.pid)" 2>/dev/null; then
+        log INFO "Nginx is running - reloading configuration (graceful)"
+        if nginx -s reload; then
+            log INFO "Nginx successfully reloaded with new TLS certificates"
+            break
+        else
+            # Don't exit here since nginx will pick up config on next start
+            log WARN "Failed to gracefully reload nginx configuration, retrying in $DELAY seconds..."
+            sleep $DELAY
+            RETRY_COUNT=$((RETRY_COUNT + 1))
+        fi
     else
-        log WARN "Failed to gracefully reload nginx configuration, but continuing"
-        # Don't exit here since nginx will pick up config on next start
+        log WARN "Nginx is not currently running, retrying in $DELAY seconds..."
+        sleep $DELAY
+        RETRY_COUNT=$((RETRY_COUNT + 1))
     fi
-else
-    log INFO "Nginx is not currently running - configuration will be applied on next start"
+done
+if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+    log ERROR "Failed to reload Nginx after $MAX_RETRIES attempts, TLS certificates will be applied on next start"
 fi
 
+sleep $DELAY
 log INFO "TLS certificate update for nginx completed successfully"


### PR DESCRIPTION
<!-- related issue number, remove if n/a -->
Related to TP-154

**Description of changes**
Changes to handle the certificate updates in the setup wizard gracefully. The commits add delay and retry loop.

**Notes** <!-- optional -->


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.