### PR TITLE
Update forms and views to clarify EST authentication methods in DevOwnerID requests

### DIFF
--- a/trustpoint/pki/forms/owner_credential.py
+++ b/trustpoint/pki/forms/owner_credential.py
@@ -366,7 +366,7 @@ class _OwnerCredentialEstBaseMixin(LoggerMixin, forms.Form):
 
 
 class OwnerCredentialAddRequestEstNoOnboardingForm(_OwnerCredentialEstBaseMixin):
-    """Form for requesting a DevOwnerID certificate via EST with username/password."""
+    """Form for requesting a DevOwnerID certificate via EST with HTTP Basic Auth (username/password)."""
 
     est_username = forms.CharField(
         max_length=128,
@@ -381,7 +381,7 @@ class OwnerCredentialAddRequestEstNoOnboardingForm(_OwnerCredentialEstBaseMixin)
     )
 
     def clean(self) -> dict[str, Any]:
-        """Validate and save the owner credential via EST no-onboarding enrollment."""
+        """Validate and save the owner credential via EST with HTTP Basic Auth."""
         cleaned_data: dict[str, Any] = super().clean() or {}
 
         unique_name = cleaned_data.get('unique_name')
@@ -420,7 +420,7 @@ class OwnerCredentialAddRequestEstNoOnboardingForm(_OwnerCredentialEstBaseMixin)
 
 
 class OwnerCredentialAddRequestEstOnboardingForm(_OwnerCredentialEstBaseMixin):
-    """Form for requesting a DevOwnerID certificate via EST with IDevID-based onboarding."""
+    """Form for requesting a DevOwnerID certificate via EST with mTLS Client Auth (two-step enrollment)."""
 
     remote_path_domain_credential = forms.CharField(
         max_length=255,
@@ -444,7 +444,7 @@ class OwnerCredentialAddRequestEstOnboardingForm(_OwnerCredentialEstBaseMixin):
     )
 
     def clean(self) -> dict[str, Any]:
-        """Validate and prepare the owner credential via EST IDevID onboarding."""
+        """Validate and prepare the owner credential via EST with mTLS Client Auth (two-step enrollment)."""
         cleaned_data: dict[str, Any] = super().clean() or {}
 
         unique_name = cleaned_data.get('unique_name')

--- a/trustpoint/pki/views/owner_credentials.py
+++ b/trustpoint/pki/views/owner_credentials.py
@@ -140,7 +140,7 @@ OwnerCredentialAddView = OwnerCredentialFileImportView
 class OwnerCredentialAddRequestEstMethodSelectView(
     OwnerCredentialContextMixin, FormView[OwnerCredentialFileImportForm]
 ):
-    """View to select between onboarding and no-onboarding for EST-based DevOwnerID enrollment."""
+    """View to select between EST authentication methods: Basic Auth or mTLS Client Auth."""
 
     template_name = 'pki/owner_credentials/add/est_method_select.html'
     form_class = OwnerCredentialFileImportForm
