### PR TITLE
CSRF TP_URLS environment variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+# .env
+# Enter all origins allowed to access the Trustpoint server (IPs, mDNS, or DNS domains)
+# Example: TP_URLS=10.10.0.2, mytrustpoint.local:8443, trustpoint.example.com
+# Note: Do not include the protocol (http:// or https://) in the URLs, and separate multiple URLs with commas.
+# You only need to include the port if it is not the default (80 for HTTP, 443 for HTTPS).
+# No need to include localhost, unless you are using a custom port.
+TP_URLS=trustpoint.local,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: trustpoint
     ports:
       - "80:80"
-      - "443:443"
+      - "8443:443"
     depends_on:
       - postgres
     environment:
@@ -16,6 +16,7 @@ services:
       DATABASE_PASSWORD: "testing321"
       DATABASE_HOST: "postgres"
       DATABASE_PORT: "5432"
+      TP_URLS: ${TP_URLS}
     
   trustpoint-worker:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: trustpoint
     ports:
       - "80:80"
-      - "8443:443"
+      - "443:443"
     depends_on:
       - postgres
     environment:

--- a/docker/trustpoint/nginx/trustpoint-nginx-https.conf
+++ b/docker/trustpoint/nginx/trustpoint-nginx-https.conf
@@ -31,11 +31,13 @@ server {
 
     location / {
         proxy_pass http://127.0.0.1:8000;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header SSL-Client-Cert $ssl_client_escaped_cert;
         proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
         proxy_set_header X-SSL-Client-S-DN $ssl_client_s_dn;
+        proxy_set_header X-Forwarded-Host $http_host;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port $server_port;
         client_max_body_size 10M;
     }
 }

--- a/docs/source/getting_started/quickstart_setup.rst
+++ b/docs/source/getting_started/quickstart_setup.rst
@@ -79,7 +79,15 @@ Step-by-Step Setup (Build container)
       The database connection between the containers uses default credentials for testing. THIS IS INSECURE.
       It is highly encouraged to change the default credentials in the `docker-compose.yml` file before building the containers.
 
-2. **Build the Trustpoint and Postgres Docker Images**
+2. **Edit the .env file to specify allowed URLs**
+
+   Open the `.env` file in the project root and set the `TP_URLS` variable to include the URLs you will use to access Trustpoint. For example:
+
+   .. code-block:: bash
+
+       TP_URLS=trustpoint.myfactory.local,localhost:8443
+
+3. **Build the Trustpoint and Postgres Docker Images**
 
    Use docker compose to build the Trustpoint and Postgres images from the source:
 
@@ -87,7 +95,7 @@ Step-by-Step Setup (Build container)
 
        docker compose build
 
-3. **Run the Trustpoint and Postgres Containers** 
+4. **Run the Trustpoint and Postgres Containers** 
 
    Start the Trustpoint and Postgres containers using the images you just built:
 

--- a/trustpoint/trustpoint/settings.py
+++ b/trustpoint/trustpoint/settings.py
@@ -145,10 +145,6 @@ ALLOWED_HOSTS = ['*']
 WSGI_APPLICATION = 'trustpoint.wsgi.application'
 
 
-# mDNS service discovery advertisement
-ADVERTISED_HOST = '127.0.0.1'
-ADVERTISED_PORT = 443
-
 
 DOCKER_CONTAINER = False
 
@@ -161,6 +157,8 @@ DEBUG = not DOCKER_CONTAINER
 ADMIN_ENABLED = bool(DEBUG)
 DEVELOPMENT_ENV = DEBUG
 
+# Reverse proxy SSL header settings
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 
 # Basic SMTP backend

--- a/trustpoint/trustpoint/settings.py
+++ b/trustpoint/trustpoint/settings.py
@@ -18,6 +18,7 @@ import time
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any, ClassVar
+from urllib.parse import urlparse
 
 import django_stubs_ext
 import psycopg
@@ -141,7 +142,6 @@ def is_postgre_available() -> bool:
 
 # ------------- Variables --------------
 
-ALLOWED_HOSTS = ['*']
 WSGI_APPLICATION = 'trustpoint.wsgi.application'
 
 
