### PR TITLE
Workflow v2 device UUID support

### DIFF
--- a/trustpoint/aoki/management/commands/aoki_gen_test_certs.py
+++ b/trustpoint/aoki/management/commands/aoki_gen_test_certs.py
@@ -90,7 +90,7 @@ class AokiTestCertGenerator:
                     [
                         x509.DNSName('test_idevid.alt'),
                         # Example manufacturer-defined UUID
-                        x509.UniformResourceIdentifier('urn:uuid:9f568186-7559-44d3-a7b2-e2ea124bf0b3')
+                        x509.UniformResourceIdentifier('urn:uuid:a0a0a0a0-a0a0-40a0-a0a0-a0a0a0a0a0a0')
                     ]), False),
             ],
             validity_days=99999,

--- a/trustpoint/pki/tests/test_idevid_authenticator.py
+++ b/trustpoint/pki/tests/test_idevid_authenticator.py
@@ -1,0 +1,236 @@
+"""Tests for the IDevID authenticator."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+
+from devices.models import DeviceModel
+from onboarding.models import OnboardingConfigModel, OnboardingPkiProtocol, OnboardingProtocol
+from pki.models import DevIdRegistration, DomainModel
+from pki.models.truststore import TruststoreModel
+from pki.util.idevid import IDevIDAuthenticationError, IDevIDAuthenticator, IDevIDVerifier
+from pki.util.x509 import CertificateGenerator
+
+def _create_idevid_cert(
+    *,
+    common_name: str,
+    subject_serial_number: str | None = None,
+    san_uris: list[str] | None = None,
+) -> x509.Certificate:
+    """Create a test IDevID certificate with optional subject serial number and SAN URIs."""
+    root_cert, root_key = CertificateGenerator.create_root_ca('IDevID Auth Test Root')
+
+    subject_attributes: list[x509.NameAttribute] = [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
+    if subject_serial_number is not None:
+        subject_attributes.append(x509.NameAttribute(NameOID.SERIAL_NUMBER, subject_serial_number))
+
+    extensions: list[tuple[x509.ExtensionType, bool]] = []
+    if san_uris:
+        extensions.append(
+            (
+                x509.SubjectAlternativeName([x509.UniformResourceIdentifier(uri) for uri in san_uris]),
+                False,
+            )
+        )
+
+    idevid_cert, _idevid_key = CertificateGenerator.create_ee(
+        issuer_private_key=root_key,
+        issuer_name=root_cert.subject,
+        subject_name=x509.Name(subject_attributes),
+        extensions=extensions,
+    )
+    return idevid_cert
+
+
+def _create_onboarding_config() -> OnboardingConfigModel:
+    """Create and save a minimal onboarding config accepted by DeviceModel validation."""
+    onboarding_config = OnboardingConfigModel(onboarding_protocol=OnboardingProtocol.MANUAL)
+    onboarding_config.set_pki_protocols([OnboardingPkiProtocol.EST])
+    onboarding_config.full_clean()
+    onboarding_config.save()
+    return onboarding_config
+
+
+def _create_devid_registration(domain: DomainModel, serial_number_pattern: str, unique_name: str) -> DevIdRegistration:
+    """Create a DevIdRegistration used by IDevIDAuthenticator lookup."""
+    truststore = TruststoreModel.objects.create(
+        unique_name=f'{unique_name}-ts',
+        intended_usage=TruststoreModel.IntendedUsage.IDEVID,
+    )
+    return DevIdRegistration.objects.create(
+        unique_name=unique_name,
+        domain=domain,
+        truststore=truststore,
+        serial_number_pattern=serial_number_pattern,
+    )
+
+
+def test_authenticate_idevid_from_x509_returns_existing_device_by_uuid(domain_instance: dict[str, object]) -> None:
+    """Returns an existing device when SAN UUID already exists in the target domain."""
+    domain = domain_instance['domain']
+    assert isinstance(domain, DomainModel)
+
+    idevid_uuid = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+    subject_sn = 'SN-UUID-EXISTING'
+    idevid_cert = _create_idevid_cert(
+        common_name='device-uuid-existing',
+        subject_serial_number=subject_sn,
+        san_uris=[f'urn:uuid:{idevid_uuid}'],
+    )
+    _create_devid_registration(domain, rf'^{subject_sn}$', 'reg-uuid-existing')
+
+    existing_device = DeviceModel.objects.create(
+        common_name='existing-device-uuid',
+        serial_number='DIFFERENT-SN',
+        domain=domain,
+        onboarding_config=_create_onboarding_config(),
+        rfc_4122_uuid=uuid.UUID(idevid_uuid),
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(IDevIDVerifier, 'verify_idevid_against_truststore', lambda *args, **kwargs: True)
+        authenticated_device = IDevIDAuthenticator.authenticate_idevid_from_x509(
+            idevid_cert=idevid_cert,
+            intermediate_cas=[],
+            domain=domain,
+        )
+
+    assert authenticated_device.pk == existing_device.pk
+    assert DeviceModel.objects.count() == 1
+
+
+def test_authenticate_idevid_from_x509_returns_existing_device_by_serial(domain_instance: dict[str, object]) -> None:
+    """Returns an existing device when subject serial number exists and no UUID SAN is present."""
+    domain = domain_instance['domain']
+    assert isinstance(domain, DomainModel)
+
+    subject_sn = 'SN-SERIAL-EXISTING'
+    idevid_cert = _create_idevid_cert(
+        common_name='device-sn-existing',
+        subject_serial_number=subject_sn,
+    )
+    _create_devid_registration(domain, rf'^{subject_sn}$', 'reg-serial-existing')
+
+    existing_device = DeviceModel.objects.create(
+        common_name='existing-device-serial',
+        serial_number=subject_sn,
+        domain=domain,
+        onboarding_config=_create_onboarding_config(),
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(IDevIDVerifier, 'verify_idevid_against_truststore', lambda *args, **kwargs: True)
+        authenticated_device = IDevIDAuthenticator.authenticate_idevid_from_x509(
+            idevid_cert=idevid_cert,
+            intermediate_cas=[],
+            domain=domain,
+        )
+
+    assert authenticated_device.pk == existing_device.pk
+    assert DeviceModel.objects.count() == 1
+
+
+def test_authenticate_idevid_from_x509_auto_creates_with_serial_and_uuid(domain_instance: dict[str, object]) -> None:
+    """Creates a new device and adopts UUID from SAN when no existing device matches."""
+    domain = domain_instance['domain']
+    assert isinstance(domain, DomainModel)
+
+    idevid_uuid = '12345678-1234-4234-9234-123456789abc'
+    subject_sn = 'SN-NEW-WITH-UUID'
+    idevid_cert = _create_idevid_cert(
+        common_name='device-autocreate-uuid',
+        subject_serial_number=subject_sn,
+        san_uris=[f'urn:uuid:{idevid_uuid}'],
+    )
+    _create_devid_registration(domain, rf'^{subject_sn}$', 'reg-create-uuid')
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(IDevIDVerifier, 'verify_idevid_against_truststore', lambda *args, **kwargs: True)
+        authenticated_device = IDevIDAuthenticator.authenticate_idevid_from_x509(
+            idevid_cert=idevid_cert,
+            intermediate_cas=[],
+            domain=domain,
+        )
+
+    assert authenticated_device.domain_id == domain.id
+    assert authenticated_device.serial_number == subject_sn
+    assert str(authenticated_device.rfc_4122_uuid) == idevid_uuid
+    assert authenticated_device.onboarding_config is not None
+    assert authenticated_device.onboarding_config.onboarding_protocol == OnboardingProtocol.EST_IDEVID
+
+
+def test_authenticate_idevid_from_x509_auto_creates_with_uuid_only(domain_instance: dict[str, object]) -> None:
+    """Creates a new device when certificate has no subject serial number but has UUID SAN URI."""
+    domain = domain_instance['domain']
+    assert isinstance(domain, DomainModel)
+
+    idevid_uuid = '87654321-4321-4321-8321-cba987654321'
+    uuid_uri = f'urn:uuid:{idevid_uuid}'
+    idevid_cert = _create_idevid_cert(
+        common_name='device-uuid-only',
+        san_uris=[uuid_uri],
+    )
+    _create_devid_registration(domain, rf'^{uuid_uri}$', 'reg-uuid-only')
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(IDevIDVerifier, 'verify_idevid_against_truststore', lambda *args, **kwargs: True)
+        authenticated_device = IDevIDAuthenticator.authenticate_idevid_from_x509(
+            idevid_cert=idevid_cert,
+            intermediate_cas=[],
+            domain=domain,
+        )
+
+    assert authenticated_device.domain_id == domain.id
+    assert authenticated_device.serial_number == ''
+    assert str(authenticated_device.rfc_4122_uuid) == idevid_uuid
+
+
+def test_authenticate_idevid_from_x509_uuid_not_reused_across_domains(issuing_ca_instance: dict[str, object]) -> None:
+    """Does not copy SAN UUID to a new device if the same UUID already exists in a different domain."""
+    issuing_ca = issuing_ca_instance['issuing_ca']
+
+    first_domain = DomainModel.objects.create(unique_name='idevid-domain-a', issuing_ca=issuing_ca, is_active=True)
+    second_domain = DomainModel.objects.create(unique_name='idevid-domain-b', issuing_ca=issuing_ca, is_active=True)
+
+    idevid_uuid = '99999999-1111-4111-8111-222222222222'
+    subject_sn = 'SN-UUID-COLLISION'
+    idevid_cert = _create_idevid_cert(
+        common_name='device-collision',
+        subject_serial_number=subject_sn,
+        san_uris=[f'urn:uuid:{idevid_uuid}'],
+    )
+    _create_devid_registration(first_domain, rf'^{subject_sn}$', 'reg-uuid-collision')
+
+    DeviceModel.objects.create(
+        common_name='existing-other-domain-device',
+        serial_number='OTHER-DOMAIN-SN',
+        domain=second_domain,
+        onboarding_config=_create_onboarding_config(),
+        rfc_4122_uuid=uuid.UUID(idevid_uuid),
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(IDevIDVerifier, 'verify_idevid_against_truststore', lambda *args, **kwargs: True)
+        authenticated_device = IDevIDAuthenticator.authenticate_idevid_from_x509(
+            idevid_cert=idevid_cert,
+            intermediate_cas=[],
+            domain=first_domain,
+        )
+
+    assert authenticated_device.domain_id == first_domain.id
+    assert str(authenticated_device.rfc_4122_uuid) != idevid_uuid
+
+
+def test_authenticate_idevid_from_x509_rejects_without_subject_sn_and_san_uri() -> None:
+    """Rejects certificates that have neither subject serial number nor SAN URI."""
+    idevid_cert = _create_idevid_cert(common_name='device-missing-identifiers')
+
+    with pytest.raises(IDevIDAuthenticationError, match='without a Subject DN Serial Number'):
+        IDevIDAuthenticator.authenticate_idevid_from_x509(
+            idevid_cert=idevid_cert,
+            intermediate_cas=[],
+        )

--- a/trustpoint/pki/util/idevid.py
+++ b/trustpoint/pki/util/idevid.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import re
 import secrets
 from typing import TYPE_CHECKING
@@ -118,8 +119,9 @@ class IDevIDAuthenticator(LoggerMixin):
         return matching_registrations
 
     @staticmethod
-    def _auto_create_device_from_idevid(
-        idevid_cert: x509.Certificate, idevid_subj_sn: str, domain: DomainModel,
+    def _auto_create_device_from_idevid(  # noqa: PLR0913 (multiple args are cleaner here than re-extracting values from idevid again)
+        idevid_cert: x509.Certificate, idevid_subj_sn: str, idevid_uuid: str | None,
+        domain: DomainModel,
         pki_protocol: OnboardingPkiProtocol,
         onboarding_protocol: OnboardingProtocol,
     ) -> DeviceModel:
@@ -142,8 +144,12 @@ class IDevIDAuthenticator(LoggerMixin):
             serial_number=idevid_subj_sn,
             common_name=common_name,
             domain=domain,
-            onboarding_config=onboarding_config_model
+            onboarding_config=onboarding_config_model,
         )
+        # if a device with the same UUID already exists (e.g. in a different domain),
+        # this will violate the unique constraint, so a random UUID is assigned instead
+        if idevid_uuid and not DeviceModel.objects.filter(rfc_4122_uuid=idevid_uuid).exists():
+            device.rfc_4122_uuid = idevid_uuid
         onboarding_config_model.full_clean()
         onboarding_config_model.save()
         device.full_clean()
@@ -169,6 +175,17 @@ class IDevIDAuthenticator(LoggerMixin):
         except x509.ExtensionNotFound:
             return None
         return san_ext.value.get_values_for_type(x509.UniformResourceIdentifier)
+
+    @staticmethod
+    def get_idevid_uuid(idevid_cert: x509.Certificate) -> str | None:
+        """Get the first UUID from the IDevID certificate SAN, or None if there is no UUID in the IDevID SAN."""
+        san_uris = IDevIDAuthenticator.get_idevid_san_uris(idevid_cert)
+        if not san_uris:
+            return None
+        for uri in san_uris:
+            if uri.startswith('urn:uuid:'):
+                return uri.removeprefix('urn:uuid:')
+        return None
 
     @classmethod
     def authenticate_idevid_from_x509_no_device(
@@ -220,7 +237,25 @@ class IDevIDAuthenticator(LoggerMixin):
         domain, idevid_subj_sn = cls.authenticate_idevid_from_x509_no_device(
             idevid_cert=idevid_cert, intermediate_cas=intermediate_cas, domain=domain
         )
-        # Check if we have a device with the same serial number
+        # Check if we have an existing device with the same UUID in the domain already
+        idevid_uuid = cls.get_idevid_uuid(idevid_cert)
+        if idevid_uuid:
+            existing_device = None
+            with contextlib.suppress(DeviceModel.DoesNotExist):
+                existing_device = DeviceModel.objects.get(
+                    domain=domain,
+                    rfc_4122_uuid=idevid_uuid,
+                )
+            # Multiple objects returned can not happen since rfc_4122_uuid is unique,
+            # but if it does, error out (MultipleObjectsReturned)
+            # TODO(Air): This may be an issue onboarding the same physical device to multiple domains,  #noqa: FIX002
+            # since the same IDevID certificate with the same UUID would be used for onboarding in each domain.
+            # Therefore, support for one device onboarding to multiple domains in the future,
+            # rather than creating a new device for each domain in Trustpoint may be desirable.
+
+            if existing_device:
+                return existing_device
+        # Check if we have an existing device with the same serial number in the domain already
         if idevid_subj_sn:
             existing_device = None
             try:
@@ -239,9 +274,11 @@ class IDevIDAuthenticator(LoggerMixin):
 
             if existing_device:
                 return existing_device
+
         return cls._auto_create_device_from_idevid(
             idevid_cert=idevid_cert,
             idevid_subj_sn=idevid_subj_sn or '',
+            idevid_uuid=idevid_uuid,
             domain=domain,
             onboarding_protocol=onboarding_protocol,
             pki_protocol=pki_protocol

--- a/trustpoint/pki/util/idevid.py
+++ b/trustpoint/pki/util/idevid.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import re
 import secrets
+import uuid
 from typing import TYPE_CHECKING
 
 from cryptography import x509
@@ -178,13 +179,17 @@ class IDevIDAuthenticator(LoggerMixin):
 
     @staticmethod
     def get_idevid_uuid(idevid_cert: x509.Certificate) -> str | None:
-        """Get the first UUID from the IDevID certificate SAN, or None if there is no UUID in the IDevID SAN."""
+        """Get the first valid UUID from the IDevID certificate SAN, or None if no valid UUID in the IDevID SAN."""
         san_uris = IDevIDAuthenticator.get_idevid_san_uris(idevid_cert)
         if not san_uris:
             return None
         for uri in san_uris:
             if uri.startswith('urn:uuid:'):
-                return uri.removeprefix('urn:uuid:')
+                uri_candidate = uri.removeprefix('urn:uuid:')
+                try:
+                    return str(uuid.UUID(uri_candidate))
+                except ValueError:
+                    continue
         return None
 
     @classmethod

--- a/trustpoint/request/authentication/base.py
+++ b/trustpoint/request/authentication/base.py
@@ -244,7 +244,11 @@ class IDevIDAuthentication(AuthenticationComponent, LoggerMixin):
 
 
 class CompositeAuthentication(AuthenticationComponent, LoggerMixin):
-    """Composite authenticator for grouping and executing multiple authentication methods."""
+    """Composite authenticator for grouping and executing multiple authentication methods.
+
+    Authentication is deemed successful if any one of the registered components
+    successfully authenticates the request by adding the associated device to the context.
+    """
 
     def __init__(self) -> None:
         """Initialize the composite authenticator with a set of authentication components."""

--- a/trustpoint/request/authentication/cmp.py
+++ b/trustpoint/request/authentication/cmp.py
@@ -337,8 +337,7 @@ class CmpSignatureBasedInitializationAuthentication(CmpAuthenticationBase):
     def authenticate(self, context: BaseRequestContext) -> None:
         """Authenticate using CMP signature-based protection for initialization requests."""
         if not isinstance(context, CmpCertificateRequestContext):
-            exc_msg = 'CmpSignatureBasedInitializationAuthentication requires a CmpCertificateRequestContext.'
-            raise TypeError(exc_msg)
+            return # Skip, auth method only applicable for CmpCertificateRequestContext
 
         if not self._should_authenticate(context):
             return
@@ -435,8 +434,7 @@ class CmpSignatureBasedCertificationAuthentication(CmpAuthenticationBase):
     def authenticate(self, context: BaseRequestContext) -> None:
         """Authenticate using CMP signature-based protection for certification requests."""
         if not isinstance(context, CmpCertificateRequestContext):
-            exc_msg = 'CmpSignatureBasedCertificationAuthentication requires a CmpCertificateRequestContext.'
-            raise TypeError(exc_msg)
+            return # Skip, auth method only applicable for CmpCertificateRequestContext
 
         if not self._should_authenticate(context):
             return
@@ -623,8 +621,7 @@ class CmpSignatureBasedRevocationAuthentication(CmpAuthenticationBase):
     def authenticate(self, context: BaseRequestContext) -> None:
         """Authenticate using CMP signature-based protection for revocation requests."""
         if not isinstance(context, CmpRevocationRequestContext):
-            exc_msg = 'CmpSignatureBasedRevocationAuthentication requires a CmpRevocationRequestContext.'
-            raise TypeError(exc_msg)
+            return # Skip, auth method only applicable for CmpRevocationRequestContext
 
         if not self._should_authenticate(context):
             return
@@ -675,8 +672,7 @@ class CmpSignatureBasedPollAuthentication(CmpAuthenticationBase):
     def authenticate(self, context: BaseRequestContext) -> None:
         """Authenticate one CMP pollReq using either a domain credential or IDevID."""
         if not isinstance(context, CmpPollRequestContext):
-            exc_msg = 'CmpSignatureBasedPollAuthentication requires a CmpPollRequestContext.'
-            raise TypeError(exc_msg)
+            return # Skip, auth method only applicable for CmpPollRequestContext
 
         if not self._should_authenticate(context):
             return
@@ -752,8 +748,7 @@ class CmpCertConfAuthentication(CmpAuthenticationBase):
     def authenticate(self, context: BaseRequestContext) -> None:
         """Resolve domain and device from the cert_hash in the certConf body."""
         if not isinstance(context, CmpCertConfRequestContext):
-            exc_msg = 'CmpCertConfAuthentication requires a CmpCertConfRequestContext.'
-            raise TypeError(exc_msg)
+            return # Skip, auth method only applicable for CmpCertConfRequestContext
 
         if not context.cert_hash:
             self._raise_value_error('certConf message is missing certHash — cannot resolve domain.')

--- a/trustpoint/request/workflows2_handler.py
+++ b/trustpoint/request/workflows2_handler.py
@@ -121,7 +121,7 @@ def _build_certificate_request_dispatch(
         trustpoint=False,
         ca_id=issuing_ca.id,
         domain_id=context.domain.id,
-        device_id=str(context.device.id),
+        device_id=context.device.id,
     )
 
     fingerprint = hashlib.sha256(context.cert_requested.tbs_certrequest_bytes).hexdigest()
@@ -210,7 +210,7 @@ def _build_cmp_request_dispatch(
         trustpoint=False,
         ca_id=issuing_ca.id,
         domain_id=context.domain.id,
-        device_id=str(context.device.id),
+        device_id=context.device.id,
     )
     certconf_status = getattr(context, 'cert_conf_status', None)
     certconf_status_str = ''
@@ -301,7 +301,7 @@ def _build_device_source(context: BaseRequestContext) -> EventSource:
         trustpoint=True,
         ca_id=_resolve_device_ca_id(domain),
         domain_id=domain_id,
-        device_id=str(context.device.id) if context.device is not None else None,
+        device_id=context.device.id if context.device is not None else None,
     )
 
 

--- a/trustpoint/workflows2/events/context_catalog.py
+++ b/trustpoint/workflows2/events/context_catalog.py
@@ -43,9 +43,17 @@ def merge(*groups: Iterable[ContextVar]) -> tuple[ContextVar, ...]:
 DEVICE_CONTEXT = ctx(
     ContextVar(
         'event.device.id',
+        'int',
+        _('Device database ID.'),
+        title=_('Device ID'),
+        group='event.device',
+        example=38,
+    ),
+    ContextVar(
+        'event.device.uuid',
         'uuid',
         _('Device UUID.'),
-        title=_('Device ID'),
+        title=_('Device UUID'),
         group='event.device',
         example='550e8400-e29b-41d4-a716-446655440000',
     ),

--- a/trustpoint/workflows2/events/payloads.py
+++ b/trustpoint/workflows2/events/payloads.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 DEVICE_TRACKED_FIELDS: tuple[str, ...] = (
     'common_name',
     'serial_number',
+
     'domain_id',
     'ip_address',
     'opc_server_port',
@@ -43,14 +44,15 @@ def serialize_source(source: Any) -> dict[str, Any]:
         'trustpoint': bool(getattr(source, 'trustpoint', False)),
         'ca_id': _json_scalar(getattr(source, 'ca_id', None)),
         'domain_id': _json_scalar(getattr(source, 'domain_id', None)),
-        'device_id': str(device_id) if (device_id := getattr(source, 'device_id', None)) is not None else None,
+        'device_id': _json_scalar(getattr(source, 'device_id', None)),
     }
 
 
 def build_device_snapshot(device: Any) -> dict[str, Any]:
     """Return a stable JSON-safe snapshot of tracked device fields."""
     snapshot: dict[str, Any] = {
-        'id': str(device_id) if (device_id := getattr(device, 'id', None)) is not None else None,
+        'id': _json_scalar(getattr(device, 'id', None)),
+        'uuid': device.rfc_4122_uuid_str if hasattr(device, 'rfc_4122_uuid_str') else None,
     }
     for field_name in DEVICE_TRACKED_FIELDS:
         snapshot[field_name] = _json_scalar(getattr(device, field_name, None))

--- a/trustpoint/workflows2/integrations/certificates.py
+++ b/trustpoint/workflows2/integrations/certificates.py
@@ -53,7 +53,7 @@ def _build_event_source_for_record(
         trustpoint=True,
         ca_id=_resolve_ca_id(domain=domain, ca_id=ca_id if ca_id is not None else explicit_ca_id),
         domain_id=domain.id if domain is not None else None,
-        device_id=str(device.id) if device is not None else None,
+        device_id=device.id if device is not None else None,
     )
 
 

--- a/trustpoint/workflows2/services/dispatch.py
+++ b/trustpoint/workflows2/services/dispatch.py
@@ -44,7 +44,7 @@ class EventSource:
     trustpoint: bool = True
     ca_id: int | None = None
     domain_id: int | None = None
-    device_id: str | None = None
+    device_id: int | None = None
 
 
 class WorkflowDispatchService:


### PR DESCRIPTION
**Description of changes**
Add `event.device.uuid` var to workflow context. `event.device.id` refers to the DB ID (pk) of the DeviceModel.
Use UUID from IDevID cert SAN URI for auto-generated device (from IDevID for zero-touch onboarding) if applicable

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.