### PR TITLE
Enabling users to configure the onboarding config via REST API

### DIFF
--- a/trustpoint/devices/serializers.py
+++ b/trustpoint/devices/serializers.py
@@ -14,7 +14,7 @@ from onboarding.models import OnboardingConfigModel, OnboardingPkiProtocol, Onbo
 from .models import DeviceModel
 
 
-class PkiProtocolField(serializers.Field):
+class PkiProtocolField(serializers.Field[int | str, int | str, int | str, Any]):
     """Custom field to accept PKI protocol as string name or integer value."""
 
     def to_internal_value(self, data: Any) -> int | str:

--- a/trustpoint/devices/serializers.py
+++ b/trustpoint/devices/serializers.py
@@ -4,19 +4,185 @@ Defines classes that handle validation and transformation
 of Device model instances to and from JSON.
 """
 
+import secrets
+from typing import Any, ClassVar
+
 from rest_framework import serializers
 
+from onboarding.models import OnboardingConfigModel, OnboardingPkiProtocol, OnboardingProtocol
+
 from .models import DeviceModel
+
+
+class PkiProtocolField(serializers.Field):
+    """Custom field to accept PKI protocol as string name or integer value."""
+
+    def to_internal_value(self, data: Any) -> int | str:
+        """Accept either string or integer for PKI protocol."""
+        if isinstance(data, (int, str)):
+            return data
+        msg = 'PKI protocol must be a string (name) or integer (value)'
+        raise serializers.ValidationError(msg)
+
+    def to_representation(self, value: Any) -> Any:
+        """Return the value as-is for serialization."""
+        return value
+
+
+class OnboardingConfigSerializer(serializers.ModelSerializer[OnboardingConfigModel]):
+    """Serializer for OnboardingConfig instances.
+
+    Handles conversion between OnboardingConfigModel objects and JSON representations.
+    Supports nested creation when creating a device with onboarding configuration.
+    Auto-generates secure credentials if not provided for applicable protocols.
+    Accepts both enum names (strings) and integer values for protocols.
+    """
+
+    pki_protocols = serializers.ListField(
+        child=PkiProtocolField(),
+        required=False,
+        allow_empty=True,
+        write_only=True,
+        help_text='List of PKI protocol names or values (e.g., ["CMP", "EST"] or [1, 2]).'
+    )
+
+    class Meta:
+        """Metadata for OnboardingConfigSerializer."""
+
+        model = OnboardingConfigModel
+        fields: ClassVar[list[str]] = [
+            'id',
+            'onboarding_protocol',
+            'onboarding_status',
+            'pki_protocols',
+            'est_password',
+            'cmp_shared_secret',
+            'opc_user',
+            'opc_password',
+            'idevid_trust_store',
+            'trust_store',
+            'opc_trust_store',
+        ]
+        read_only_fields: ClassVar[list[str]] = ['id', 'onboarding_status']
+
+    def _generate_secure_secret(self, length: int = 32) -> str:
+        """Generate a cryptographically secure random secret.
+
+        Args:
+            length: The length of the secret in bytes (default 32 = 256 bits)
+
+        Returns:
+            A URL-safe base64-encoded secret string
+        """
+        return secrets.token_urlsafe(length)
+
+    def _parse_pki_protocol(self, value: str | int | OnboardingPkiProtocol) -> OnboardingPkiProtocol:
+        """Parse PKI protocol from string name, integer value, or enum instance.
+
+        Args:
+            value: Either enum name (e.g., "CMP"), integer value (e.g., 1), or OnboardingPkiProtocol enum
+
+        Returns:
+            OnboardingPkiProtocol enum instance
+
+        Raises:
+            serializers.ValidationError: If the value is invalid
+        """
+        # Already an enum instance
+        if isinstance(value, OnboardingPkiProtocol):
+            return value
+
+        if isinstance(value, int):
+            try:
+                return OnboardingPkiProtocol(value)
+            except ValueError:
+                valid_values = [p.value for p in OnboardingPkiProtocol]
+                msg = f'Invalid PKI protocol value: {value}. Valid values: {valid_values}'
+                raise serializers.ValidationError(msg) from None
+
+        # Try to parse as string (enum name)
+        try:
+            return OnboardingPkiProtocol[str(value).upper()]
+        except KeyError:
+            valid_names = [p.name for p in OnboardingPkiProtocol]
+            msg = f'Invalid PKI protocol name: {value}. Valid names: {valid_names}'
+            raise serializers.ValidationError(msg) from None
+
+    def create(self, validated_data: dict[str, Any]) -> OnboardingConfigModel:
+        """Create OnboardingConfigModel instance with proper PKI protocol handling.
+
+        Auto-generates secure credentials for applicable protocols if not provided:
+        - CMP_SHARED_SECRET: generates cmp_shared_secret
+        - EST_USERNAME_PASSWORD or REST_USERNAME_PASSWORD: generates est_password
+        """
+        pki_protocol_values = validated_data.pop('pki_protocols', [])
+        onboarding_protocol = validated_data.get('onboarding_protocol')
+
+        if onboarding_protocol == OnboardingProtocol.CMP_SHARED_SECRET and not validated_data.get('cmp_shared_secret'):
+            validated_data['cmp_shared_secret'] = self._generate_secure_secret()
+
+        if (onboarding_protocol in (OnboardingProtocol.EST_USERNAME_PASSWORD, OnboardingProtocol.REST_USERNAME_PASSWORD)
+            and not validated_data.get('est_password')):
+            validated_data['est_password'] = self._generate_secure_secret()
+
+        instance = OnboardingConfigModel(**validated_data)
+
+        if pki_protocol_values:
+            protocol_enums = [self._parse_pki_protocol(val) for val in pki_protocol_values]
+            instance.set_pki_protocols(protocol_enums)
+
+        instance.save()
+        return instance
+
+    def update(self, instance: OnboardingConfigModel, validated_data: dict[str, Any]) -> OnboardingConfigModel:
+        """Update OnboardingConfigModel instance with proper PKI protocol handling."""
+        pki_protocol_values = validated_data.pop('pki_protocols', None)
+
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+
+        if pki_protocol_values is not None:
+            protocol_enums = [self._parse_pki_protocol(val) for val in pki_protocol_values]
+            instance.set_pki_protocols(protocol_enums)
+
+        instance.save()
+        return instance
 
 
 class DeviceSerializer(serializers.ModelSerializer[DeviceModel]):
     """Serializer for Device instances.
 
     Handles conversion between Device model objects and JSON representations.
