### PR TITLE
Add Prometheus metrics configuration and endpoint support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "django-dbbackup>=5.0.0",
     "django-filter~=25.1",
     "django-filter-stubs>=0.1.3",
+    "django-prometheus>=2.4.0",
     "django-stubs[compatible-mypy]>=5.2.2",
     "django-taggit>=6.1.0,<7",
     "djangorestframework>=3.16.1",

--- a/trustpoint/management/forms.py
+++ b/trustpoint/management/forms.py
@@ -29,6 +29,7 @@ from management.models import (
     LoggingConfig,
     NotificationConfig,
     PKCS11Token,
+    PrometheusConfig,
     SecurityConfig,
 )
 from management.models.workflows2 import WorkflowExecutionConfig
@@ -357,6 +358,33 @@ class NotificationConfigForm(forms.ModelForm[NotificationConfig]):
                 }
             )
         return crl_expiry
+
+
+class PrometheusConfigForm(forms.ModelForm['PrometheusConfig']):
+    """Form for managing the Prometheus metrics endpoint configuration."""
+
+    class Meta:
+        """ModelForm Meta configuration for PrometheusConfigForm."""
+
+        model = PrometheusConfig
+        fields: ClassVar[list[str]] = ['enabled']
+        widgets: ClassVar[dict[str, Any]] = {
+            'enabled': forms.CheckboxInput(attrs={'class': 'form-check-input', 'role': 'switch'}),
+        }
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the PrometheusConfigForm."""
+        super().__init__(*args, **kwargs)
+
+        self.helper = FormHelper()
+        self.helper.form_tag = False
+        self.helper.layout = Layout(
+            Fieldset(
+                _('Prometheus Metrics Export'),
+                Field('enabled'),
+            ),
+        )
+
 
 class BackupOptionsForm(forms.ModelForm[BackupOptions]):
     """Form for editing BackupOptions settings."""

--- a/trustpoint/management/migrations/0003_tp_v0_6_0_dev1.py
+++ b/trustpoint/management/migrations/0003_tp_v0_6_0_dev1.py
@@ -23,6 +23,16 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
+            name='PrometheusConfig',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('enabled', models.BooleanField(default=False, help_text='When enabled, the /prometheus/metrics endpoint is available for scraping.', verbose_name='Enable Prometheus metrics endpoint')),
+            ],
+            options={
+                'verbose_name': 'Prometheus Configuration',
+            },
+        ),
+        migrations.CreateModel(
             name='WorkflowExecutionConfig',
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),

--- a/trustpoint/management/models/__init__.py
+++ b/trustpoint/management/models/__init__.py
@@ -16,6 +16,7 @@ from management.models.notifications import (
     WeakSignatureAlgorithm,
 )
 from management.models.pkcs11 import PKCS11Token
+from management.models.prometheus import PrometheusConfig
 from management.models.security import SecurityConfig
 from management.models.tls import TlsSettings
 
@@ -32,6 +33,7 @@ __all__ = [
     'NotificationModel',
     'NotificationStatus',
     'PKCS11Token',
+    'PrometheusConfig',
     'SecurityConfig',
     'TlsSettings',
     'WeakECCCurve',

--- a/trustpoint/management/models/prometheus.py
+++ b/trustpoint/management/models/prometheus.py
@@ -1,0 +1,33 @@
+"""Prometheus Configuration Model."""
+
+from __future__ import annotations
+
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+from django_stubs_ext.db.models import TypedModelMeta
+
+
+class PrometheusConfig(models.Model):
+    """Stores global configuration for the Prometheus metrics endpoint."""
+
+    objects: models.Manager[PrometheusConfig]
+
+    enabled = models.BooleanField(
+        default=False,
+        verbose_name=_('Enable Prometheus metrics endpoint'),
+        help_text=_('When enabled, the /prometheus/metrics endpoint is available for scraping.'),
+    )
+
+    class Meta(TypedModelMeta):
+        """Meta class configuration."""
+
+        verbose_name = _('Prometheus Configuration')
+
+    def __str__(self) -> str:
+        """Return a human-readable name for the Prometheus configuration."""
+        return 'Prometheus Settings'
+
+    @classmethod
+    def get(cls) -> PrometheusConfig:
+        """Return the singleton Prometheus configuration, creating it if necessary."""
+        return cls.objects.first() or cls.objects.create()

--- a/trustpoint/management/views/settings.py
+++ b/trustpoint/management/views/settings.py
@@ -23,10 +23,17 @@ from management.forms import (
     InternationalizationConfigForm,
     LoggingConfigForm,
     NotificationConfigForm,
+    PrometheusConfigForm,
     SecurityConfigForm,
     WorkflowExecutionConfigForm,
 )
-from management.models import InternationalizationConfig, LoggingConfig, NotificationConfig, SecurityConfig
+from management.models import (
+    InternationalizationConfig,
+    LoggingConfig,
+    NotificationConfig,
+    PrometheusConfig,
+    SecurityConfig,
+)
 from management.models.audit_log import AuditLog
 from management.models.workflows2 import WorkflowExecutionConfig
 from management.security.features import AutoGenPkiFeature
@@ -262,7 +269,11 @@ def build_workflow_execution_context(
 
 
 class SettingsFormViewMixin[FormType: (
-    InternationalizationConfigForm | LoggingConfigForm | NotificationConfigForm | SecurityConfigForm
+    InternationalizationConfigForm
+    | LoggingConfigForm
+    | NotificationConfigForm
+    | PrometheusConfigForm
+    | SecurityConfigForm
 )](
     PageContextMixin,
     SecurityLevelMixin,
@@ -341,18 +352,18 @@ class SettingsTabView(TemplateView):
         metrics_view.setup(self.request)
         metrics_context = metrics_view.get_context_data()
 
+        context['prometheus_form'] = metrics_context['form']
+        context['prometheus_config'] = metrics_context['prometheus_config']
         context['uptime'] = metrics_context['uptime']
         context['started_time'] = metrics_context['started_time']
         context['database_size'] = metrics_context['database_size']
         context['started_time_ts'] = int(APP_STARTED_AT.timestamp())
+        for key in ('memory_available', 'memory_message', 'memory_usage', 'memory_usage_number',
+                    'memory_usage_unit', 'memory_limit', 'memory_anon', 'memory_file', 'memory_kernel',
+                    'disk_available', 'disk_message', 'disk_read', 'disk_write',
+                    'network_available', 'network_message', 'network_received', 'network_transmitted'):
+            context[key] = metrics_context[key]
 
-        context.update(get_memory_metrics())
-        context.update(get_disk_metrics())
-        context.update(get_network_metrics())
-
-        return context
-        workflow_execution_form = kwargs.get('workflow_execution_form')
-        context.update(build_workflow_execution_context(self.request, workflow_execution_form))
         return context
 
     def post(self, request: HttpRequest, *_args: Any, **_kwargs: Any) -> HttpResponse:
@@ -660,21 +671,35 @@ class NotificationSettingsView(SettingsFormViewMixin[NotificationConfigForm]):
         return context
 
 
-class MetricsSettingsView(TemplateView):
-    """View for displaying runtime metrics."""
+class MetricsSettingsView(SettingsFormViewMixin[PrometheusConfigForm]):
+    """View for displaying runtime metrics and managing the Prometheus export toggle."""
 
     template_name = 'management/includes/metrics_configuration.html'
+    form_class = PrometheusConfigForm
+    setting_type = 'metrics'
+
+    def get_form_kwargs(self) -> dict[str, Any]:
+        """Load the singleton PrometheusConfig instance into the form."""
+        kwargs = super().get_form_kwargs()
+        kwargs['instance'] = PrometheusConfig.get()
+        return kwargs
+
+    def form_valid(self, form: PrometheusConfigForm) -> HttpResponse:
+        """Save the Prometheus configuration and redirect back to the metrics tab."""
+        form.save()
+        messages.success(self.request, _('Prometheus configuration saved successfully.'))
+        return redirect(self.get_success_url())
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         """Build the context dictionary for the metrics settings page."""
         context = super().get_context_data(**kwargs)
-        context['page_category'] = 'management'
-        context['page_name'] = 'settings'
-        context['setting_type'] = 'metrics'
-
+        context['prometheus_config'] = PrometheusConfig.get()
         context['uptime'] = format_uptime(APP_STARTED_AT)
         context['started_time'] = APP_STARTED_AT
         context['database_size'] = get_database_size()
+        context.update(get_memory_metrics())
+        context.update(get_disk_metrics())
+        context.update(get_network_metrics())
         return context
 
 class ChangeLogLevelView(View):

--- a/trustpoint/templates/management/includes/metrics_configuration.html
+++ b/trustpoint/templates/management/includes/metrics_configuration.html
@@ -1,0 +1,47 @@
+{% load i18n %}
+{% load crispy_forms_filters %}
+
+{# Prometheus Configuration Card #}
+<div class="card mb-3">
+    <div class="card-header">
+        <h5 class="mb-0">{% trans "Prometheus Metrics Export" %}</h5>
+    </div>
+    <div class="card-body pt-4 pb-2">
+        <p class="text-muted mb-3">
+            {% blocktrans trimmed %}
+                When enabled, Trustpoint exposes a <code>/prometheus/metrics</code> endpoint
+                that Prometheus can scrape. The endpoint collects HTTP request/response
+                counters, database query metrics, and Django migration state.
+            {% endblocktrans %}
+        </p>
+
+        {% if prometheus_config.enabled %}
+        <div class="alert alert-success mb-3" role="alert">
+            <i class="bi bi-check-circle me-2"></i>
+            <strong>{% trans "Metrics endpoint is active." %}</strong>
+        </div>
+        {% else %}
+        <div class="alert alert-secondary mb-3" role="alert">
+            <i class="bi bi-slash-circle me-2"></i>
+            {% trans "The metrics endpoint is currently disabled. Enable it below to allow Prometheus to scrape metrics." %}
+        </div>
+        {% endif %}
+
+        <form method="POST" action="{% url 'management:settings-metrics' %}" id="prometheus_configuration">
+            {% csrf_token %}
+            <fieldset class="form-group tp-form-group">
+                {% crispy form %}
+            </fieldset>
+        </form>
+    </div>
+    <div class="card-footer d-flex justify-content-between">
+        <div class="tp-card-btn-footer m-1">
+            <button class="btn btn-primary" type="submit" form="prometheus_configuration">
+                {% trans "Save" %}
+            </button>
+        </div>
+    </div>
+</div>
+
+{# Runtime / Container Metrics (read-only display) #}
+{% include 'management/includes/metrics.html' %}

--- a/trustpoint/templates/management/settings.html
+++ b/trustpoint/templates/management/settings.html
@@ -82,7 +82,7 @@
     </div>
 
     <div id="panel-metrics" class="tp-settings-panel">
-      {% include 'management/includes/metrics.html' %}
+      {% include 'management/includes/metrics_configuration.html' with form=prometheus_form %}
     </div>
 
   </div>

--- a/trustpoint/trustpoint/settings.py
+++ b/trustpoint/trustpoint/settings.py
@@ -86,6 +86,7 @@ PUBLIC_PATHS = [
     '/crl',
     '/setup-wizard',
     '/devices/browser',
+    '/prometheus/',
 ]
 
 
@@ -301,6 +302,7 @@ INSTALLED_APPS = [
     'aoki.apps.AokiConfig',
     'management.apps.ManagementConfig',
     'trustpoint_core',
+    'django_prometheus',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -323,6 +325,7 @@ if DEVELOPMENT_ENV and not DOCKER_CONTAINER:
     INSTALLED_APPS.append('behave_django')
 
 MIDDLEWARE = [
+    'django_prometheus.middleware.PrometheusBeforeMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
@@ -334,6 +337,7 @@ MIDDLEWARE = [
     'trustpoint.middleware.TrustpointLoginRequiredMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django_prometheus.middleware.PrometheusAfterMiddleware',
 ]
 
 

--- a/trustpoint/trustpoint/tests/test_settings.py
+++ b/trustpoint/trustpoint/tests/test_settings.py
@@ -183,6 +183,7 @@ def test_public_paths():
         '/crl',
         '/setup-wizard',
         '/devices/browser',
+        '/prometheus/'
     ]
     assert isinstance(public_paths, list), 'PUBLIC_PATHS should be a list.'
     assert public_paths == expected_paths, 'PUBLIC_PATHS should match the defined values.'

--- a/trustpoint/trustpoint/urls.py
+++ b/trustpoint/trustpoint/urls.py
@@ -39,6 +39,7 @@ from rest_framework_simplejwt.views import (
 from pki.views.issuing_cas import CrlDownloadView
 
 from .views import base
+from .views.prometheus import prometheus_metrics_view
 
 last_modified_date = timezone.now()
 
@@ -76,6 +77,7 @@ urlpatterns += [
     path('home/', include('home.urls')),
     path('devices/', include('devices.urls')),
     path('management/', include('management.urls')),
+    path('prometheus/metrics', prometheus_metrics_view, name='prometheus-metrics'),
     path('i18n/', include('django.conf.urls.i18n')),
     path(
         'jsi18n/',

--- a/trustpoint/trustpoint/views/prometheus.py
+++ b/trustpoint/trustpoint/views/prometheus.py
@@ -1,0 +1,21 @@
+"""Prometheus metrics endpoint view."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.http import Http404, HttpResponse
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+from management.models.prometheus import PrometheusConfig
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest
+
+
+def prometheus_metrics_view(_request: HttpRequest) -> HttpResponse:
+    """Serve Prometheus metrics if the endpoint is enabled in configuration."""
+    config = PrometheusConfig.get()
+    if not config.enabled:
+        raise Http404
+    return HttpResponse(generate_latest(), content_type=CONTENT_TYPE_LATEST)

