### PR TITLE
Add DevIdRegistration API endpoints and serializers

### DIFF
--- a/trustpoint/pki/api_urls.py
+++ b/trustpoint/pki/api_urls.py
@@ -6,7 +6,7 @@ from rest_framework.routers import DefaultRouter
 
 from pki.views.cert_profiles import CertProfileViewSet
 from pki.views.certificates import CertificateViewSet
-from pki.views.domains import DomainViewSet
+from pki.views.domains import DevIdRegistrationViewSet, DomainViewSet
 from pki.views.issuing_cas import IssuingCaViewSet
 from pki.views.owner_credentials_api import DevOwnerIdViewSet
 from pki.views.truststores import TruststoreViewSet
@@ -17,6 +17,7 @@ router.register(r'cert-profiles', CertProfileViewSet, basename='cert-profiles')
 router.register(r'issuing-cas', IssuingCaViewSet, basename='issuing-ca')
 router.register(r'truststores', TruststoreViewSet, basename='truststore')
 router.register(r'domains', DomainViewSet, basename='domain')
+router.register(r'devid-registrations', DevIdRegistrationViewSet, basename='devid-registration')
 router.register(r'devownerid', DevOwnerIdViewSet, basename='devownerid')
 
 urlpatterns = router.urls

--- a/trustpoint/pki/serializer/__init__.py
+++ b/trustpoint/pki/serializer/__init__.py
@@ -1,10 +1,13 @@
 """Serializer package for pki app."""
 from .certificate import CertificateSerializer
+from .devid_registration import DevIdRegistrationDetailSerializer, DevIdRegistrationSerializer
 from .issuing_ca import IssuingCaSerializer
 from .truststore import TruststoreSerializer
 
 __all__ = [
     'CertificateSerializer',
+    'DevIdRegistrationDetailSerializer',
+    'DevIdRegistrationSerializer',
     'IssuingCaSerializer',
     'TruststoreSerializer',
 ]

--- a/trustpoint/pki/serializer/devid_registration.py
+++ b/trustpoint/pki/serializer/devid_registration.py
@@ -1,0 +1,59 @@
+"""Serializers for DevIdRegistration-related API endpoints.
+
+Defines classes that handle validation and transformation
+of DevIdRegistration model instances to and from JSON.
+"""
+
+from typing import ClassVar
+
+from rest_framework import serializers
+
+from pki.models.devid_registration import DevIdRegistration
+from util.field import UniqueNameValidator
+
+
+class DevIdRegistrationSerializer(serializers.ModelSerializer[DevIdRegistration]):
+    """Serializer for DevIdRegistration instances.
+
+    Handles conversion between DevIdRegistration model objects and JSON representations.
+    """
+
+    unique_name = serializers.CharField(
+        max_length=256,
+        required=False,
+        allow_blank=True,
+        help_text='Optional unique name. If omitted, the truststore name is used.',
+        validators=[UniqueNameValidator()],
+    )
+
+    class Meta:
+        """Metadata for DevIdRegistrationSerializer, defining model and serialized fields."""
+
+        model = DevIdRegistration
+        fields: ClassVar[list[str]] = ['id', 'unique_name', 'truststore', 'domain', 'serial_number_pattern']
+        read_only_fields: ClassVar[list[str]] = ['id']
+
+
+class DevIdRegistrationDetailSerializer(serializers.ModelSerializer[DevIdRegistration]):
+    """Detailed serializer for a single DevIdRegistration instance.
+
+    Includes related object names for readability.
+    """
+
+    truststore_name = serializers.CharField(source='truststore.unique_name', read_only=True)
+    domain_name = serializers.CharField(source='domain.unique_name', read_only=True)
+
+    class Meta:
+        """Metadata for DevIdRegistrationDetailSerializer, defining model and serialized fields."""
+
+        model = DevIdRegistration
+        fields: ClassVar[list[str]] = [
+            'id',
+            'unique_name',
+            'truststore',
+            'truststore_name',
+            'domain',
+            'domain_name',
+            'serial_number_pattern',
+        ]
+        read_only_fields: ClassVar[list[str]] = ['id', 'truststore_name', 'domain_name']