+    Supports nested creation of onboarding_config when provided in the request.
     """
+
+    onboarding_config = OnboardingConfigSerializer(required=False, allow_null=True)
 
     class Meta:
         """Metadata for DeviceSerializer, defining model and serialized fields."""
 
         model = DeviceModel
         fields = '__all__'
+
+    def create(self, validated_data: dict[str, Any]) -> DeviceModel:
+        """Create DeviceModel instance with nested onboarding_config if provided."""
+        onboarding_config_data = validated_data.pop('onboarding_config', None)
+
+        if onboarding_config_data:
+            onboarding_config = OnboardingConfigSerializer().create(onboarding_config_data)
+            validated_data['onboarding_config'] = onboarding_config
+
+        return super().create(validated_data)
+
+    def update(self, instance: DeviceModel, validated_data: dict[str, Any]) -> DeviceModel:
+        """Update DeviceModel instance, handling nested onboarding_config updates."""
+        onboarding_config_data = validated_data.pop('onboarding_config', None)
+
+        if onboarding_config_data is not None:
+            if instance.onboarding_config:
+                OnboardingConfigSerializer().update(instance.onboarding_config, onboarding_config_data)
+            else:
+                onboarding_config = OnboardingConfigSerializer().create(onboarding_config_data)
+                validated_data['onboarding_config'] = onboarding_config
+
+        return super().update(instance, validated_data)

--- a/trustpoint/devices/serializers.py
+++ b/trustpoint/devices/serializers.py
@@ -43,7 +43,11 @@ class OnboardingConfigSerializer(serializers.ModelSerializer[OnboardingConfigMod
         required=False,
         allow_empty=True,
         write_only=True,
-        help_text='List of PKI protocol names or values (e.g., ["CMP", "EST"] or [1, 2]).'
+        help_text=(
+            'List of PKI protocol names or values. '
+            'Accepts: "CMP" (1), "EST" (2), "OPC_GDS_PUSH" (4), "REST" (8). '
+            'Can use names ["CMP", "EST"] or values [1, 2] or mix both.'
+        )
     )
 
     class Meta:
@@ -64,6 +68,21 @@ class OnboardingConfigSerializer(serializers.ModelSerializer[OnboardingConfigMod
             'opc_trust_store',
         ]
         read_only_fields: ClassVar[list[str]] = ['id', 'onboarding_status']
+        extra_kwargs: ClassVar[dict[str, dict[str, str]]] = {
+            'onboarding_protocol': {
+                'help_text': (
+                    'Onboarding protocol: MANUAL (0), CMP_IDEVID (1), CMP_SHARED_SECRET (2), '
+                    'EST_IDEVID (3), EST_USERNAME_PASSWORD (4), AOKI (5), BRSKI (6), '
+                    'OPC_GDS_PUSH (7), REST_USERNAME_PASSWORD (8), AGENT (9)'
+                )
+            },
+            'est_password': {
+                'help_text': 'Password for EST. Auto-generated if omitted for EST protocols.'
+            },
+            'cmp_shared_secret': {
+                'help_text': 'Shared secret for CMP. Auto-generated if omitted for CMP protocols.'
+            },
+        }
 
     def _generate_secure_secret(self, length: int = 32) -> str:
         """Generate a cryptographically secure random secret.

