### PR TITLE
Certificate Profiles: CA certificates only allowed if explicitly stated in profile

### DIFF
--- a/trustpoint/pki/tests/test_cert_profiles.py
+++ b/trustpoint/pki/tests/test_cert_profiles.py
@@ -139,6 +139,37 @@ def test_unspecified_cn_present_reject() -> None:
     with pytest.raises(ProfileValidationError, match="Field 'common_name' is not explicitly allowed in the profile."):
         verifier.apply_profile_to_request(request)
 
+def test_reject_mods_rejects_falsy_disallowed_field() -> None:
+    """Test that reject_mods=True rejects disallowed fields even if their value is falsy."""
+    profile = {
+        'type': 'cert_profile',
+        'subj': {'allow': ['cn']},
+        'reject_mods': True
+    }
+    verifier = JSONProfileVerifier(profile)
+    request = {
+        'subj': {
+            'cn': 'example.com',
+            'serial_number': ''
+        }
+    }
+    with pytest.raises(ProfileValidationError, match="Field 'serial_number' is not explicitly allowed in the profile."):
+        verifier.apply_profile_to_request(request)
+
+def test_required_false_does_not_require_field() -> None:
+    """Test that required=False does not trigger a missing-field validation error or insert empty objects."""
+    profile = {
+        'type': 'cert_profile',
+        'subj': {'cn': {'required': False}},
+        'reject_mods': True,
+    }
+    verifier = JSONProfileVerifier(profile)
+    request = {
+        'subj': {}
+    }
+    validated_request = verifier.apply_profile_to_request(request)
+    assert 'common_name' not in validated_request['subject']
+
 def test_default_cn_present_in_request() -> None:
     """Test that the request CN takes precedence over the profile's default CN."""
     profile = {

--- a/trustpoint/pki/tests/test_cert_profiles.py
+++ b/trustpoint/pki/tests/test_cert_profiles.py
@@ -438,6 +438,88 @@ def test_allowed_ext_allow_any_explicit_profile() -> None:
     print('Validated Request: ', validated_request)
     assert validated_request['extensions']['subject_alternative_name']['dns_names'] == ['any.allowed.example.com']
 
+def test_implicit_ca_disallowed() -> None:
+    """Test that a request for a CA certificate fails if Basic Constraints is not explicitly specified in the profile, even if allow='*'."""
+    profile = {
+        'type': 'cert_profile',
+        'subj': {'cn': 'example.com'},
+        'ext': {
+            'allow': '*',
+        },
+        'reject_mods': False,
+        'mutable': True
+    }
+    verifier = JSONProfileVerifier(profile)
+    request = {
+        'subj': {'cn': 'example.com'},
+        'ext': {'basic_constraints': {'ca': True, 'path_length': None}}
+    }
+    with pytest.raises(ProfileValidationError, match="Field 'basic_constraints' is not explicitly allowed in the profile."):
+        validated_request = verifier.apply_profile_to_request(request)
+        print('Validated Request: ', validated_request)
+
+def test_explicit_ca_disallowed() -> None:
+    """Test that a request for a CA certificate fails if Basic Constraints is ca=False, even if allow='*'."""
+    profile = {
+        'type': 'cert_profile',
+        'subj': {'cn': 'example.com'},
+        'ext': {
+            'allow': '*',
+            'basic_constraints': {'ca': False}
+        },
+        'reject_mods': False,
+        'mutable': True
+    }
+    verifier = JSONProfileVerifier(profile)
+    request = {
+        'subj': {'cn': 'example.com'},
+        'ext': {'basic_constraints': {'ca': True, 'path_length': None}}
+    }
+    validated_request = verifier.apply_profile_to_request(request)
+    assert validated_request['extensions']['basic_constraints']['ca'] is False
+
+def test_explicit_ca_disallowed_reject_mods() -> None:
+    """Test that a request for a CA certificate fails if Basic Constraints is ca=False, even if allow='*'."""
+    profile = {
+        'type': 'cert_profile',
+        'subj': {'cn': 'example.com'},
+        'ext': {
+            'allow': '*',
+            'basic_constraints': {'ca': False}
+        },
+        'reject_mods': True,
+        'mutable': True
+    }
+    verifier = JSONProfileVerifier(profile)
+    request = {
+        'subj': {'cn': 'example.com'},
+        'ext': {'basic_constraints': {'ca': True, 'path_length': None}}
+    }
+    with pytest.raises(ProfileValidationError, match="Field 'ca' is not mutable in the profile."):
+        validated_request = verifier.apply_profile_to_request(request)
+        print('Validated Request: ', validated_request)
+
+def test_explicit_ca_allowed() -> None:
+    """Test that a request for a CA certificate passes if Basic Constraints is explicitly set as mutable."""
+    profile = {
+        'type': 'cert_profile',
+        'subj': {'cn': 'example.com'},
+        'ext': {
+            'allow': '*',
+            'basic_constraints': {'ca': False, 'mutable': True}
+        },
+        'reject_mods': False,
+    }
+    verifier = JSONProfileVerifier(profile)
+    request = {
+        'subj': {'cn': 'example.com'},
+        'ext': {'basic_constraints': {'ca': True, 'path_length': None}}
+    }
+    validated_request = verifier.apply_profile_to_request(request)
+    print('Validated Request: ', validated_request)
+    assert validated_request['extensions']['basic_constraints']['ca'] is True
+
+
 def test_sample_request_contains_ext_defaults() -> None:
     """Test that a sample request generated from a profile includes default extension values."""
     profile = {

--- a/trustpoint/pki/util/cert_profile.py
+++ b/trustpoint/pki/util/cert_profile.py
@@ -269,6 +269,7 @@ class CertProfileBaseModel(BaseModel):
     """
     allow: list[str] | Literal['*'] | None = None
     reject_mods: bool = Field(default=False)
+    mutable: bool = Field(default=False)
 
     @field_validator('allow', mode='before')
     @classmethod
@@ -299,7 +300,7 @@ class ProfileCrlDistributionPointsExtensionModel(CRLDistributionPointsExtensionM
 
 class ProfileExtensionsModel(CertProfileBaseModel):
     """Model for the extensions of a certificate profile, with profile constraints."""
-    basic_constraints: ProfileBasicConstraintsExtensionModel | ProfileValuePropertyModel | None = Field(
+    basic_constraints: ProfileBasicConstraintsExtensionModel | None = Field(
         default=None,
         validation_alias=ALIASES.get('basic_constraints'),
     )
@@ -513,9 +514,64 @@ class JSONProfileVerifier:
 
         return request
 
+    def _ensure_ca_true_explicit_profile(self, request: dict[str, Any]) -> None:
+        """Reject CA=true requests unless Basic Constraints is explicitly present in the profile.
+
+        This prevents implicit allow='*' from introducing CA issuance capability.
+        """
+        request_extensions = request.get('extensions')
+        if not isinstance(request_extensions, dict):
+            return
+
+        request_basic_constraints = request_extensions.get('basic_constraints')
+        if not isinstance(request_basic_constraints, dict):
+            return
+
+        if request_basic_constraints.get('ca') is not True:
+            return
+
+        profile_extensions = self.profile_dict.get('extensions')
+        if not isinstance(profile_extensions, dict):
+            msg = "Field 'basic_constraints' is not explicitly allowed in the profile."
+            raise ProfileValidationError(msg)
+
+        profile_basic_constraints = profile_extensions.get('basic_constraints')
+        if not isinstance(profile_basic_constraints, dict):
+            msg = "Field 'basic_constraints' is not explicitly allowed in the profile."
+            raise ProfileValidationError(msg)
+
+        # Explicitly allow CA issuance only if either:
+        # 1) profile basic_constraints.ca is True, or
+        # 2) profile basic_constraints.mutable is True, or
+        # 3) profile basic_constraints.ca is a value-property dict with mutable=True.
+        profile_ca = profile_basic_constraints.get('ca')
+        basic_constraints_mutable = bool(profile_basic_constraints.get('mutable', False))
+
+        ca_is_explicitly_true = profile_ca is True
+        ca_is_explicitly_mutable = (
+            isinstance(profile_ca, dict) and bool(profile_ca.get('mutable', False))
+        )
+        if ca_is_explicitly_true or basic_constraints_mutable or ca_is_explicitly_mutable:
+            return
+
+        # CA=true requested but not permitted by profile.
+        effective_reject_mods = bool(
+            profile_basic_constraints.get(
+                'reject_mods',
+                profile_extensions.get('reject_mods', self.profile_dict.get('reject_mods', False)),
+            )
+        )
+        if effective_reject_mods:
+            msg = "Field 'ca' is not mutable in the profile."
+            raise ProfileValidationError(msg)
+
+        # In non-reject mode, force the profile value (default deny) for CA.
+        request_basic_constraints['ca'] = bool(profile_ca) if profile_ca is not None else False
+
     def apply_profile_to_request(self, request: dict[str, Any]) -> dict[str, Any]:
         """Apply the profile to a certificate request and return the modified request."""
         validated_request = self.validate_request(request=request)
+        self._ensure_ca_true_explicit_profile(validated_request)
         logger.debug('Validated Request before profile rules: %s', validated_request)
         return self._apply_profile_rules(validated_request, self.profile_dict)
 

--- a/trustpoint/pki/util/cert_profile.py
+++ b/trustpoint/pki/util/cert_profile.py
@@ -409,12 +409,12 @@ class JSONProfileVerifier:
         """
         if not isinstance(request, dict):
             return
-        for field, value in list(request.items()):
+        for field, _value in list(request.items()):
             if field in profile or profile_config.allow_implicit or (allow_list and field in allow_list):
                 # Field is explicitly or implicitly allowed, keep it
                 continue
             # Field is not allowed, remove it
-            if profile_config.reject_mods and value:
+            if profile_config.reject_mods:
                 msg = f"Field '{field}' is not explicitly allowed in the profile."
                 raise ProfileValidationError(msg)
             del request[field]
@@ -432,14 +432,18 @@ class JSONProfileVerifier:
                 logger.debug("Setting default for field '%s' to %s", field, profile_value['default'])
                 request[field] = profile_value['default']
                 return
-            if 'required' in profile_value:
+            if profile_value.get('required'):
                 # Required field is missing in the request
                 msg = f"Field '{field}' is required but not present in the request."
                 raise ProfileValidationError(msg)
+            non_keyword_children = {k: v for k, v in profile_value.items() if k not in CERT_PROFILE_KEYWORDS}
+            if not non_keyword_children:
+                # Metadata-only policy object (e.g. {'required': False}) does not materialize output fields.
+                return
             # TODO(Air): 're' case  # noqa: FIX002
             # should be fine to always call as "value" and stuff will get filtered and we end up with a no-op
             request[field] = self._apply_profile_rules(
-                request.setdefault(field, {}), profile_value, profile_config)
+                request.get(field, {}), profile_value, profile_config)
         elif JSONProfileVerifier._is_simple_type(profile_value):
             request[field] = profile_value
         else:
@@ -618,14 +622,18 @@ class JSONProfileVerifier:
                     logger.debug("Setting default for field '%s' to %s", field, profile_value['default'])
                     request[field] = profile_value['default']
                     continue
-                if 'required' in profile_value:
+                if profile_value.get('required'):
                     # Required field is missing in the request
                     request[field] = f'CHANGEME_{field}_required'
+                    continue
+                non_keyword_children = {k: v for k, v in profile_value.items() if k not in CERT_PROFILE_KEYWORDS}
+                if not non_keyword_children:
+                    # Metadata-only policy object should not generate a sample payload field.
                     continue
                 # TODO(Air): 're' case  # noqa: FIX002
                 # should be fine to always call as "value" and stuff will get filtered and we end up with a no-op
                 request[field] = self._apply_profile_rules_sample(
-                    request.setdefault(field, {}), profile_value, profile_config)
+                    request.get(field, {}), profile_value, profile_config)
             elif JSONProfileVerifier._is_simple_type(profile_value):
                 request[field] = profile_value
             else:

