### PR TITLE
Add forms and views for language, logging, and notification configuration

### DIFF
--- a/trustpoint/management/forms.py
+++ b/trustpoint/management/forms.py
@@ -853,8 +853,9 @@ class LanguageConfigForm(forms.Form):
         """Initialize the LanguageConfigForm."""
         super().__init__(*args, **kwargs)
 
-        language_field: forms.ChoiceField[Any] = self.fields['language']  # type: ignore[assignment]
-        language_field.choices = settings.LANGUAGES
+        language_field = self.fields['language']
+        if isinstance(language_field, forms.ChoiceField):
+            language_field.choices = settings.LANGUAGES
 
     def save(self) -> None:
         """Save method for form compatibility (language is handled by Django's set_language view)."""

--- a/trustpoint/management/forms.py
+++ b/trustpoint/management/forms.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, NoReturn, cast
+import logging
+from typing import TYPE_CHECKING, Any, ClassVar, NoReturn, cast
 
 from crispy_bootstrap5.bootstrap5 import Field
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Fieldset, Layout
 from cryptography.x509 import Certificate
 from django import forms
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.utils.translation import gettext_lazy as _
@@ -19,7 +21,14 @@ from trustpoint_core.serializer import (
     PrivateKeySerializer,
 )
 
-from management.models import BackupOptions, KeyStorageConfig, NotificationConfig, PKCS11Token, SecurityConfig
+from management.models import (
+    BackupOptions,
+    KeyStorageConfig,
+    LoggingConfig,
+    NotificationConfig,
+    PKCS11Token,
+    SecurityConfig,
+)
 from management.security import manager
 from management.security.features import AutoGenPkiFeature, SecurityFeature
 from pki.models import CredentialModel
@@ -830,3 +839,49 @@ class PKCS11ConfigForm(forms.Form):
                     setattr(token, field, value)
             token.save()
         return token