--- a/trustpoint/devices/tests/test_api/test_device_viewset.py
+++ b/trustpoint/devices/tests/test_api/test_device_viewset.py
@@ -7,16 +7,24 @@ The serializer uses fields='__all__', so all model fields appear in responses.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from django.contrib.auth.base_user import AbstractBaseUser
-
 from devices.models import DeviceModel
-from onboarding.models import NoOnboardingConfigModel, NoOnboardingPkiProtocol
+from onboarding.models import (
+    NoOnboardingConfigModel,
+    NoOnboardingPkiProtocol,
+    OnboardingPkiProtocol,
+    OnboardingProtocol,
+)
+
+if TYPE_CHECKING:
+    from django.contrib.auth.base_user import AbstractBaseUser
 
 
 @pytest.fixture
@@ -28,8 +36,8 @@ def api_client() -> APIClient:
 @pytest.fixture
 def user() -> AbstractBaseUser:
     """Create a test user."""
-    User = get_user_model()
-    return User.objects.create_user(username='device_api_testuser', password='testpass123')
+    user_model = get_user_model()
+    return user_model.objects.create_user(username='device_api_testuser', password='testpass123')  # noqa: S106
 
 
 @pytest.fixture
@@ -229,3 +237,261 @@ class TestDeviceViewSetDelete:
         """Deleting a non-existent id returns 404."""
         response = authenticated_client.delete(reverse('device-detail', args=[99999]))
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+class TestDeviceViewSetWithOnboardingConfig:
+    """Tests for creating and updating devices with onboarding_config."""
+
+    def test_create_device_with_onboarding_config_cmp_shared_secret(
+        self, authenticated_client: APIClient
+    ) -> None:
+        """POST with nested onboarding_config creates both device and config."""
+        payload = {
+            'common_name': 'device-with-onboarding',
+            'serial_number': 'SN-ONBOARD-001',
+            'onboarding_config': {
+                'onboarding_protocol': OnboardingProtocol.CMP_SHARED_SECRET,
+                'cmp_shared_secret': 'my-secret-123',
+                'pki_protocols': [OnboardingPkiProtocol.CMP],
+            },
+        }
+        response = authenticated_client.post(reverse('device-list'), payload, format='json')
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert 'onboarding_config' in response.data
+        assert response.data['onboarding_config'] is not None
+
+        device = DeviceModel.objects.get(pk=response.data['id'])
+        assert device.onboarding_config is not None
+        assert device.onboarding_config.onboarding_protocol == OnboardingProtocol.CMP_SHARED_SECRET
+        assert device.onboarding_config.cmp_shared_secret == 'my-secret-123'  # noqa: S105
+
+    def test_create_device_with_onboarding_config_est_username_password(
+        self, authenticated_client: APIClient
+    ) -> None:
+        """POST with EST username/password onboarding creates device correctly."""
+        payload = {
+            'common_name': 'device-est-onboarding',
+            'serial_number': 'SN-EST-001',
+            'onboarding_config': {
+                'onboarding_protocol': OnboardingProtocol.EST_USERNAME_PASSWORD,
+                'est_password': 'est-password-456',
+                'pki_protocols': [OnboardingPkiProtocol.EST],
+            },
+        }
+        response = authenticated_client.post(reverse('device-list'), payload, format='json')
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Verify onboarding config
+        device = DeviceModel.objects.get(pk=response.data['id'])
+        assert device.onboarding_config is not None
+        assert device.onboarding_config.onboarding_protocol == OnboardingProtocol.EST_USERNAME_PASSWORD
+        assert device.onboarding_config.est_password == 'est-password-456'  # noqa: S105
+
+    def test_create_device_with_onboarding_config_multiple_pki_protocols(
+        self, authenticated_client: APIClient
+    ) -> None:
+        """POST with multiple PKI protocols creates device correctly."""
+        payload = {
+            'common_name': 'device-multi-pki',
+            'serial_number': 'SN-MULTI-001',
+            'onboarding_config': {
+                'onboarding_protocol': OnboardingProtocol.CMP_SHARED_SECRET,
+                'cmp_shared_secret': 'multi-secret',
+                'pki_protocols': [OnboardingPkiProtocol.CMP, OnboardingPkiProtocol.EST],
+            },
+        }
+        response = authenticated_client.post(reverse('device-list'), payload, format='json')
+        assert response.status_code == status.HTTP_201_CREATED
+
+        device = DeviceModel.objects.get(pk=response.data['id'])
+        assert device.onboarding_config is not None
+        assert device.onboarding_config.has_pki_protocol(OnboardingPkiProtocol.CMP)
+        assert device.onboarding_config.has_pki_protocol(OnboardingPkiProtocol.EST)
+
+    def test_update_device_with_new_onboarding_config(
+        self,
+        authenticated_client: APIClient,
+        device: DeviceModel,
+    ) -> None:
+        """PATCH to add onboarding_config to an existing device."""
+        url = reverse('device-detail', args=[device.pk])
+        payload = {
+            'onboarding_config': {
+                'onboarding_protocol': OnboardingProtocol.CMP_SHARED_SECRET,
+                'cmp_shared_secret': 'updated-secret',
+                'pki_protocols': [OnboardingPkiProtocol.CMP],
+            },
+        }
+        response = authenticated_client.patch(url, payload, format='json')
+        assert response.status_code == status.HTTP_200_OK
+
+        # Verify onboarding config was created
+        device.refresh_from_db()
+        assert device.onboarding_config is not None
+        assert device.onboarding_config.cmp_shared_secret == 'updated-secret'  # noqa: S105
+
+    def test_create_device_without_onboarding_config_is_still_valid(
+        self, authenticated_client: APIClient, no_onboarding_config: NoOnboardingConfigModel
+    ) -> None:
+        """POST without onboarding_config still works (backward compatibility)."""
+        payload = {
+            'common_name': 'device-no-onboarding',
+            'serial_number': 'SN-NO-ONBOARD',
+            'no_onboarding_config': no_onboarding_config.pk,
+        }
+        response = authenticated_client.post(reverse('device-list'), payload, format='json')
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data['onboarding_config'] is None
+
+    def test_create_device_with_auto_generated_cmp_shared_secret(
+        self, authenticated_client: APIClient
+    ) -> None:
+        """POST without cmp_shared_secret auto-generates a secure secret."""
+        payload = {
+            'common_name': 'device-auto-secret',
+            'serial_number': 'SN-AUTO-001',
+            'onboarding_config': {
+                'onboarding_protocol': OnboardingProtocol.CMP_SHARED_SECRET,
+                'pki_protocols': [OnboardingPkiProtocol.CMP],
+            },
+        }
+        response = authenticated_client.post(reverse('device-list'), payload, format='json')
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Verify device was created with auto-generated secret
+        device = DeviceModel.objects.get(pk=response.data['id'])
+        assert device.onboarding_config is not None
+        assert device.onboarding_config.onboarding_protocol == OnboardingProtocol.CMP_SHARED_SECRET
+        assert device.onboarding_config.cmp_shared_secret != ''
+        assert len(device.onboarding_config.cmp_shared_secret) > 20  # Should be a long secure secret
+
+    def test_create_device_with_auto_generated_est_password(
+        self, authenticated_client: APIClient
+    ) -> None:
+        """POST without est_password auto-generates a secure password."""
+        payload = {
+            'common_name': 'device-auto-est',
+            'serial_number': 'SN-AUTO-EST-001',
+            'onboarding_config': {
+                'onboarding_protocol': OnboardingProtocol.EST_USERNAME_PASSWORD,
+                'pki_protocols': [OnboardingPkiProtocol.EST],
+            },
+        }
+        response = authenticated_client.post(reverse('device-list'), payload, format='json')
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Verify device was created with auto-generated password
+        device = DeviceModel.objects.get(pk=response.data['id'])
+        assert device.onboarding_config is not None
+        assert device.onboarding_config.onboarding_protocol == OnboardingProtocol.EST_USERNAME_PASSWORD
+        assert device.onboarding_config.est_password != ''
+        assert len(device.onboarding_config.est_password) > 20  # Should be a long secure password
+
+    def test_create_device_user_provided_secret_not_overridden(
+        self, authenticated_client: APIClient
+    ) -> None:
+        """POST with explicit cmp_shared_secret does not auto-generate."""
+        user_secret = 'user-provided-secret-123'
+        payload = {
+            'common_name': 'device-user-secret',
+            'serial_number': 'SN-USER-001',
+            'onboarding_config': {
+                'onboarding_protocol': OnboardingProtocol.CMP_SHARED_SECRET,
+                'cmp_shared_secret': user_secret,
+                'pki_protocols': [OnboardingPkiProtocol.CMP],
+            },
+        }
+        response = authenticated_client.post(reverse('device-list'), payload, format='json')
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Verify user-provided secret is preserved
+        device = DeviceModel.objects.get(pk=response.data['id'])
+        assert device.onboarding_config is not None
+        assert device.onboarding_config.cmp_shared_secret == user_secret
+
+    def test_create_device_with_pki_protocol_enum_names(
+        self, authenticated_client: APIClient
+    ) -> None:
+        """POST with PKI protocol enum names (strings) works correctly."""
+        payload = {
+            'common_name': 'device-enum-names',
+            'serial_number': 'SN-ENUM-001',
+            'onboarding_config': {
+                'onboarding_protocol': OnboardingProtocol.CMP_SHARED_SECRET,
+                'cmp_shared_secret': 'test-secret',
+                'pki_protocols': ['CMP', 'EST'],  # Using enum names instead of values
+            },
+        }
+        response = authenticated_client.post(reverse('device-list'), payload, format='json')
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Verify protocols are correctly parsed
+        device = DeviceModel.objects.get(pk=response.data['id'])
+        assert device.onboarding_config is not None
+        assert device.onboarding_config.has_pki_protocol(OnboardingPkiProtocol.CMP)
+        assert device.onboarding_config.has_pki_protocol(OnboardingPkiProtocol.EST)
+
+    def test_create_device_with_mixed_pki_protocol_format(
+        self, authenticated_client: APIClient
+    ) -> None:
+        """POST with mixed PKI protocol formats (names and values) works."""
+        payload = {
+            'common_name': 'device-mixed-format',
+            'serial_number': 'SN-MIXED-001',
+            'onboarding_config': {
+                'onboarding_protocol': OnboardingProtocol.CMP_SHARED_SECRET,
+                'cmp_shared_secret': 'test-secret',
+                'pki_protocols': ['CMP', 2],  # Mix of enum name and integer value
+            },
+        }
+        response = authenticated_client.post(reverse('device-list'), payload, format='json')
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Verify protocols are correctly parsed
+        device = DeviceModel.objects.get(pk=response.data['id'])
+        assert device.onboarding_config is not None
+        assert device.onboarding_config.has_pki_protocol(OnboardingPkiProtocol.CMP)
+        assert device.onboarding_config.has_pki_protocol(OnboardingPkiProtocol.EST)
+
+    def test_create_device_with_lowercase_pki_protocol_names(
+        self, authenticated_client: APIClient
+    ) -> None:
+        """POST with lowercase PKI protocol names works (case-insensitive)."""
+        payload = {
+            'common_name': 'device-lowercase',
+            'serial_number': 'SN-LOWER-001',
+            'onboarding_config': {
+                'onboarding_protocol': OnboardingProtocol.CMP_SHARED_SECRET,
+                'cmp_shared_secret': 'test-secret',
+                'pki_protocols': ['cmp', 'est'],  # Lowercase enum names
+            },
+        }
+        response = authenticated_client.post(reverse('device-list'), payload, format='json')
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Verify protocols are correctly parsed
+        device = DeviceModel.objects.get(pk=response.data['id'])
+        assert device.onboarding_config is not None
+        assert device.onboarding_config.has_pki_protocol(OnboardingPkiProtocol.CMP)
+        assert device.onboarding_config.has_pki_protocol(OnboardingPkiProtocol.EST)
+
+    def test_create_device_with_invalid_pki_protocol_name_returns_400(
+        self, authenticated_client: APIClient
+    ) -> None:
+        """POST with invalid PKI protocol name returns 400."""
+        payload = {
+            'common_name': 'device-invalid-proto',
+            'serial_number': 'SN-INVALID-001',
+            'onboarding_config': {
+                'onboarding_protocol': OnboardingProtocol.CMP_SHARED_SECRET,
+                'cmp_shared_secret': 'test-secret',
+                'pki_protocols': ['INVALID_PROTOCOL'],
+            },
+        }
+        response = authenticated_client.post(reverse('device-list'), payload, format='json')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        # Error can be in response.data directly or nested under onboarding_config
+        assert 'INVALID_PROTOCOL' in str(response.data)
+