@@ -159,6 +159,36 @@ DEVELOPMENT_ENV = DEBUG
 
 # Reverse proxy SSL header settings
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+ALLOWED_HOSTS = ['localhost', '127.0.0.1', '[::1]']
+CSRF_TRUSTED_ORIGINS = ['http://localhost:8000', 'http://127.0.0.1:8000']
+
+raw_urls = os.getenv('TP_URLS', '')
+
+if raw_urls:
+    # Split by comma and clean up whitespace
+    url_list = [url.strip() for url in raw_urls.split(',') if url.strip()]
+
+    for url in url_list:
+        # Ensure scheme is present (fallback to https)
+        parsed = urlparse(url) if url.startswith(('http://', 'https://')) else urlparse(f'https://{url}')
+
+        host_with_port = parsed.netloc
+
+        # 1. Extract just host/IP for ALLOWED_HOSTS (strip port)
+        host_only = host_with_port.split(':')[0]
+        if host_only not in ALLOWED_HOSTS:
+            ALLOWED_HOSTS.append(host_only)
+
+            # If mDNS domain, trust subdomains too
+            if host_only.endswith('.local') and f'.{host_only}' not in ALLOWED_HOSTS:
+                ALLOWED_HOSTS.append(f'.{host_only}')
+
+        # 2. Extract the exact origin (scheme + host + port) for CSRF
+        # e.g., "https://trustpoint.local:8443" or "http://10.10.0.2"
+        exact_origin = f'{parsed.scheme}://{host_with_port}'
+        if exact_origin not in CSRF_TRUSTED_ORIGINS:
+            CSRF_TRUSTED_ORIGINS.append(exact_origin)
 
 
 # Basic SMTP backend

--- a/trustpoint/trustpoint/tests/test_settings.py
+++ b/trustpoint/trustpoint/tests/test_settings.py
@@ -27,6 +27,49 @@ def test_debug_setting():
     assert settings.DEBUG is (not settings.DOCKER_CONTAINER), 'DEBUG should be the inverse of DOCKER_CONTAINER.'
 
 
+def test_tp_urls_not_set_keeps_default_hosts_and_origins(monkeypatch):
+    """Ensure defaults remain unchanged when TP_URLS is not set."""
+    monkeypatch.delenv('TP_URLS', raising=False)
+
+    importlib.reload(settings)
+
+    assert 'localhost' in settings.ALLOWED_HOSTS
+    assert '127.0.0.1' in settings.ALLOWED_HOSTS
+    assert '[::1]' in settings.ALLOWED_HOSTS
+    assert 'http://localhost:8000' in settings.CSRF_TRUSTED_ORIGINS
+    assert 'http://127.0.0.1:8000' in settings.CSRF_TRUSTED_ORIGINS
+
+
+def test_tp_urls_derives_allowed_hosts_and_csrf_origins(monkeypatch):
+    """Ensure TP_URLS entries are parsed into ALLOWED_HOSTS and CSRF_TRUSTED_ORIGINS."""
+    monkeypatch.setenv('TP_URLS', 'trustpoint.local:8443, http://10.10.0.2, https://example.org')
+
+    importlib.reload(settings)
+
+    assert 'trustpoint.local' in settings.ALLOWED_HOSTS
+    assert '.trustpoint.local' in settings.ALLOWED_HOSTS
+    assert '10.10.0.2' in settings.ALLOWED_HOSTS
+    assert 'example.org' in settings.ALLOWED_HOSTS
+
+    assert 'https://trustpoint.local:8443' in settings.CSRF_TRUSTED_ORIGINS
+    assert 'http://10.10.0.2' in settings.CSRF_TRUSTED_ORIGINS
+    assert 'https://example.org' in settings.CSRF_TRUSTED_ORIGINS
+
+
+def test_tp_urls_deduplicates_hosts_and_origins(monkeypatch):
+    """Ensure repeated TP_URLS values do not create duplicate entries."""
+    monkeypatch.setenv(
+        'TP_URLS',
+        ' https://dup.local:9443,https://dup.local:9443 , dup.local:9443 ',
+    )
+
+    importlib.reload(settings)
+
+    assert settings.ALLOWED_HOSTS.count('dup.local') == 1
+    assert settings.ALLOWED_HOSTS.count('.dup.local') == 1
+    assert settings.CSRF_TRUSTED_ORIGINS.count('https://dup.local:9443') == 1
+
+
 def test_database_settings(monkeypatch):
     """Ensure database settings are set correctly."""
     with mock.patch('socket.create_connection') as mock_socket_conn:


### PR DESCRIPTION
<!-- related issue number, remove if n/a -->
Related to #746 (builds upon it)

**Description of changes**
Add `TP_URLS` environment variable to set ALLOWED_HOSTS and CSRF_TRUSTED_ORIGINS

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.