--- a/uv.lock
+++ b/uv.lock
@@ -785,6 +785,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-prometheus"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "prometheus-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/c7/dc39c4c19f7b35e827a486d08376de1fad31c50decb26c56e32668314f13/django_prometheus-2.5.0.tar.gz", hash = "sha256:4837b3c3734d8350880839ab8235aafd250b668c348e159d4aecc3cbefeee53e", size = 26465, upload-time = "2026-05-26T19:04:00.77Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/5d/6ec3083ba69545696c962ae505a0e52e280e7592d4c278c2f3803cabb688/django_prometheus-2.5.0-py2.py3-none-any.whl", hash = "sha256:f15efb526cd53f9cf12da72dc55506322f5566b017a819ff27be1da302303134", size = 31801, upload-time = "2026-05-26T19:03:59.505Z" },
+]
+
+[[package]]
 name = "django-q2"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1477,6 +1490,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]
@@ -2315,6 +2337,7 @@ dependencies = [
     { name = "django-dbbackup" },
     { name = "django-filter" },
     { name = "django-filter-stubs" },
+    { name = "django-prometheus" },
     { name = "django-q2" },
     { name = "django-stubs", extra = ["compatible-mypy"] },
     { name = "django-taggit" },
@@ -2387,6 +2410,7 @@ requires-dist = [
     { name = "django-dbbackup", specifier = ">=5.0.0" },
     { name = "django-filter", specifier = "~=25.1" },
     { name = "django-filter-stubs", specifier = ">=0.1.3" },
+    { name = "django-prometheus", specifier = ">=2.4.0" },
     { name = "django-q2", specifier = ">=1.9.0" },
     { name = "django-stubs", extras = ["compatible-mypy"], specifier = ">=5.2.2" },
     { name = "django-taggit", specifier = ">=6.1.0,<7" },


### PR DESCRIPTION
- support for Prometheus metrics export
- adds a configuration model and admin UI to enable or disable the `/prometheus/metrics` endpoint, 
- integrates the `django-prometheus` package for metrics collection

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.

