### PR TITLE
CertConf workflow v2 trigger

### DIFF
--- a/trustpoint/cmp/tests/test_views.py
+++ b/trustpoint/cmp/tests/test_views.py
@@ -216,7 +216,6 @@ class TestCmpInitializationRequestView:
             operation='certification',
         )
 
-        assert mock_request_context.event == Events.cmp_certification
         mock_workflow2_cls.return_value.handle.assert_called_once_with(mock_request_context)
         mock_processor_cls.return_value.process_operation.assert_called_once_with(mock_request_context)
         assert response.status_code == 200

--- a/trustpoint/cmp/util.py
+++ b/trustpoint/cmp/util.py
@@ -103,6 +103,10 @@ class PKIFailureInfo(enum.IntEnum):
     DUPLICATE_CERT_REQ = 26
 
 
+# PKIStatus value 2 = "rejection" per RFC 4210 Section 5.2.3. (certConf)
+PKI_STATUS_REJECTION = 2
+
+
 class NameParser:
     """Provides class methods to transform pyasn1 (General)Names into x509.(General)Names."""
 

--- a/trustpoint/cmp/views.py
+++ b/trustpoint/cmp/views.py
@@ -110,10 +110,6 @@ class CmpRequestView(LoggerMixin, View):
 
             parser = CmpMessageParser()
             ctx = cast('CmpBaseRequestContext', parser.parse(ctx))
-            if ctx.cmp_body_type == 'ir' and ctx.operation == 'initialization':
-                ctx.event = Events.cmp_initialization
-            elif ctx.cmp_body_type == 'cr' and ctx.operation == 'certification':
-                ctx.event = Events.cmp_certification
 
             authenticator = CmpAuthentication()
             authenticator.authenticate(ctx)

--- a/trustpoint/cmp/views.py
+++ b/trustpoint/cmp/views.py
@@ -26,7 +26,6 @@ from request.request_validator.http_req import CmpHttpRequestValidator
 from request.workflow2_issuance import release_delivered_workflow2_request
 from request.workflows2_handler import Workflow2Handler
 from trustpoint.logger import LoggerMixin
-from workflows2.events.request_events import Events
 
 if TYPE_CHECKING:
     from typing import Any

--- a/trustpoint/request/message_parser/cmp.py
+++ b/trustpoint/request/message_parser/cmp.py
@@ -546,6 +546,11 @@ class CmpCertificateBodyValidation(LoggerMixin):
 
         context.cert_requested = request_builder
 
+        if body_type == 'ir' and context.operation == 'initialization':
+            context.event = Events.cmp_initialization
+        elif body_type == 'cr' and context.operation == 'certification':
+            context.event = Events.cmp_certification
+
 
 class CmpRevocationBodyValidation(LoggerMixin):
     """Sub-component for validating CMP revocation body for RR message type."""
@@ -726,10 +731,6 @@ class CmpBodyValidation(ParsingComponent, LoggerMixin):
             if body_type in ('ir', 'cr'):
                 context = context.narrow(CmpCertificateRequestContext)
                 CmpCertificateBodyValidation().parse_ircr_body(context, pki_body, body_type)
-                if body_type == 'ir' and context.operation == 'initialization':
-                    context.event = Events.cmp_initialization
-                elif body_type == 'cr' and context.operation == 'certification':
-                    context.event = Events.cmp_certification
             elif body_type == 'rr':
                 context = context.narrow(CmpRevocationRequestContext)
                 CmpRevocationBodyValidation().parse_rr_body(context, pki_body)

--- a/trustpoint/request/message_parser/cmp.py
+++ b/trustpoint/request/message_parser/cmp.py
@@ -22,6 +22,7 @@ from request.request_context import (
     CmpRevocationRequestContext,
 )
 from trustpoint.logger import LoggerMixin
+from workflows2.events.request_events import Events
 
 from .base import CertProfileParsing, CompositeParsing, DomainParsing, ParsingComponent
 
@@ -725,12 +726,17 @@ class CmpBodyValidation(ParsingComponent, LoggerMixin):
             if body_type in ('ir', 'cr'):
                 context = context.narrow(CmpCertificateRequestContext)
                 CmpCertificateBodyValidation().parse_ircr_body(context, pki_body, body_type)
+                if body_type == 'ir' and context.operation == 'initialization':
+                    context.event = Events.cmp_initialization
+                elif body_type == 'cr' and context.operation == 'certification':
+                    context.event = Events.cmp_certification
             elif body_type == 'rr':
                 context = context.narrow(CmpRevocationRequestContext)
                 CmpRevocationBodyValidation().parse_rr_body(context, pki_body)
             elif body_type == 'certConf':
                 context = context.narrow(CmpCertConfRequestContext)
                 CmpCertConfBodyValidation().parse_certconf_body(context, pki_body)