+
+
+class LanguageConfigForm(forms.Form):
+    """Form for managing language configuration."""
+
+    language = forms.ChoiceField(
+        label=_('Language'),
+        widget=forms.Select(attrs={'class': 'form-select'}),
+    )
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the LanguageConfigForm."""
+        super().__init__(*args, **kwargs)
+
+        self.fields['language'].choices = settings.LANGUAGES
+
+    def save(self) -> None:
+        """Save method for form compatibility (language is handled by Django's set_language view)."""
+
+
+class LoggingConfigForm(forms.Form):
+    """Form for managing logging configuration."""
+
+    LOG_LEVELS: ClassVar[list[tuple[str, str]]] = [
+        ('DEBUG', 'DEBUG'),
+        ('INFO', 'INFO'),
+        ('WARNING', 'WARNING'),
+        ('ERROR', 'ERROR'),
+        ('CRITICAL', 'CRITICAL'),
+    ]
+
+    loglevel = forms.ChoiceField(
+        label=_('Log Level'),
+        choices=LOG_LEVELS,
+        widget=forms.Select(attrs={'class': 'form-select'}),
+    )
+
+    def save(self) -> None:
+        """Save the logging configuration."""
+        level = self.cleaned_data['loglevel']
+        logger = logging.getLogger()
+        logger.setLevel(getattr(logging, level))
+        LoggingConfig.objects.update_or_create(
+            id=1,
+            defaults={'log_level': level}
+        )

--- a/trustpoint/management/forms.py
+++ b/trustpoint/management/forms.py
@@ -853,7 +853,8 @@ class LanguageConfigForm(forms.Form):
         """Initialize the LanguageConfigForm."""
         super().__init__(*args, **kwargs)
 
-        self.fields['language'].choices = settings.LANGUAGES
+        language_field: forms.ChoiceField[Any] = self.fields['language']  # type: ignore[assignment]
+        language_field.choices = settings.LANGUAGES
 
     def save(self) -> None:
         """Save method for form compatibility (language is handled by Django's set_language view)."""

--- a/trustpoint/management/tests/test_views/test_settings.py
+++ b/trustpoint/management/tests/test_views/test_settings.py
@@ -7,18 +7,20 @@ from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from management.forms import SecurityConfigForm
 from management.models import LoggingConfig, SecurityConfig
-from management.views.settings import ChangeLogLevelView, LOG_LEVELS, SettingsView
+from management.views.settings import ChangeLogLevelView, SecuritySettingsView, SettingsTabView
 from pki.util.keys import AutoGenPkiKeyAlgorithm
 
+LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
 
-class SettingsViewTest(TestCase):
-    """Test suite for SettingsView."""
+
+class SecuritySettingsViewTest(TestCase):
+    """Test suite for SecuritySettingsView."""
 
     def setUp(self):
         """Set up test fixtures."""
         self.factory = RequestFactory()
-        self.view = SettingsView()
-        self.view.request = self.factory.get('/settings/')
+        self.view = SecuritySettingsView()
+        self.view.request = self.factory.get('/settings/security/')
 
         # Enable message storage
         from django.contrib.messages.storage.fallback import FallbackStorage
@@ -35,7 +37,7 @@ class SettingsViewTest(TestCase):
 
     def test_template_name(self):
         """Test correct template is used."""
-        self.assertEqual(self.view.template_name, 'management/settings.html')
+        self.assertEqual(self.view.template_name, 'management/includes/security_configuration.html')
 
     def test_form_class(self):
         """Test correct form class is used."""
@@ -43,7 +45,7 @@ class SettingsViewTest(TestCase):
 
     def test_success_url(self):
         """Test success URL is set correctly."""
-        self.assertEqual(str(self.view.success_url), reverse('management:settings'))
+        self.assertEqual(str(self.view.success_url), reverse('management:settings-security'))
 
     def test_page_category_and_name(self):
         """Test page category and name are set correctly."""
@@ -72,20 +74,6 @@ class SettingsViewTest(TestCase):
         
         self.assertEqual(context['page_category'], 'management')
         self.assertEqual(context['page_name'], 'settings')
-
-    def test_get_context_data_includes_log_levels(self):
-        """Test get_context_data includes log levels."""
-        context = self.view.get_context_data()
-        
-        self.assertIn('loglevels', context)
-        self.assertEqual(context['loglevels'], LOG_LEVELS)
-
-    def test_get_context_data_includes_current_log_level(self):
-        """Test get_context_data includes current log level."""
-        context = self.view.get_context_data()
-        
-        self.assertIn('current_loglevel', context)
-        self.assertIsInstance(context['current_loglevel'], str)
 
     def test_get_context_data_includes_notification_configs(self):
         """Test get_context_data includes notification configurations JSON."""
@@ -237,9 +225,50 @@ class SettingsViewTest(TestCase):
         self.assertTrue(any('error' in str(msg).lower() for msg in messages_list))
 
     def test_inherits_from_form_view(self):
-        """Test SettingsView inherits from FormView."""
+        """Test SecuritySettingsView inherits from FormView."""
         from django.views.generic.edit import FormView
-        self.assertTrue(issubclass(SettingsView, FormView))
+        self.assertTrue(issubclass(SecuritySettingsView, FormView))
+
+
+class SettingsTabViewTest(TestCase):
+    """Test suite for SettingsTabView."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.factory = RequestFactory()
+        self.view = SettingsTabView()
+        self.view.request = self.factory.get('/settings/')
+
+        # Create security config
+        SecurityConfig.objects.create(
+            id=1,
+            security_mode=SecurityConfig.SecurityModeChoices.BROWNFIELD,
+            auto_gen_pki=False,
+        )
+
+    def test_template_name(self):
+        """Test correct template is used."""
+        self.assertEqual(self.view.template_name, 'management/settings.html')
+
+    def test_get_context_data_includes_log_levels(self):
+        """Test get_context_data includes log levels."""
+        context = self.view.get_context_data()
+        
+        self.assertIn('loglevels', context)
+        self.assertEqual(context['loglevels'], LOG_LEVELS)
+
+    def test_get_context_data_includes_current_log_level(self):
+        """Test get_context_data includes current log level."""
+        context = self.view.get_context_data()
+        
+        self.assertIn('current_loglevel', context)
+        self.assertIsInstance(context['current_loglevel'], str)
+
+    def test_inherits_from_template_view(self):
+        """Test SettingsTabView inherits from TemplateView."""
+        from django.views.generic import TemplateView
+        self.assertTrue(issubclass(SettingsTabView, TemplateView))
+
 
 
 class ChangeLogLevelViewTest(TestCase):
@@ -277,11 +306,11 @@ class ChangeLogLevelViewTest(TestCase):
         
         # Check success message
         messages_list = list(get_messages(request))
-        self.assertTrue(any('DEBUG' in str(msg) for msg in messages_list))
+        self.assertTrue(any('updated successfully' in str(msg).lower() for msg in messages_list))
         
         # Check redirect
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse('management:settings'))
+        self.assertTrue(response.url.startswith(reverse('management:settings')))
 
     def test_post_with_invalid_log_level(self):
         """Test POST with invalid log level shows error."""

--- a/trustpoint/management/urls.py
+++ b/trustpoint/management/urls.py
@@ -2,12 +2,33 @@
 
 from django.urls import path, re_path
 
-from .views import IndexView, backup, help_support, key_storage, logging, notifications, settings, tls
+from .views import (
+    IndexView,
+    backup,
+    help_support,
+    key_storage,
+    logging,
+    notifications,
+    settings,
+    tls,
+)
 
 app_name = 'management'
 urlpatterns = [
     path('', IndexView.as_view(), name='index'),
-    # path('settings/', settings.settings, name='settings'),  # noqa: ERA001
+    # Settings URLs
+    path('settings/', settings.SettingsTabView.as_view(), name='settings'),
+    path('settings/language/', settings.LanguageSettingsView.as_view(), name='settings-language'),
+    path('settings/security/', settings.SecuritySettingsView.as_view(), name='settings-security'),
+    path('settings/logging/', settings.LoggingSettingsView.as_view(), name='settings-logging'),
+    path(
+        'settings/notifications/',
+        settings.NotificationSettingsView.as_view(),
+        name='settings-notifications'
+    ),
+    # Backward compatibility for log level change
+    path('loglevel/change', settings.ChangeLogLevelView.as_view(), name='change-loglevel'),
+    # Logging file views
     path('logging/files/', logging.LoggingFilesTableView.as_view(), name='logging-files'),
     re_path(
         r'^logging/files/details/(?P<filename>trustpoint\.log(?:\.\d{1,5})?)/?$',
@@ -24,8 +45,7 @@ urlpatterns = [
         logging.LoggingFilesDownloadMultipleView.as_view(),
         name='logging-files-download-multiple',
     ),
-    path('loglevel/change', settings.ChangeLogLevelView.as_view(), name='change-loglevel'),
-    path('settings/', settings.SettingsView.as_view(), name='settings'),
+    # TLS views
     path('tls/', tls.TlsView.as_view(), name='tls'),
     path('tls/add/method-select/', tls.TlsAddMethodSelectView.as_view(),
         name='tls-add-method_select',
@@ -49,11 +69,7 @@ urlpatterns = [
         name='tls-delete_confirm',
     ),
     path('tls/activate/<int:pk>', tls.ActivateTlsServerView.as_view(), name='activate-tls'),
-    path(
-        'backups/',
-        backup.BackupManageView.as_view(extra_context={'page_category': 'management', 'page_name': 'backup'}),
-        name='backups'
-    ),
+    # Backup views
     path(
         'backups/',
         backup.BackupManageView.as_view(extra_context={'page_category': 'management', 'page_name': 'backup'}),
@@ -66,6 +82,7 @@ urlpatterns = [
         name='backup-download-multiple'
     ),
     path('backups/delete-multiple/', backup.BackupFilesDeleteMultipleView.as_view(), name='backup-delete-multiple'),
+    # Other views
     path('help/', help_support.HelpView.as_view(), name='help'),
     path('key_storage/', key_storage.KeyStorageConfigView.as_view(), name='key_storage'),
     path('notifications/refresh/', notifications.RefreshNotificationsView.as_view(), name='refresh_notifications'),

--- a/trustpoint/management/views/settings.py
+++ b/trustpoint/management/views/settings.py
@@ -1,19 +1,21 @@
-"""Settings views."""
+"""Settings views with dedicated views for each setting type."""
 
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from django.contrib import messages
 from django.core.management import call_command
 from django.shortcuts import redirect
-from django.urls import reverse, reverse_lazy
+from django.urls import reverse_lazy
+from django.utils import translation
 from django.utils.translation import gettext as _
 from django.views import View
+from django.views.generic import TemplateView
 from django.views.generic.edit import FormView
 
-from management.forms import NotificationConfigForm, SecurityConfigForm
+from management.forms import LanguageConfigForm, LoggingConfigForm, NotificationConfigForm, SecurityConfigForm
 from management.models import LoggingConfig, NotificationConfig, SecurityConfig
 from management.security.features import AutoGenPkiFeature
 from management.security.mixins import SecurityLevelMixin
@@ -22,116 +24,135 @@ from trustpoint.logger import LoggerMixin
 from trustpoint.page_context import PageContextMixin
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from django.http import HttpRequest, HttpResponse
 
 
-LOG_LEVELS=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
-class SettingsView(PageContextMixin, SecurityLevelMixin, LoggerMixin, FormView[SecurityConfigForm]):
-    """A view for managing security settings in the Trustpoint application.
-
-    This view handles the display and processing of the SecurityConfigForm,
-    allowing users to configure security-related settings such as security mode,
-    auto-generated PKI, and notification configurations.
-    """
-    template_name = 'management/settings.html'
-    form_class = SecurityConfigForm
-    success_url = reverse_lazy('management:settings')
+class SettingsFormViewMixin[FormType: (
+    LanguageConfigForm | LoggingConfigForm | NotificationConfigForm | SecurityConfigForm
+)](
+    PageContextMixin,
+    SecurityLevelMixin,
+    LoggerMixin,
+    FormView[FormType],
+):
+    """Base mixin for all settings form views."""
 
     page_category = 'management'
     page_name = 'settings'
 
-    def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
-        """Handle POST requests for both SecurityConfig and NotificationConfig forms.
+    setting_type: str = 'general'
 
-        Parameters
-        ----------
-        request : HttpRequest
-            The HTTP request object.
-        *args : tuple
-            Positional arguments.
-        **kwargs : dict
-            Keyword arguments.
+    def get_success_url(self) -> str:
+        """Return the URL to redirect to after successful form submission."""
+        return f"{reverse_lazy('management:settings')}?tab={self.setting_type}"
 
-        Returns:
-        -------
-        HttpResponse
-            A response object.
-        """
-        # Check which form was submitted
-        if 'security_configuration' in request.POST:
-            # Handle SecurityConfigForm
-            form = self.get_form()
-            if form.is_valid():
-                return self.form_valid(form)
-            return self.form_invalid(form)
-        if 'notification_configuration' in request.POST:
-            notification_config = NotificationConfig.get()
-            notification_form = NotificationConfigForm(request.POST, instance=notification_config)
-            self.logger.debug('NotificationConfigForm validation: is_valid=%s', notification_form.is_valid())
-            if notification_form.is_valid():
-                # Get the enabled status before and after
-                was_enabled = notification_config.enabled
+    def form_valid(self, form: FormType) -> HttpResponse:
+        """Handle valid form submission."""
+        form.save()
+        messages.success(self.request, _('Your changes were saved successfully.'))
+        return super().form_valid(form)
 
-                notification_form.save()
+    def form_invalid(self, form: FormType) -> HttpResponse:
+        """Handle invalid form submission."""
+        messages.error(self.request, _('Error saving the configuration'))
+        return super().form_invalid(form)
 
-                notification_config.refresh_from_db()
-                cleaned_enabled = notification_config.enabled
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        """Build the context dictionary for rendering the page."""
+        context = super().get_context_data(**kwargs)
+        context['page_category'] = self.page_category
+        context['page_name'] = self.page_name
+        context['setting_type'] = self.setting_type
+        return context
 
-                if cleaned_enabled:
-                    needs_init = not notification_config.notification_cycle_enabled or not was_enabled
 
-                    if needs_init:
-                        try:
-                            notification_config.notification_cycle_enabled = True
-                            notification_config.save(update_fields=['notification_cycle_enabled'])
+class SettingsTabView(TemplateView):
+    """Main settings view with tab interface."""
 
-                            call_command('init_notifications')
+    template_name = 'management/settings.html'
 
-                            if not was_enabled:
-                                messages.success(
-                                    request,
-                                    _('Notifications enabled and notification cycle initialized.')
-                                )
-                            else:
-                                messages.success(
-                                    request,
-                                    _('Notification configuration saved and cycle reinitialized.')
-                                )
-                        except Exception:  # pylint: disable=broad-except
-                            self.logger.exception('Error initializing notifications')
-                            messages.error(
-                                request,
-                                _('Notifications saved but error initializing notification cycle.')
-                            )
-                    else:
-                        messages.success(request, _('Notification configuration saved successfully.'))
-                else:
-                    if notification_config.notification_cycle_enabled:
-                        notification_config.notification_cycle_enabled = False
-                        notification_config.save(update_fields=['notification_cycle_enabled'])
-                    messages.success(request, _('Notifications disabled successfully.'))
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        """Build the context for the settings page."""
+        context = super().get_context_data(**kwargs)
+        context['page_category'] = 'management'
+        context['page_name'] = 'settings'
 
-                return redirect(self.success_url)
-            self.logger.error('Notification form errors: %s', notification_form.errors)
-            self.logger.error('Notification form non-field errors: %s', notification_form.non_field_errors())
-            messages.error(request, _('Error saving notification configuration'))
-            return self.render_to_response(
-                self.get_context_data(notification_form=notification_form)
-            )
-        return super().post(request, *args, **kwargs)
+        context['active_tab'] = self.request.GET.get('tab', 'language')
+
+        language_view = LanguageSettingsView()
+        language_view.request = self.request
+        language_view.setup(self.request)
+        context['language_form'] = language_view.get_form()
+
+        security_view = SecuritySettingsView()
+        security_view.request = self.request
+        security_view.setup(self.request)
+        context['security_form'] = security_view.get_form()
+        context['notification_configurations_json'] = SecurityConfig.get_settings_preview_json()
+
+        logging_view = LoggingSettingsView()
+        logging_view.request = self.request
+        logging_view.setup(self.request)
+        context['logging_form'] = logging_view.get_form()
+        context['loglevels'] = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
+        current_level_num = logging.getLogger().getEffectiveLevel()
+        context['current_loglevel'] = logging.getLevelName(current_level_num)
+
+        notification_view = NotificationSettingsView()
+        notification_view.request = self.request
+        notification_view.setup(self.request)
+        context['notification_form'] = notification_view.get_form()
+        context['notification_config'] = NotificationConfig.get()
+
+        return context
+
+
+class LanguageSettingsView(SettingsFormViewMixin[LanguageConfigForm]):
+    """View for managing language settings."""
+
+    template_name = 'management/includes/language_configuration.html'
+    form_class = LanguageConfigForm
+    setting_type = 'language'
+
+    def get_initial(self) -> dict[str, Any]:
+        """Get initial form data."""
+        initial = super().get_initial()
+        initial['language'] = translation.get_language()
+        return initial
+
+    def form_valid(self, form: LanguageConfigForm) -> HttpResponse:
+        """Handle valid language form submission."""
+        language = form.cleaned_data['language']
+
+        translation.activate(language)
+
+        response = redirect(self.get_success_url())
+
+        response.set_cookie(
+            key='django_language',
+            value=language,
+            max_age=365 * 24 * 60 * 60,  # 1 year
+            path='/',
+            samesite='Lax',
+        )
+
+        messages.success(self.request, _('Language changed successfully.'))
+        return response
+
+
+class SecuritySettingsView(SettingsFormViewMixin[SecurityConfigForm]):
+    """View for managing security settings."""
+
+    template_name = 'management/includes/security_configuration.html'
+    form_class = SecurityConfigForm
+    setting_type = 'security'
+    success_url = reverse_lazy('management:settings-security')
 
     def get_form_kwargs(self) -> dict[str, Any]:
         """Get the keyword arguments for instantiating the form.
 
-        This method retrieves or creates the `SecurityConfig` instance
-        and includes it in the form's keyword arguments.
-
         Returns:
-        -------
-        dict
-            The keyword arguments for the form, including the `instance`.
+            The keyword arguments for the form, including the instance.
         """
         kwargs = super().get_form_kwargs()
         try:
@@ -142,19 +163,15 @@ class SettingsView(PageContextMixin, SecurityLevelMixin, LoggerMixin, FormView[S
         return kwargs
 
     def form_valid(self, form: SecurityConfigForm) -> HttpResponse:
-        """Handle valid form submission.
+        """Handle valid security form submission.
 
         This method processes the form data, applies security settings,
         and displays success messages to the user.
 
-        Parameters
-        ----------
-        form : SecurityConfigForm
-            The form instance containing the submitted data.
+        Parameters:
+            form: The form instance containing the submitted data.
 
         Returns:
-        -------
-        HttpResponse
             A redirect response to the success URL.
         """
         old_conf = SecurityConfig.objects.get(pk=form.instance.pk) if form.instance.pk else None
@@ -206,24 +223,10 @@ class SettingsView(PageContextMixin, SecurityLevelMixin, LoggerMixin, FormView[S
                 self.logger.info('Auto-generated PKI disabled')
 
         messages.success(self.request, _('Your changes were saved successfully.'))
-        return super().form_valid(form)
+        return redirect(self.get_success_url())
 
     def form_invalid(self, form: SecurityConfigForm) -> HttpResponse:
-        """Handle invalid form submission.
-
-        This method displays an error message and re-renders the form
-        with validation errors.
-
-        Parameters
-        ----------
-        form : SecurityConfigForm
-            The form instance containing the submitted data.
-
-        Returns:
-        -------
-        HttpResponse
-            A response rendering the form with errors.
-        """
+        """Handle invalid security form submission."""
         messages.error(self.request, _('Error saving the configuration'))
         extra: dict[str, Any] = {'form': form}
         if hasattr(form, '_violations'):
@@ -233,69 +236,137 @@ class SettingsView(PageContextMixin, SecurityLevelMixin, LoggerMixin, FormView[S
         return self.render_to_response(self.get_context_data(**extra))
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
-        """Build the context dictionary for rendering the settings page.
-
-        This method adds page metadata, notification configurations, log levels,
-        task execution status, and the current log level to the context.
-
-        Parameters
-        ----------
-        **kwargs : dict
-            Additional context variables.
-
-        Returns:
-        -------
-        dict[str, Any]
-            The context dictionary for the template.
-        """
+        """Build the context dictionary for the security settings page."""
         context = super().get_context_data(**kwargs)
-        context['page_category'] = 'management'
-        context['page_name'] = 'settings'
-
         context['notification_configurations_json'] = SecurityConfig.get_settings_preview_json()
-        context['loglevels'] = LOG_LEVELS
+        return context
+
+
+class LoggingSettingsView(SettingsFormViewMixin[LoggingConfigForm]):
+    """View for managing logging settings."""
+
+    template_name = 'management/includes/log_configuration.html'
+    form_class = LoggingConfigForm
+    setting_type = 'log'
+
+    def get_initial(self) -> dict[str, Any]:
+        """Get initial form data with current log level."""
+        initial = super().get_initial()
+        current_level_num = logging.getLogger().getEffectiveLevel()
+        initial['loglevel'] = logging.getLevelName(current_level_num)
+        return initial
+
+    def form_valid(self, form: LoggingConfigForm) -> HttpResponse:
+        """Handle valid logging form submission."""
+        level = form.cleaned_data['loglevel']
+        self.logger.info('Changing log level to: %s', level)
+
+        logger = logging.getLogger()
+        logger.setLevel(getattr(logging, level))
+
+        LoggingConfig.objects.update_or_create(
+            id=1,
+            defaults={'log_level': level}
+        )
+
+        self.logger.info('Log level successfully changed to: %s', level)
+        messages.success(self.request, _('Log level changed to %(level)s') % {'level': level})
+        return redirect(self.get_success_url())
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        """Build the context dictionary for the logging settings page."""
+        context = super().get_context_data(**kwargs)
+        context['loglevels'] = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
         current_level_num = logging.getLogger().getEffectiveLevel()
         context['current_loglevel'] = logging.getLevelName(current_level_num)
+        return context
 
-        # Add notification configuration form
+
+class NotificationSettingsView(SettingsFormViewMixin[NotificationConfigForm]):
+    """View for managing notification settings."""
+
+    template_name = 'management/includes/notification_configuration.html'
+    form_class = NotificationConfigForm
+    setting_type = 'notifications'
+
+    def get_form_kwargs(self) -> dict[str, Any]:
+        """Get the keyword arguments for instantiating the form."""
+        kwargs = super().get_form_kwargs()
         notification_config = NotificationConfig.get()
-        context['notification_form'] = NotificationConfigForm(instance=notification_config)
-        context['notification_config'] = notification_config
+        kwargs['instance'] = notification_config
+        return kwargs
 
+    def form_valid(self, form: NotificationConfigForm) -> HttpResponse:
+        """Handle valid notification form submission."""
+        notification_config = form.instance
+        was_enabled = notification_config.enabled
+
+        form.save()
+        notification_config.refresh_from_db()
+        cleaned_enabled = notification_config.enabled
+
+        if cleaned_enabled:
+            needs_init = not notification_config.notification_cycle_enabled or not was_enabled
+
+            if needs_init:
+                try:
+                    notification_config.notification_cycle_enabled = True
+                    notification_config.save(update_fields=['notification_cycle_enabled'])
+
+                    call_command('init_notifications')
+
+                    if not was_enabled:
+                        messages.success(
+                            self.request,
+                            _('Notifications enabled and notification cycle initialized.')
+                        )
+                    else:
+                        messages.success(
+                            self.request,
+                            _('Notification configuration saved and cycle reinitialized.')
+                        )
+                except Exception:
+                    self.logger.exception('Error initializing notifications')
+                    messages.error(
+                        self.request,
+                        _('Notifications saved but error initializing notification cycle.')
+                    )
+            else:
+                messages.success(self.request, _('Notification configuration saved successfully.'))
+        else:
+            if notification_config.notification_cycle_enabled:
+                notification_config.notification_cycle_enabled = False
+                notification_config.save(update_fields=['notification_cycle_enabled'])
+            messages.success(self.request, _('Notifications disabled successfully.'))
+
+        return redirect(self.get_success_url())
+
+    def form_invalid(self, form: NotificationConfigForm) -> HttpResponse:
+        """Handle invalid notification form submission."""
+        self.logger.error('Notification form errors: %s', form.errors)
+        self.logger.error('Notification form non-field errors: %s', form.non_field_errors())
+        messages.error(self.request, _('Error saving notification configuration'))
+        return super().form_invalid(form)
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        """Build the context dictionary for the notification settings page."""
+        context = super().get_context_data(**kwargs)
+        notification_config = NotificationConfig.get()
+        context['notification_form'] = context.get('form', self.get_form())
+        context['notification_config'] = notification_config
         return context
 
 
 class ChangeLogLevelView(View):
-    """A view for changing the logging level in the Trustpoint application.
+    """Deprecated view for changing the logging level."""
 
-    This view handles POST requests to update the logging level dynamically.
-    """
     def post(self, request: HttpRequest) -> HttpResponse:
-        """Handle POST requests to change the logging level.
-
-        This method validates the provided log level, updates the logger
-        and database configuration if valid, and redirects back to the settings page.
-
-        Parameters
-        ----------
-        request : HttpRequest
-            The HTTP request object containing the POST data.
-
-        Returns:
-        -------
-        HttpResponse
-            A redirect response to the settings page.
-        """
-        level = request.POST.get('loglevel', '').upper()
-        if level not in LOG_LEVELS:
-            messages.error(request, f'Invalid log level: {level}')
+        """Handle POST requests to change the logging level."""
+        form = LoggingConfigForm(request.POST)
+        if form.is_valid():
+            form.save()
+            messages.success(request, _('Log level updated successfully.'))
         else:
-            logger = logging.getLogger()
-            logger.setLevel(getattr(logging, level))
-            LoggingConfig.objects.update_or_create(
-                id=1,
-                defaults={'log_level': level}
-            )
-            messages.success(request, f'Log level set to {level}')
+            messages.error(request, _('Invalid log level.'))
 
-        return redirect(reverse('management:settings'))
+        return redirect(reverse_lazy('management:settings') + '?tab=log')

--- a/trustpoint/templates/management/includes/language_configuration.html
+++ b/trustpoint/templates/management/includes/language_configuration.html
@@ -3,20 +3,10 @@
 <div class="card">
     <div class="card-header"><h5 class="mb-0">{% trans "Language Configuration" %}</h5></div>
     <div class="card-body pt-4 pb-4">
-        <form method="POST" action="{% url 'set_language' %}" enctype="multipart/form-data" id="language_configuration">
+        <form method="POST" action="{% url 'management:settings-language' %}" enctype="multipart/form-data" id="language_configuration">
             {% csrf_token %}
             <fieldset class="form-group tp-form-group">
-                <input name="next" type="hidden" value="{{ redirect_to }}">
-                <select name="language" class="select form-select">
-                    {% get_current_language as LANGUAGE_CODE %}
-                    {% get_available_languages as LANGUAGES %}
-                    {% get_language_info_list for LANGUAGES as languages %}
-                    {% for language in languages %}
-                        <option value="{{ language.code }}"{% if language.code == LANGUAGE_CODE %} selected{% endif %}>
-                            {{ language.name_local }} ({{ language.code }})
-                        </option>
-                    {% endfor %}
-                </select>
+                {{ form.language }}
             </fieldset>
         </form>
     </div>

--- a/trustpoint/templates/management/includes/log_configuration.html
+++ b/trustpoint/templates/management/includes/log_configuration.html
@@ -3,17 +3,10 @@
 <div class="card">
     <div class="card-header"><h5 class="mb-0">{% trans "Log Configuration" %}</h5></div>
     <div class="card-body pt-4 pb-4">
-        <form method="POST" action="{% url 'management:change-loglevel' %}" id="loglevel_configuration">
+        <form method="POST" action="{% url 'management:settings-logging' %}" id="loglevel_configuration">
             {% csrf_token %}
             <fieldset class="form-group tp-form-group">
-                <input name="next" type="hidden" value="{{ redirect_to }}">
-                <select name="loglevel" class="select form-select">
-                    {% for loglevel in loglevels %}
-                        <option value="{{ loglevel }}"{% if loglevel == current_loglevel %} selected{% endif %}>
-                            {{ loglevel }}
-                        </option>
-                    {% endfor %}
-                </select>
+                {{ form.loglevel }}
             </fieldset>
         </form>
     </div>

--- a/trustpoint/templates/management/includes/notification_configuration.html
+++ b/trustpoint/templates/management/includes/notification_configuration.html
@@ -22,11 +22,10 @@
         </div>
         {% endif %}
 
-        <form method="POST" enctype="multipart/form-data" id="notification_configuration">
+        <form method="POST" action="{% url 'management:settings-notifications' %}" enctype="multipart/form-data" id="notification_configuration">
             {% csrf_token %}
-            <input type="hidden" name="notification_configuration" value="1">
             <fieldset class="form-group tp-form-group">
-                {% crispy notification_form %}
+                {% crispy form %}
             </fieldset>
         </form>
     </div>

--- a/trustpoint/templates/management/includes/security_configuration.html
+++ b/trustpoint/templates/management/includes/security_configuration.html
@@ -19,7 +19,7 @@
         </div>
         {% endif %}
 
-        <form method="POST" enctype="multipart/form-data" id="security_configuration">
+        <form method="POST" action="{% url 'management:settings-security' %}" enctype="multipart/form-data" id="security_configuration">
             {% csrf_token %}
             <fieldset class="form-group tp-form-group">
                 {% crispy form %}

--- a/trustpoint/templates/management/settings.html
+++ b/trustpoint/templates/management/settings.html
@@ -7,28 +7,28 @@
 <div class="tp-settings-layout">
 
   <div class="tp-settings-tabs">
-    <a class="tp-settings-tab-link" href="#" data-settings-tab="panel-language">{% trans "Language" %}</a>
-    <a class="tp-settings-tab-link" href="#" data-settings-tab="panel-security">{% trans "Security" %}</a>
-    <a class="tp-settings-tab-link" href="#" data-settings-tab="panel-log">{% trans "Logging" %}</a>
-    <a class="tp-settings-tab-link" href="#" data-settings-tab="panel-notifications">{% trans "Notifications" %}</a>
+    <a class="tp-settings-tab-link" href="{% url 'management:settings' %}?tab=language" data-settings-tab="panel-language">{% trans "Language" %}</a>
+    <a class="tp-settings-tab-link" href="{% url 'management:settings' %}?tab=security" data-settings-tab="panel-security">{% trans "Security" %}</a>
+    <a class="tp-settings-tab-link" href="{% url 'management:settings' %}?tab=log" data-settings-tab="panel-log">{% trans "Logging" %}</a>
+    <a class="tp-settings-tab-link" href="{% url 'management:settings' %}?tab=notifications" data-settings-tab="panel-notifications">{% trans "Notifications" %}</a>
   </div>
 
   <div class="tp-settings-content">
 
     <div id="panel-language" class="tp-settings-panel">
-      {% include 'management/includes/language_configuration.html' %}
+      {% include 'management/includes/language_configuration.html' with form=language_form %}
     </div>
 
     <div id="panel-security" class="tp-settings-panel">
-      {% include 'management/includes/security_configuration.html' %}
+      {% include 'management/includes/security_configuration.html' with form=security_form %}
     </div>
 
     <div id="panel-log" class="tp-settings-panel">
-      {% include 'management/includes/log_configuration.html' %}
+      {% include 'management/includes/log_configuration.html' with form=logging_form %}
     </div>
 
     <div id="panel-notifications" class="tp-settings-panel">
-      {% include 'management/includes/notification_configuration.html' %}
+      {% include 'management/includes/notification_configuration.html' with form=notification_form %}
     </div>
 
   </div>
@@ -59,7 +59,10 @@
         });
     });
 
-    var saved = localStorage.getItem(STORAGE_KEY) || DEFAULT_TAB;
+    // Get tab from URL parameter or localStorage
+    var urlParams = new URLSearchParams(window.location.search);
+    var tabParam = urlParams.get('tab');
+    var saved = tabParam ? 'panel-' + tabParam : (localStorage.getItem(STORAGE_KEY) || DEFAULT_TAB);
     if (!document.getElementById(saved)) saved = DEFAULT_TAB;
     activate(saved);
 }());


### PR DESCRIPTION
- Refactored monolithic settings view into dedicated views (LanguageSettingsView, SecuritySettingsView, LoggingSettingsView, NotificationSettingsView)
- Created generic base mixin for code reuse

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.