--- a/trustpoint/devices/views/device_api.py
+++ b/trustpoint/devices/views/device_api.py
@@ -1,10 +1,12 @@
 """REST API viewsets for device management."""
 
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from django.utils.translation import gettext_lazy
 from drf_spectacular.utils import OpenApiExample, extend_schema
 from rest_framework import viewsets
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 # noinspection PyUnresolvedReferences
 from devices.models import (
@@ -173,7 +175,7 @@ class DeviceViewSet(viewsets.ModelViewSet[DeviceModel]):
             ),
         ]
     )
-    def create(self, request, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN201
+    def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Create a new device, optionally with onboarding configuration."""
         return super().create(request, *args, **kwargs)
 

--- a/trustpoint/devices/views/device_api.py
+++ b/trustpoint/devices/views/device_api.py
@@ -3,7 +3,7 @@
 from typing import ClassVar
 
 from django.utils.translation import gettext_lazy
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiExample, extend_schema
 from rest_framework import viewsets
 
 # noinspection PyUnresolvedReferences
@@ -27,6 +27,10 @@ class DeviceViewSet(viewsets.ModelViewSet[DeviceModel]):
 
     Supports standard CRUD operations such as list, retrieve,
     create, update, and delete.
+
+    When creating a device, you can optionally include an onboarding_config
+    to set up automatic certificate enrollment. The API supports both
+    enum names (e.g., "CMP", "EST") and integer values for protocols.
     """
 
     queryset = DeviceModel.objects.all()
@@ -34,14 +38,148 @@ class DeviceViewSet(viewsets.ModelViewSet[DeviceModel]):
     action_descriptions: ClassVar[dict[str, str]] = {
         'list': 'Retrieve a list of all devices.',
         'retrieve': 'Retrieve a single device by id.',
-        'create': 'Create a new device with name, serial number, and status.',
+        'create': (
+            'Create a new device with name, serial number, and status. '
+            'Optionally include onboarding_config for automatic certificate enrollment.'
+        ),
         'update': 'Update an existing device.',
         'partial_update': 'Partially update an existing device.',
         'destroy': 'Delete a device.',
     }
+
+    @extend_schema(
+        description=(
+            'Create a new device with optional onboarding configuration.\n\n'
+            '**Onboarding Protocol Values:**\n'
+            '- `0` = MANUAL: Manual certificate issuance\n'
+            '- `1` = CMP_IDEVID: CMP with manufacturer IDevID certificate\n'
+            '- `2` = CMP_SHARED_SECRET: CMP with pre-shared secret\n'
+            '- `3` = EST_IDEVID: EST with manufacturer IDevID certificate\n'
+            '- `4` = EST_USERNAME_PASSWORD: EST with username/password\n'
+            '- `5` = AOKI: Automated zero-touch onboarding\n'
+            '- `6` = BRSKI: Bootstrapping protocol (future)\n'
+            '- `7` = OPC_GDS_PUSH: OPC UA Global Discovery Server\n'
+            '- `8` = REST_USERNAME_PASSWORD: REST API with credentials\n'
+            '- `9` = AGENT: Trustpoint agent-managed\n\n'
+            '**PKI Protocol Values** (supports both integers and string names):\n'
+            '- `1` or `"CMP"`: Certificate Management Protocol\n'
+            '- `2` or `"EST"`: Enrollment over Secure Transport\n'
+            '- `4` or `"OPC_GDS_PUSH"`: OPC UA GDS Push\n'
+            '- `8` or `"REST"`: REST API\n\n'
+            '**Auto-Generated Credentials:**\n'
+            '- CMP_SHARED_SECRET (2): Auto-generates `cmp_shared_secret` if omitted\n'
+            '- EST_USERNAME_PASSWORD (4) or REST_USERNAME_PASSWORD (8): Auto-generates `est_password` if omitted\n'
+            '- Generated secrets are cryptographically secure 256-bit values'
+        ),
+        examples=[
+            OpenApiExample(
+                'Basic Device without Onboarding',
+                value={
+                    'common_name': 'device-001',
+                    'serial_number': 'SN123456789',
+                },
+                request_only=True,
+                description='Minimal device creation without onboarding configuration',
+            ),
+            OpenApiExample(
+                'CMP with Auto-Generated Shared Secret',
+                value={
+                    'common_name': 'cmp-device-auto',
+                    'serial_number': 'SN-CMP-001',
+                    'domain': 1,
+                    'onboarding_config': {
+                        'onboarding_protocol': 2,
+                        'pki_protocols': ['CMP'],
+                    },
+                },
+                request_only=True,
+                description=(
+                    'Uses CMP_SHARED_SECRET (2) protocol. '
+                    'Shared secret is automatically generated and returned in response.'
+                ),
+            ),
+            OpenApiExample(
+                'CMP with Custom Shared Secret',
+                value={
+                    'common_name': 'cmp-device-custom',
+                    'serial_number': 'SN-CMP-002',
+                    'domain': 1,
+                    'onboarding_config': {
+                        'onboarding_protocol': 2,
+                        'cmp_shared_secret': 'my-custom-secret-123',
+                        'pki_protocols': [1],
+                    },
+                },
+                request_only=True,
+                description='CMP with user-provided shared secret. PKI protocol as integer (1=CMP).',
+            ),
+            OpenApiExample(
+                'EST with Username & Password',
+                value={
+                    'common_name': 'est-device',
+                    'serial_number': 'SN-EST-001',
+                    'domain': 1,
+                    'onboarding_config': {
+                        'onboarding_protocol': 4,
+                        'est_password': 'secure-password-456',
+                        'pki_protocols': ['EST'],
+                        'trust_store': 5,
+                    },
+                },
+                request_only=True,
+                description=(
+                    'Uses EST_USERNAME_PASSWORD (4) protocol. '
+                    'Password can be omitted for auto-generation.'
+                ),
+            ),
+            OpenApiExample(
+                'Multiple PKI Protocols (Mixed Format)',
+                value={
+                    'common_name': 'multi-protocol-device',
+                    'serial_number': 'SN-MULTI-001',
+                    'domain': 1,
+                    'ip_address': '192.168.1.100',
+                    'onboarding_config': {
+                        'onboarding_protocol': 2,
+                        'pki_protocols': ['CMP', 2, 'REST'],
+                        'trust_store': 5,
+                    },
+                },
+                request_only=True,
+                description=(
+                    'Device supporting multiple PKI protocols. '
+                    'Shows mixed format: strings ("CMP", "REST") and integers (2=EST).'
+                ),
+            ),
+            OpenApiExample(
+                'OPC UA GDS Push Device',
+                value={
+                    'common_name': 'opc-server',
+                    'serial_number': 'SN-OPC-001',
+                    'domain': 1,
+                    'ip_address': '192.168.1.50',
+                    'opc_server_port': 4840,
+                    'device_type': 2,
+                    'onboarding_config': {
+                        'onboarding_protocol': 7,
+                        'opc_user': 'admin',
+                        'opc_password': 'opc-secure-pass',
+                        'pki_protocols': ['OPC_GDS_PUSH'],
+                        'opc_trust_store': 10,
+                    },
+                },
+                request_only=True,
+                description='OPC UA GDS Push device with all required OPC-specific fields.',
+            ),
+        ]
+    )
+    def create(self, request, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN201
+        """Create a new device, optionally with onboarding configuration."""
+        return super().create(request, *args, **kwargs)
 
     def get_view_description(self, html: bool = False) -> str:  # noqa: FBT001, FBT002
         """Return a description for the given action."""
         if hasattr(self, 'action') and self.action in self.action_descriptions:
             return self.action_descriptions[self.action]
         return super().get_view_description(html)
+


### PR DESCRIPTION
```
{
  "common_name": "my-device",
  "serial_number": "SN-12345",
  "domain": 1,
  "onboarding_config": {
    "onboarding_protocol": 2,
    "pki_protocols": [1]
  }
}
```



**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.