+                context.event = Events.cmp_certconf
 
             self.logger.info('CMP body type validation successful: %s body extracted', body_type.upper())
 

--- a/trustpoint/request/operation_processor/cert_conf.py
+++ b/trustpoint/request/operation_processor/cert_conf.py
@@ -1,14 +1,11 @@
 """CMP certConf operation processor classes."""
 
-from cmp.util import PKIFailureInfo
+from cmp.util import PKI_STATUS_REJECTION, PKIFailureInfo
 from request.request_context import BaseRequestContext, CmpCertConfRequestContext
 from trustpoint.logger import LoggerMixin
 
 from .base import AbstractOperationProcessor
 from .revoke_cert import CertificateRevocationProcessor
-
-# PKIStatus value 2 = "rejection" per RFC 4210 Section 5.2.3.
-_PKI_STATUS_REJECTION = 2
 
 
 class CertConfProcessor(AbstractOperationProcessor, LoggerMixin):
@@ -31,7 +28,7 @@ class CertConfProcessor(AbstractOperationProcessor, LoggerMixin):
             exc_msg = 'CertConfProcessor requires a CmpCertConfRequestContext.'
             raise TypeError(exc_msg)
 
-        if context.cert_conf_status != _PKI_STATUS_REJECTION:
+        if context.cert_conf_status != PKI_STATUS_REJECTION:
             self.logger.info(
                 'certConf received for certReqId=%s — status accepted. No CA operation required.',
                 context.cert_req_id,

--- a/trustpoint/request/workflows2_handler.py
+++ b/trustpoint/request/workflows2_handler.py
@@ -6,13 +6,13 @@ import hashlib
 from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
-import logging
 from typing import Any, ClassVar, Literal
 
 from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.x509 import CertificateSigningRequest
 from pyasn1.codec.der import encoder as der_encoder  # type: ignore[import-untyped]
 
+from cmp.util import PKI_STATUS_REJECTION
 from request.request_context import (
     BaseCertificateRequestContext,
     BaseRequestContext,
@@ -193,7 +193,7 @@ def _build_rest_reenroll_dispatch(
 
 
 def _build_cmp_request_dispatch(
-    context: BaseCertificateRequestContext,
+    context: BaseCertificateRequestContext | CmpCertConfRequestContext,
     *,
     on: str,
     operation: str,
@@ -212,6 +212,11 @@ def _build_cmp_request_dispatch(
         domain_id=context.domain.id,
         device_id=str(context.device.id),
     )
+    certconf_status = getattr(context, 'cert_conf_status', None)
+    certconf_status_str = ''
+    if certconf_status is not None:
+        certconf_status_str = 'rejected' if certconf_status == PKI_STATUS_REJECTION else 'accepted'
+
 
     fingerprint = hashlib.sha256(fingerprint_source).hexdigest()
     transaction_id = _cmp_transaction_id(context)
@@ -224,12 +229,11 @@ def _build_cmp_request_dispatch(
             'operation': operation,
             'transaction_id': transaction_id or '',
             'fingerprint': fingerprint,
-            #'cert_profile': context.cert_profile_str or '',
+            'cert_profile': context.cert_profile_str if hasattr(context, 'cert_profile_str') else '',
+            'certconf_status': certconf_status_str,
         },
         'source': serialize_source(source),
     }
-    log = logging.getLogger('trustpoint')
-    log.info('Event dict: %s', event)
 
     return Workflow2DispatchRequest(
         on=on,
@@ -261,7 +265,7 @@ def _build_cmp_certification_dispatch(
 
 
 def _build_cmp_certconf_dispatch(
-    context: BaseCertificateRequestContext,
+    context: CmpCertConfRequestContext,
 ) -> Workflow2DispatchRequest | None:
     return _build_cmp_request_dispatch(
         context,
@@ -392,7 +396,6 @@ class Workflow2CertificateRequestHandler(LoggerMixin):
     _DISPATCH_BUILDERS: ClassVar[dict[tuple[str, str], Workflow2DispatchBuilder]] = {
         ('cmp', 'initialization'): _build_cmp_initialization_dispatch,
         ('cmp', 'certification'): _build_cmp_certification_dispatch,
-        ('cmp', 'certconf'): _build_cmp_certconf_dispatch,
         ('est', 'simpleenroll'): _build_est_simpleenroll_dispatch,
         ('est', 'simplereenroll'): _build_est_simplereenroll_dispatch,
         ('rest', 'enroll'): _build_rest_enroll_dispatch,
@@ -401,11 +404,14 @@ class Workflow2CertificateRequestHandler(LoggerMixin):
 
     def handle(self, context: BaseRequestContext) -> Workflow2HandleResult:
         """Dispatch one certificate-request event into Workflow 2."""
-        if not isinstance(context, (BaseCertificateRequestContext, CmpCertConfRequestContext)):
-            msg = 'Workflow2CertificateRequestHandler requires a BaseCertificateRequestContext.'
+        if isinstance(context, CmpCertConfRequestContext):
+            dispatch_request = _build_cmp_certconf_dispatch(context)
+        elif isinstance(context, BaseCertificateRequestContext):
+            dispatch_request = self._build_dispatch_request(context)
+        else:
+            msg = ('Workflow2CertificateRequestHandler requires a '
+                   'BaseCertificateRequestContext or CmpCertConfRequestContext.')
             raise TypeError(msg)
-
-        dispatch_request = self._build_dispatch_request(context)
         if dispatch_request is None:
             return Workflow2HandleResult.continue_processing()
 

--- a/trustpoint/request/workflows2_handler.py
+++ b/trustpoint/request/workflows2_handler.py
@@ -6,6 +6,7 @@ import hashlib
 from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
+import logging
 from typing import Any, ClassVar, Literal
 
 from cryptography.hazmat.primitives.serialization import Encoding
@@ -16,6 +17,7 @@ from request.request_context import (
     BaseCertificateRequestContext,
     BaseRequestContext,
     CmpBaseRequestContext,
+    CmpCertConfRequestContext,
     HttpBaseRequestContext,
 )
 from trustpoint.logger import LoggerMixin
@@ -222,10 +224,12 @@ def _build_cmp_request_dispatch(
             'operation': operation,
             'transaction_id': transaction_id or '',
             'fingerprint': fingerprint,
-            'cert_profile': context.cert_profile_str or '',
+            #'cert_profile': context.cert_profile_str or '',
         },
         'source': serialize_source(source),
     }
+    log = logging.getLogger('trustpoint')
+    log.info('Event dict: %s', event)
 
     return Workflow2DispatchRequest(
         on=on,
@@ -253,6 +257,16 @@ def _build_cmp_certification_dispatch(
         context,
         on=Triggers.CMP_CERTIFICATION,
         operation='certification',
+    )
+
+
+def _build_cmp_certconf_dispatch(
+    context: BaseCertificateRequestContext,
+) -> Workflow2DispatchRequest | None:
+    return _build_cmp_request_dispatch(
+        context,
+        on=Triggers.CMP_CERTCONF,
+        operation='certconf',
     )
 
 
@@ -378,6 +392,7 @@ class Workflow2CertificateRequestHandler(LoggerMixin):
     _DISPATCH_BUILDERS: ClassVar[dict[tuple[str, str], Workflow2DispatchBuilder]] = {
         ('cmp', 'initialization'): _build_cmp_initialization_dispatch,
         ('cmp', 'certification'): _build_cmp_certification_dispatch,
+        ('cmp', 'certconf'): _build_cmp_certconf_dispatch,
         ('est', 'simpleenroll'): _build_est_simpleenroll_dispatch,
         ('est', 'simplereenroll'): _build_est_simplereenroll_dispatch,
         ('rest', 'enroll'): _build_rest_enroll_dispatch,
@@ -386,7 +401,7 @@ class Workflow2CertificateRequestHandler(LoggerMixin):
 
     def handle(self, context: BaseRequestContext) -> Workflow2HandleResult:
         """Dispatch one certificate-request event into Workflow 2."""
-        if not isinstance(context, BaseCertificateRequestContext):
+        if not isinstance(context, (BaseCertificateRequestContext, CmpCertConfRequestContext)):
             msg = 'Workflow2CertificateRequestHandler requires a BaseCertificateRequestContext.'
             raise TypeError(msg)
 

--- a/trustpoint/workflows2/events/builtin.py
+++ b/trustpoint/workflows2/events/builtin.py
@@ -6,6 +6,8 @@ from django.utils.translation import gettext_lazy as _
 
 from workflows2.events.context_catalog import (
     CERTIFICATE_CONTEXT,
+    CMP_CERTCONF_CONTEXT,
+    CMP_CERTREQ_CONTEXT,
     CMP_CONTEXT,
     DEVICE_CONTEXT,
     DEVICE_UPDATE_CONTEXT,
@@ -82,7 +84,7 @@ def register_builtin_events() -> None:
                 group_title='CMP',
                 keywords=('cmp', 'initialization', 'ir', 'enrollment', 'request'),
                 allowed_step_types=STEPSET_GATED_ENROLLMENT,
-                context_vars=merge(DEVICE_CONTEXT, CMP_CONTEXT, SOURCE_CONTEXT),
+                context_vars=merge(DEVICE_CONTEXT, CMP_CONTEXT, CMP_CERTREQ_CONTEXT, SOURCE_CONTEXT),
             ),
             EventSpec(
                 key=Triggers.CMP_CERTIFICATION,
@@ -92,7 +94,7 @@ def register_builtin_events() -> None:
                 group_title='CMP',
                 keywords=('cmp', 'certification', 'cr', 'enrollment', 'request'),
                 allowed_step_types=STEPSET_GATED_ENROLLMENT,
-                context_vars=merge(DEVICE_CONTEXT, CMP_CONTEXT, SOURCE_CONTEXT),
+                context_vars=merge(DEVICE_CONTEXT, CMP_CONTEXT, CMP_CERTREQ_CONTEXT, SOURCE_CONTEXT),
             ),
             EventSpec(
                 key=Triggers.CMP_CERTCONF,
@@ -102,7 +104,7 @@ def register_builtin_events() -> None:
                 group_title='CMP',
                 keywords=('cmp', 'certificateconfirmation', 'certconf', 'enrollment', 'request'),
                 allowed_step_types=STEPSET_GATED_ENROLLMENT,
-                context_vars=merge(DEVICE_CONTEXT, CMP_CONTEXT, SOURCE_CONTEXT),
+                context_vars=merge(DEVICE_CONTEXT, CMP_CONTEXT, CMP_CERTCONF_CONTEXT, SOURCE_CONTEXT),
             ),
             EventSpec(
                 key=Triggers.EST_SIMPLEENROLL,

--- a/trustpoint/workflows2/events/builtin.py
+++ b/trustpoint/workflows2/events/builtin.py
@@ -95,6 +95,16 @@ def register_builtin_events() -> None:
                 context_vars=merge(DEVICE_CONTEXT, CMP_CONTEXT, SOURCE_CONTEXT),
             ),
             EventSpec(
+                key=Triggers.CMP_CERTCONF,
+                title=_('CMP certConf'),
+                description=_('CMP certification confirmation received.'),
+                group='cmp_requests',
+                group_title='CMP',
+                keywords=('cmp', 'certificateconfirmation', 'certconf', 'enrollment', 'request'),
+                allowed_step_types=STEPSET_GATED_ENROLLMENT,
+                context_vars=merge(DEVICE_CONTEXT, CMP_CONTEXT, SOURCE_CONTEXT),
+            ),
+            EventSpec(
                 key=Triggers.EST_SIMPLEENROLL,
                 title=_('EST simpleenroll'),
                 description=_('EST simpleenroll request received.'),

--- a/trustpoint/workflows2/events/context_catalog.py
+++ b/trustpoint/workflows2/events/context_catalog.py
@@ -302,13 +302,27 @@ CMP_CONTEXT = ctx(
         group='event.cmp',
         example='0f2d7d8a...',
     ),
-    ContextVar(
+)
+
+CMP_CERTREQ_CONTEXT = ctx(
+        ContextVar(
         'event.cmp.cert_profile',
         'string',
         _('Requested certificate profile.'),
         title=_('Certificate profile'),
         group='event.cmp',
         example='tls-client',
+    ),
+)
+
+CMP_CERTCONF_CONTEXT = ctx(
+        ContextVar(
+        'event.cmp.certconf_status',
+        'string',
+        _('CMP certConf status.'),
+        title=_('certConf status'),
+        group='event.cmp',
+        example='accepted',
     ),
 )
 

--- a/trustpoint/workflows2/events/request_events.py
+++ b/trustpoint/workflows2/events/request_events.py
@@ -60,6 +60,13 @@ class Events:
         handler='certificate_request',
     )
 
+    cmp_certconf = Event(
+        key='cmp_certconf',
+        protocol='cmp',
+        operation='certconf',
+        handler='certificate_request',
+    )
+
     device_created = Event(
         key='device_created',
         protocol='device',

--- a/trustpoint/workflows2/events/triggers.py
+++ b/trustpoint/workflows2/events/triggers.py
@@ -20,6 +20,7 @@ class Triggers:
     CERTIFICATE_REVOKED: ClassVar[str] = 'certificate.revoked'
     CMP_INITIALIZATION: ClassVar[str] = 'cmp.initialization'
     CMP_CERTIFICATION: ClassVar[str] = 'cmp.certification'
+    CMP_CERTCONF: ClassVar[str] = 'cmp.certconf'
     EST_SIMPLEENROLL: ClassVar[str] = 'est.simpleenroll'
     EST_SIMPLEREENROLL: ClassVar[str] = 'est.simplereenroll'
     REST_ENROLL: ClassVar[str] = 'rest.enroll'


### PR DESCRIPTION
**Description of changes**
Adds CMP certConf request trigger to the v2 workflow engine. Passes value to indicate acceptance of cert by client (`${event.cmp.certconf_status}` (accepted/rejected)

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.