### PR TITLE
AOKI default cert profile fix

### DIFF
--- a/trustpoint/request/authorization/base.py
+++ b/trustpoint/request/authorization/base.py
@@ -66,14 +66,19 @@ class CertificateProfileAuthorization(AuthorizationComponent, LoggerMixin):
 
         requested_profile = context.cert_profile_str
 
-        if not requested_profile:
-            error_message = 'Certificate profile is missing in the context. Authorization denied.'
-            self.logger.warning('Certificate profile authorization failed: Profile information is missing')
-            raise ValueError(error_message)
-
         if not context.domain:
             error_message = 'Domain information is missing in the context. Authorization denied.'
             self.logger.warning('Certificate profile authorization failed: Domain information is missing')
+            raise ValueError(error_message)
+
+        if not requested_profile and context.domain_str == '.aoki':
+            # For AOKI requests, if no profile is specified, default to the domain credential profile
+            requested_profile = context.domain.get_domain_credential_profile_name()
+            context.cert_profile_str = requested_profile
+
+        if not requested_profile:
+            error_message = 'Certificate profile is missing in the context. Authorization denied.'
+            self.logger.warning('Certificate profile authorization failed: Profile information is missing')
             raise ValueError(error_message)
 
         try:

--- a/trustpoint/request/message_parser/base.py
+++ b/trustpoint/request/message_parser/base.py
@@ -60,18 +60,24 @@ class CertProfileParsing(ParsingComponent, LoggerMixin):
             return
         certprofile_str = context.cert_profile_str
 
-        if not certprofile_str and context.domain is not None:
-            certprofile_str = context.domain.get_domain_credential_profile_name()
-            context.cert_profile_str = certprofile_str
-            self.logger.info(
-                "No certificate profile specified, using domain credential profile: '%s'",
-                certprofile_str,
-            )
-
         if not certprofile_str:
-            error_message = 'Certificate profile is missing in the request context.'
-            self.logger.warning('Certificate profile parsing failed: Profile string is missing')
-            raise ValueError(error_message)
+            if context.domain is not None:
+                certprofile_str = context.domain.get_domain_credential_profile_name()
+                context.cert_profile_str = certprofile_str
+                self.logger.info(
+                    "No certificate profile specified, using domain credential profile: '%s'",
+                    certprofile_str,
+                )
+            elif context.domain_str == '.aoki':
+                self.logger.info(
+                    "No certificate profile specified and special domain '.aoki' detected, "
+                    "deferring domain credential profile resolution to authorization step"
+                )
+                return
+            else:
+                error_message = 'Certificate profile is missing in the request context.'
+                self.logger.warning('Certificate profile parsing failed: Profile string is missing')
+                raise ValueError(error_message)
 
         self.logger.info("Certificate profile parsing successful: Profile '%s'", certprofile_str)
 


### PR DESCRIPTION
**Description of changes**
Fixes AOKI onboarding with special `.aoki` domain when not specifying a certificate profile (defaults to domain default domain credential)

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.