--- a/trustpoint/pki/util/cert_profile.py
+++ b/trustpoint/pki/util/cert_profile.py
@@ -288,6 +288,9 @@ class ProfileSubjectModel(SubjectModel, CertProfileBaseModel):
     """Model for the subject DN of a certificate profile, with profile constraints."""
 
 # Profile-specific extension models are required for extensions that allow lists of strings/nested structures
+class ProfileBasicConstraintsExtensionModel(BasicConstraintsExtensionModel, CertProfileBaseModel):
+    """Model for the Basic Constraints extension of a certificate profile, with profile constraints."""
+
 class ProfileSanExtensionModel(SanExtensionModel, CertProfileBaseModel):
     """Model for the SAN extension of a certificate profile, with profile constraints."""
 
@@ -296,7 +299,7 @@ class ProfileCrlDistributionPointsExtensionModel(CRLDistributionPointsExtensionM
 
 class ProfileExtensionsModel(CertProfileBaseModel):
     """Model for the extensions of a certificate profile, with profile constraints."""
-    basic_constraints: BasicConstraintsExtensionModel | ProfileValuePropertyModel | None = Field(
+    basic_constraints: ProfileBasicConstraintsExtensionModel | ProfileValuePropertyModel | None = Field(
         default=None,
         validation_alias=ALIASES.get('basic_constraints'),
     )

--- a/trustpoint/pki/util/cert_profile.py
+++ b/trustpoint/pki/util/cert_profile.py
@@ -69,7 +69,7 @@ class ProfileValuePropertyModel(BaseModel):
     value: Any | None = None
     default: Any | None = None
     required: bool = False
-    mutable: bool = True
+    mutable: bool = False
 
 class SubjectModel(BaseModel):
     """Model for the subject DN of a certificate profile."""
@@ -148,7 +148,7 @@ class BasicConstraintsExtensionModel(BaseExtensionModel):
 
     model_config = ConfigDict(extra='forbid')
 
-class SanExtensionModel(BaseExtensionModel, ProfileValuePropertyModel):
+class SanExtensionModel(BaseExtensionModel):
     """Model for the SAN extension of a certificate profile."""
     dns_names: list[str] | ProfileValuePropertyModel | None = Field(default=None, validation_alias='dns')
     ip_addresses: list[str] | ProfileValuePropertyModel | None = Field(default=None, validation_alias='ip')
@@ -262,14 +262,13 @@ class ProfileValidityModel(BaseModel):
 
     model_config = ConfigDict(extra='ignore', populate_by_name=True)
 
-class CertProfileBaseModel(BaseModel):
+class CertProfileBaseModel(ProfileValuePropertyModel):
     """Base model for each nesting level of certificate profiles.
 
     This allows for granular control over allowed fields and constraints at each level.
     """
     allow: list[str] | Literal['*'] | None = None
     reject_mods: bool = Field(default=False)
-    mutable: bool = Field(default=False)
 
     @field_validator('allow', mode='before')
     @classmethod
@@ -292,6 +291,12 @@ class ProfileSubjectModel(SubjectModel, CertProfileBaseModel):
 class ProfileBasicConstraintsExtensionModel(BasicConstraintsExtensionModel, CertProfileBaseModel):
     """Model for the Basic Constraints extension of a certificate profile, with profile constraints."""
 
+class ProfileKeyUsageExtensionModel(KeyUsageExtensionModel, CertProfileBaseModel):
+    """Model for the Key Usage extension of a certificate profile, with profile constraints."""
+
+class ProfileExtendedKeyUsageExtensionModel(ExtendedKeyUsageExtensionModel, CertProfileBaseModel):
+    """Model for the Extended Key Usage extension of a certificate profile, with profile constraints."""
+
 class ProfileSanExtensionModel(SanExtensionModel, CertProfileBaseModel):
     """Model for the SAN extension of a certificate profile, with profile constraints."""
 
@@ -304,19 +309,19 @@ class ProfileExtensionsModel(CertProfileBaseModel):
         default=None,
         validation_alias=ALIASES.get('basic_constraints'),
     )
-    key_usage: KeyUsageExtensionModel | ProfileValuePropertyModel | None = Field(
+    key_usage: ProfileKeyUsageExtensionModel | None = Field(
         default=None,
         validation_alias=ALIASES.get('key_usage'),
     )
-    extended_key_usage: ExtendedKeyUsageExtensionModel | ProfileValuePropertyModel | None = Field(
+    extended_key_usage: ProfileExtendedKeyUsageExtensionModel | None = Field(
         default=None,
         validation_alias=ALIASES.get('extended_key_usage'),
     )
-    subject_alternative_name: ProfileSanExtensionModel | ProfileValuePropertyModel | None = Field(
+    subject_alternative_name: ProfileSanExtensionModel | None = Field(
         default=None,
         validation_alias=ALIASES.get('subject_alternative_name'),
     )
-    crl_distribution_points: ProfileCrlDistributionPointsExtensionModel | ProfileValuePropertyModel | None = Field(
+    crl_distribution_points: ProfileCrlDistributionPointsExtensionModel | None = Field(
         default=None,
         validation_alias=ALIASES.get('crl_distribution_points'),
     )


### PR DESCRIPTION
**Description of changes**
- Requesting a CA certificate requires either an explicit `{'ca':true}` or `{'mutable':true}` in the associated profile
- required=False in profile no longer inserts an empty object in the verified request
- reject_mods now also disallows fields added by the request with a false(y) value
- Simplified the way `CertProfileBaseModel` inherits from `ProfileValuePropertyModel`, reducing risk of mis-typing by pydantic specifically with extensions

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.