### PR TITLE
Fix CSRF failure on custom port

### DIFF
--- a/docker/trustpoint/nginx/trustpoint-nginx-https.conf
+++ b/docker/trustpoint/nginx/trustpoint-nginx-https.conf
@@ -31,11 +31,13 @@ server {
 
     location / {
         proxy_pass http://127.0.0.1:8000;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header SSL-Client-Cert $ssl_client_escaped_cert;
         proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
         proxy_set_header X-SSL-Client-S-DN $ssl_client_s_dn;
+        proxy_set_header X-Forwarded-Host $http_host;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port $server_port;
         client_max_body_size 10M;
     }
 }

--- a/trustpoint/trustpoint/settings.py
+++ b/trustpoint/trustpoint/settings.py
@@ -145,10 +145,6 @@ ALLOWED_HOSTS = ['*']
 WSGI_APPLICATION = 'trustpoint.wsgi.application'
 
 
-# mDNS service discovery advertisement
-ADVERTISED_HOST = '127.0.0.1'
-ADVERTISED_PORT = 443
-
 
 DOCKER_CONTAINER = False
 
@@ -161,6 +157,8 @@ DEBUG = not DOCKER_CONTAINER
 ADMIN_ENABLED = bool(DEBUG)
 DEVELOPMENT_ENV = DEBUG
 
+# Reverse proxy SSL header settings
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 
 # Basic SMTP backend


### PR DESCRIPTION
**Description of changes**
Fixes CSRF failure when assigning any external port but standard `443` to Docker.

**Notes** <!-- optional -->
This does not yet solve all CSRF problems, a follow-up PR will introduce an env variable to set trusted origins.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.