--- a/trustpoint/pki/views/domains.py
+++ b/trustpoint/pki/views/domains.py
@@ -16,8 +16,11 @@ from django.views.generic import DeleteView
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import CreateView, FormView
 from django.views.generic.list import ListView
+from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_view
-from rest_framework import viewsets
+from rest_framework import filters, status, viewsets
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 
 from management.models.audit_log import AuditLog
 from pki.forms import DevIdAddMethodSelectForm, DevIdRegistrationForm
@@ -29,6 +32,7 @@ from pki.models import (
     DomainModel,
 )
 from pki.models.truststore import TruststoreModel
+from pki.serializer.devid_registration import DevIdRegistrationDetailSerializer, DevIdRegistrationSerializer
 from pki.serializer.domain import DomainDetailSerializer, DomainSerializer
 from trustpoint.settings import UIConfig
 from trustpoint.views.base import (
@@ -39,9 +43,12 @@ from trustpoint.views.base import (
 )
 
 if TYPE_CHECKING:
+    from typing import ClassVar
+
     from django.db.models import QuerySet
     from django.forms import Form
     from django.http import HttpRequest
+    from rest_framework.request import Request
 
 
 class DomainContextMixin(ContextDataMixin):
@@ -479,5 +486,62 @@ class DomainViewSet(viewsets.ModelViewSet[DomainModel]):
         if self.action == 'retrieve':
             return DomainDetailSerializer
         return DomainSerializer
+
+
+@extend_schema(tags=['DevID Registration'])
+@extend_schema_view(
+    list=extend_schema(description='Retrieve a list of all DevID registrations.'),
+    retrieve=extend_schema(description='Retrieve a single DevID registration by id.'),
+    create=extend_schema(description='Create a new DevID registration.'),
+    update=extend_schema(description='Update an existing DevID registration.'),
+    partial_update=extend_schema(description='Partially update an existing DevID registration.'),
+    destroy=extend_schema(description='Delete a DevID registration.'),
+)
+class DevIdRegistrationViewSet(viewsets.ModelViewSet[DevIdRegistration]):
+    """ViewSet for managing DevIdRegistration instances via REST API.
+
+    Supports standard CRUD operations such as list, retrieve,
+    create, update, and delete.
+    """
+
+    queryset = DevIdRegistration.objects.all()
+    serializer_class = DevIdRegistrationSerializer
+    permission_classes = (IsAuthenticated,)
+    filter_backends = (DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter)
+    filterset_fields: ClassVar = ['domain', 'truststore']
+    search_fields: ClassVar = ['unique_name', 'serial_number_pattern']
+    ordering_fields: ClassVar = ['unique_name']
+
+    def get_serializer_class(
+        self,
+    ) -> type[DevIdRegistrationDetailSerializer | DevIdRegistrationSerializer]:
+        """Return the detail serializer for retrieve, and the list serializer for all other actions."""
+        if self.action == 'retrieve':
+            return DevIdRegistrationDetailSerializer
+        return DevIdRegistrationSerializer
+
+    def create(self, request: Request, *_args: Any, **_kwargs: Any) -> Response:
+        """Create a new DevID registration.
+
+        If ``unique_name`` is blank the truststore's name is used as default.
+        """
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        unique_name: str = serializer.validated_data.get('unique_name', '')
+        if not unique_name:
+            truststore = serializer.validated_data.get('truststore')
+            if truststore is not None:
+                serializer.validated_data['unique_name'] = truststore.unique_name
+
+        serializer.save()
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    def destroy(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Delete a DevID registration."""
+        del request, args, kwargs
+        instance = self.get_object()
+        self.perform_destroy(instance)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 


### PR DESCRIPTION
- Introduced DevIdRegistrationViewSet for managing DevIdRegistration instances.
- Added serializers for DevIdRegistration, including detail and list serializers.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.