@@ -151,7 +151,7 @@ class OwnerCredentialAddRequestEstMethodSelectView(
         return self.render_to_response(self.get_context_data())
 
     def post(self, request: HttpRequest, *_args: Any, **_kwargs: Any) -> HttpResponse:
-        """Redirect based on whether onboarding or no-onboarding is chosen."""
+        """Redirect based on the selected EST authentication method (Basic Auth or mTLS Client Auth)."""
         method = request.POST.get('method_select')
         if method == 'no_onboarding':
             return HttpResponseRedirect(reverse_lazy('pki:owner_credentials-add-est-no-onboarding'))
@@ -163,7 +163,7 @@ class OwnerCredentialAddRequestEstMethodSelectView(
 class OwnerCredentialAddRequestEstNoOnboardingView(
     OwnerCredentialContextMixin, FormView[OwnerCredentialAddRequestEstNoOnboardingForm]
 ):
-    """View to request a DevOwnerID via EST using username/password (no IDevID onboarding)."""
+    """View to request a DevOwnerID via EST using HTTP Basic Auth (username/password)."""
 
     template_name = 'pki/owner_credentials/add/est_request.html'
     form_class = OwnerCredentialAddRequestEstNoOnboardingForm
@@ -172,7 +172,7 @@ class OwnerCredentialAddRequestEstNoOnboardingView(
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         """Add heading context."""
         context = super().get_context_data(**kwargs)
-        context['form_title'] = _('Request DevOwnerID via EST — No Onboarding (Username / Password)')
+        context['form_title'] = _('Request DevOwnerID via EST — Basic Auth (Username / Password)')
         context['back_url'] = reverse_lazy('pki:owner_credentials-add-est')
         return context
 
@@ -214,7 +214,7 @@ class OwnerCredentialAddRequestEstNoOnboardingView(
 class OwnerCredentialAddRequestEstOnboardingView(
     OwnerCredentialContextMixin, FormView[OwnerCredentialAddRequestEstOnboardingForm]
 ):
-    """View to request a DevOwnerID via EST using IDevID-based onboarding (mTLS client certificate)."""
+    """View to request a DevOwnerID via EST using mTLS Client Auth (two-step enrollment with domain credential)."""
 
     template_name = 'pki/owner_credentials/add/est_request.html'
     form_class = OwnerCredentialAddRequestEstOnboardingForm
@@ -223,15 +223,15 @@ class OwnerCredentialAddRequestEstOnboardingView(
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         """Add heading context."""
         context = super().get_context_data(**kwargs)
-        context['form_title'] = _('Request DevOwnerID via EST — Onboarding (IDevID)')
+        context['form_title'] = _('Request DevOwnerID via EST — mTLS Client Auth')
         context['back_url'] = reverse_lazy('pki:owner_credentials-add-est')
         return context
 
     def form_valid(self, form: OwnerCredentialAddRequestEstOnboardingForm) -> HttpResponse:
-        """Save the OwnerCredentialModel with its EST onboarding configuration.
+        """Save the OwnerCredentialModel with its EST mTLS Client Auth configuration.
 
         Creates the ``OwnerCredentialModel`` with all remote-endpoint fields and redirects
-        to the truststore-association step, mirroring the no-onboarding workflow.
+        to the truststore-association step.
         """
         owner_credential = OwnerCredentialModel.objects.create(
             unique_name=form.cleaned_data['unique_name'],
@@ -856,10 +856,10 @@ class OwnerCredentialRequestCertEstView(
     ) -> dict[str, Any]:
         """Build keyword arguments for ``EstCertificateRequestContext``.
 
-        For ``REMOTE_EST`` (no onboarding) → username/password auth,
+        For ``REMOTE_EST`` (Basic Auth) → username/password auth,
         truststore from ``no_onboarding_config``.
 
-        For ``REMOTE_EST_ONBOARDING`` → mTLS with the domain credential,
+        For ``REMOTE_EST_ONBOARDING`` (mTLS Client Auth) → mTLS with the domain credential,
         truststore from ``onboarding_config``.
         """
         kwargs: dict[str, Any] = {

--- a/trustpoint/templates/pki/owner_credentials/add/est_method_select.html
+++ b/trustpoint/templates/pki/owner_credentials/add/est_method_select.html
@@ -12,28 +12,28 @@
 
                 <div class="card d-flex flex-column" style="max-width: 400px; width: 100%;">
                     <div class="card-body d-flex flex-column">
-                        <h5 class="card-title"><strong>{% trans 'No Onboarding' %}</strong></h5>
+                        <h5 class="card-title"><strong>{% trans 'Basic authentication' %}</strong></h5>
                         <hr class="hr-m">
                         <p class="card-text flex-grow-1">
                             {% trans 'Authenticate directly to the remote EST server using a username and password (HTTP Basic Auth) to retrieve the DevOwnerID certificate.' %}
                         </p>
                         <a href="{% url 'pki:owner_credentials-add-est-no-onboarding' %}"
                            class="btn btn-primary mt-auto w-100" style="max-width: 250px; margin-left: auto; margin-right: auto;">
-                            {% trans 'No Onboarding' %}
+                            {% trans 'Basic authentication' %}
                         </a>
                     </div>
                 </div>
 
                 <div class="card d-flex flex-column" style="max-width: 400px; width: 100%;">
                     <div class="card-body d-flex flex-column">
-                        <h5 class="card-title"><strong>{% trans 'Onboarding' %}</strong></h5>
+                        <h5 class="card-title"><strong>{% trans 'Mutual TLS authentication' %}</strong></h5>
                         <hr class="hr-m">
                         <p class="card-text flex-grow-1">
-                            {% trans 'Two-step enrollment: first request a client certificate from the remote EST server using the device IDevID, then use that client certificate to request the DevOwnerID.' %}
+                            {% trans 'Two-step enrollment: first request a client certificate from the remote EST server using username/password, then use that client certificate to request the DevOwnerID.' %}
                         </p>
                         <a href="{% url 'pki:owner_credentials-add-est-onboarding' %}"
                            class="btn btn-primary mt-auto w-100" style="max-width: 250px; margin-left: auto; margin-right: auto;">
-                            {% trans 'Onboarding' %}
+                            {% trans 'Mutual TLS authentication' %}
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
- Renamed "No Onboarding" → "Basic authentication" and "Onboarding" → "Mutual TLS authentication" across UI, views, and form documentation for clarity

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.