### PR TITLE
Workflow v2 definitions REST API

### DIFF
--- a/trustpoint/trustpoint/urls.py
+++ b/trustpoint/trustpoint/urls.py
@@ -91,6 +91,7 @@ urlpatterns += [
     path('api/', include('signer.api_urls')),
     path('api/', include('management.api_urls')),
     path('api/', include('rest_pki.api_urls')),
+    path('api/', include('workflows2.api_urls')),
 
     # JWT endpoints
     path('api/token/', CustomTokenObtainPairView.as_view(), name='token_obtain_pair'),

--- a/trustpoint/workflows2/api_urls.py
+++ b/trustpoint/workflows2/api_urls.py
@@ -1,0 +1,10 @@
+"""API routes for Workflow 2 DRF endpoints."""
+
+from rest_framework.routers import DefaultRouter
+
+from workflows2.api_views import Workflow2DefinitionViewSet
+
+router = DefaultRouter()
+router.register(r'workflow2-definitions', Workflow2DefinitionViewSet, basename='workflow2-definition')
+
+urlpatterns = router.urls

--- a/trustpoint/workflows2/api_views.py
+++ b/trustpoint/workflows2/api_views.py
@@ -1,0 +1,130 @@
+"""DRF API views for Workflow 2 definitions."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiExample, extend_schema
+from rest_framework import status, viewsets
+from rest_framework.response import Response
+
+from workflows2.models import Workflow2Definition
+from workflows2.serializers import Workflow2DefinitionSerializer
+from workflows2.services.definitions import WorkflowDefinitionService
+
+if TYPE_CHECKING:
+    from rest_framework.request import Request
+
+
+MINIMAL_WORKFLOW_YAML_EXAMPLE = """\
+schema: trustpoint.workflow.v2
+name: Minimal workflow
+enabled: true
+
+trigger:
+    on: certificate.issued
+    sources:
+        trustpoint: true
+
+apply: []
+
+workflow:
+    start: done
+    steps:
+        done:
+            type: set
+            vars: {}
+    flow: []
+"""
+
+YAML_REQUEST_EXAMPLE = OpenApiExample(
+        name='Example workflow v2 YAML',
+        value=MINIMAL_WORKFLOW_YAML_EXAMPLE,
+        request_only=True,
+        media_type='application/yaml',
+)
+
+
+@extend_schema(tags=['Workflows2'])
+class Workflow2DefinitionViewSet(viewsets.ModelViewSet[Workflow2Definition]):
+    """CRUD API for Workflow 2 definitions.
+
+    Create and update operations accept the entire request body as YAML text.
+    """
+
+    queryset = Workflow2Definition.objects.order_by('-created_at')
+    serializer_class = Workflow2DefinitionSerializer
+
+    @staticmethod
+    def _request_yaml_text(request: Request) -> str:
+        """Return UTF-8 YAML text from the raw request body."""
+        try:
+            yaml_text = request.body.decode('utf-8')
+        except UnicodeDecodeError as exc:
+            msg = f'Request body must be UTF-8 encoded YAML: {exc!s}'
+            raise ValueError(msg) from exc
+
+        if not yaml_text.strip():
+            msg = 'Request body must contain YAML text.'
+            raise ValueError(msg)
+        return yaml_text
+
+    @extend_schema(
+        request={'application/yaml': OpenApiTypes.STR},
+        examples=[YAML_REQUEST_EXAMPLE],
+    )
+    def create(self, request: Request, *_args: object, **_kwargs: object) -> Response:
+        """Create a definition from YAML text in the request body."""
+        try:
+            yaml_text = self._request_yaml_text(request)
+        except ValueError as exc:
+            return Response({'detail': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+        svc = WorkflowDefinitionService()
+        obj, res = svc.create_definition(name=None, enabled=None, yaml_text=yaml_text)
+
+        if not res.ok:
+            return Response({'detail': res.error or 'Workflow compilation failed.'}, status=status.HTTP_400_BAD_REQUEST)
+        if obj is None:
+            return Response({'detail': 'Workflow save succeeded without returning a definition.'}, status=500)
+
+        serializer = self.get_serializer(obj)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+    @extend_schema(
+        request={'application/yaml': OpenApiTypes.STR},
+        examples=[YAML_REQUEST_EXAMPLE],
+    )
+    def update(self, request: Request, *_args: object, **_kwargs: object) -> Response:
+        """Update a definition from YAML text in the request body."""
+        try:
+            yaml_text = self._request_yaml_text(request)
+        except ValueError as exc:
+            return Response({'detail': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+        definition = self.get_object()
+        svc = WorkflowDefinitionService()
+        updated, res = svc.update_definition(
+            definition=definition,
+            name=None,
+            enabled=None,
+            yaml_text=yaml_text,
+        )
+
+        if not res.ok:
+            return Response({'detail': res.error or 'Workflow compilation failed.'}, status=status.HTTP_400_BAD_REQUEST)
+        if updated is None:
+            return Response({'detail': 'Workflow update succeeded without returning a definition.'}, status=500)
+
+        serializer = self.get_serializer(updated)
+        return Response(serializer.data)
+
+    @extend_schema(
+        request={'application/yaml': OpenApiTypes.STR},
+        examples=[YAML_REQUEST_EXAMPLE],
+    )
+    def partial_update(self, request: Request, *_args: object, **_kwargs: object) -> Response:
+        """Treat PATCH like PUT because updates are YAML document replacements."""
+        return self.update(request, *_args, **_kwargs)

--- a/trustpoint/workflows2/serializers.py
+++ b/trustpoint/workflows2/serializers.py
@@ -1,0 +1,27 @@
+"""Serializers for Workflow 2 API endpoints."""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+from workflows2.models import Workflow2Definition
+
+
+class Workflow2DefinitionSerializer(serializers.ModelSerializer[Workflow2Definition]):
+    """Serialize persisted Workflow 2 definitions."""
+
+    class Meta:
+        """Serializer metadata."""
+
+        model = Workflow2Definition
+        fields = (
+            'id',
+            'name',
+            'enabled',
+            'trigger_on',
+            'yaml_text',
+            'ir_json',
+            'ir_hash',
+            'created_at',
+        )
+        read_only_fields = ('id', 'trigger_on', 'ir_json', 'ir_hash', 'created_at')

--- a/trustpoint/workflows2/services/definitions.py
+++ b/trustpoint/workflows2/services/definitions.py
@@ -111,8 +111,8 @@ class WorkflowDefinitionService:
     def create_definition(
         self,
         *,
-        name: str,
-        enabled: bool,
+        name: str | None,
+        enabled: bool | None,
         yaml_text: str,
     ) -> tuple[Workflow2Definition | None, CompileResult]:
         """Create a new definition from validated YAML text."""
@@ -138,8 +138,8 @@ class WorkflowDefinitionService:
         self,
         *,
         definition: Workflow2Definition,
-        name: str,
-        enabled: bool,
+        name: str | None,
+        enabled: bool | None,
         yaml_text: str,
     ) -> tuple[Workflow2Definition | None, CompileResult]:
         """Update an existing definition from validated YAML text."""

--- a/trustpoint/workflows2/tests/test_api_views.py
+++ b/trustpoint/workflows2/tests/test_api_views.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from workflows2.models import Workflow2Definition
+
+
+VALID_CREATE_YAML = """\
+schema: trustpoint.workflow.v2
+name: API Created Workflow
+enabled: true
+
+trigger:
+  on: device.created
+  sources:
+    trustpoint: true
+
+workflow:
+  start: done
+  steps:
+    done:
+      type: set
+      vars: {}
+  flow: []
+"""
+
+
+VALID_UPDATE_YAML = """\
+schema: trustpoint.workflow.v2
+name: API Updated Workflow
+enabled: false
+
+trigger:
+  on: certificate.issued
+  sources:
+    trustpoint: true
+
+workflow:
+  start: done
+  steps:
+    done:
+      type: set
+      vars:
+        status: updated
+  flow: []
+"""
+
+
+INVALID_YAML = """\
+schema: trustpoint.workflow.v2
+name: Bad
+workflow:
+  start: 
+"""
+
+
+class Workflow2DefinitionApiViewSetTests(TestCase):
+    def setUp(self) -> None:
+        self.user = get_user_model().objects.create_user(
+            username='workflow2-api-tester',
+            password='testpass123',
+        )
+        self.authenticated_client = APIClient()
+        self.authenticated_client.force_authenticate(user=self.user)
+
+    @staticmethod
+    def _create_definition(*, name: str = 'Stored workflow', trigger_on: str = 'device.created') -> Workflow2Definition:
+        return Workflow2Definition.objects.create(
+            name=name,
+            enabled=True,
+            trigger_on=trigger_on,
+            yaml_text=VALID_CREATE_YAML,
+            ir_json={
+                'name': name,
+                'enabled': True,
+                'trigger': {'on': trigger_on},
+                'workflow': {'start': 'done', 'steps': {}, 'flow': []},
+                'meta': {'ir_hash': 'abc123'},
+            },
+            ir_hash='abc123',
+        )
+
+    def test_list_requires_authentication(self) -> None:
+        response = APIClient().get(reverse('workflow2-definition-list'))
+        self.assertEqual(response.status_code, 401)
+
+    def test_list_returns_saved_definitions(self) -> None:
+        definition = self._create_definition(name='List me')
+
+        response = self.authenticated_client.get(reverse('workflow2-definition-list'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertGreaterEqual(len(response.json()), 1)
+        ids = [item['id'] for item in response.json()]
+        self.assertIn(str(definition.id), ids)
+
+    def test_retrieve_returns_definition(self) -> None:
+        definition = self._create_definition(name='Retrieve me')
+
+        response = self.authenticated_client.get(reverse('workflow2-definition-detail', kwargs={'pk': definition.id}))
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload['id'], str(definition.id))
+        self.assertEqual(payload['name'], 'Retrieve me')
+
+    def test_create_uses_yaml_request_body_and_compiles_server_side(self) -> None:
+        response = self.authenticated_client.post(
+            reverse('workflow2-definition-list'),
+            data=VALID_CREATE_YAML,
+            content_type='text/plain',
+        )
+
+        self.assertEqual(response.status_code, 201)
+        payload = response.json()
+        self.assertEqual(payload['name'], 'API Created Workflow')
+        self.assertTrue(payload['enabled'])
+        self.assertEqual(payload['trigger_on'], 'device.created')
+        self.assertIn('ir_json', payload)
+        self.assertTrue(payload['ir_hash'])
+
+        definition = Workflow2Definition.objects.get(id=payload['id'])
+        self.assertEqual(definition.name, 'API Created Workflow')
+        self.assertTrue(definition.enabled)
+        self.assertEqual(definition.trigger_on, 'device.created')
+
+    def test_create_rejects_invalid_yaml(self) -> None:
+        response = self.authenticated_client.post(
+            reverse('workflow2-definition-list'),
+            data=INVALID_YAML,
+            content_type='text/plain',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('detail', response.json())
+
+    def test_update_uses_yaml_request_body_and_recompiles_server_side(self) -> None:
+        definition = self._create_definition(name='Before update', trigger_on='device.created')
+
+        response = self.authenticated_client.put(
+            reverse('workflow2-definition-detail', kwargs={'pk': definition.id}),
+            data=VALID_UPDATE_YAML,
+            content_type='text/plain',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload['name'], 'API Updated Workflow')
+        self.assertFalse(payload['enabled'])
+        self.assertEqual(payload['trigger_on'], 'certificate.issued')
+
+        definition.refresh_from_db()
+        self.assertEqual(definition.name, 'API Updated Workflow')
+        self.assertFalse(definition.enabled)
+        self.assertEqual(definition.trigger_on, 'certificate.issued')
+
+    def test_delete_removes_definition(self) -> None:
+        definition = self._create_definition()
+
+        response = self.authenticated_client.delete(reverse('workflow2-definition-detail', kwargs={'pk': definition.id}))
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Workflow2Definition.objects.filter(id=definition.id).exists())


### PR DESCRIPTION
Adds CRUD DRF API endpoints for managing workflow v2 (YAML) definitions

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.