### PR TITLE
Add bootstrap hint for initial login

### DIFF
--- a/trustpoint/templates/users/login.html
+++ b/trustpoint/templates/users/login.html
@@ -11,6 +11,18 @@
 {% block content %}
 
     <section class="tp-setup-form-shell">
+        {% if show_bootstrap_hint %}
+            <div class="alert alert-info d-flex" role="alert">
+                <div>
+                    <strong>{% trans "Initial Setup" %}</strong><br>
+                    {% blocktranslate with username=bootstrap_username %}
+                    This is your first login. The initial credentials can be found in the Docker container logs.
+                    Look for "Trustpoint bootstrap username" and "Trustpoint bootstrap password".
+                    {% endblocktranslate %}
+                </div>
+            </div>
+        {% endif %}
+
         {% if messages %}
             <div class="messages tp-messages text-center tp-setup-form-messages">
                 {% for message in messages %}

--- a/trustpoint/users/tests/test_integration.py
+++ b/trustpoint/users/tests/test_integration.py
@@ -1,5 +1,7 @@
 """Integration tests for the users app."""
 
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 from django.urls import reverse
@@ -85,3 +87,57 @@ class LoginIntegrationTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.wsgi_request.user.is_authenticated)
+
+
+class BootstrapHintTest(TestCase):
+    """Test the bootstrap hint feature on the login page."""
+
+    def setUp(self) -> None:
+        self.client = Client()
+        self.login_url = reverse('users:login')
+
+    @patch('users.views.SetupWizardCompletedModel.setup_wizard_completed')
+    def test_bootstrap_hint_shown_for_new_user(self, mock_setup_completed: object) -> None:
+        """Bootstrap hint should be shown when setup is not complete and admin has never logged in."""
+        mock_setup_completed.return_value = False
+        User.objects.create_user(username='admin', password='testpass123')
+
+        response = self.client.get(self.login_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context.get('show_bootstrap_hint'))
+        self.assertEqual(response.context.get('bootstrap_username'), 'admin')
+
+    @patch('users.views.SetupWizardCompletedModel.setup_wizard_completed')
+    def test_bootstrap_hint_not_shown_after_login(self, mock_setup_completed: object) -> None:
+        """Bootstrap hint should not be shown once the admin has logged in."""
+        mock_setup_completed.return_value = False
+        user = User.objects.create_user(username='admin', password='testpass123')
+        self.client.login(username='admin', password='testpass123')
+        user.refresh_from_db()
+
+        self.client.logout()
+        response = self.client.get(self.login_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context.get('show_bootstrap_hint', False))
+
+    @patch('users.views.SetupWizardCompletedModel.setup_wizard_completed')
+    def test_bootstrap_hint_not_shown_when_user_doesnt_exist(self, mock_setup_completed: object) -> None:
+        """Bootstrap hint should not be shown when bootstrap user doesn't exist."""
+        mock_setup_completed.return_value = False
+        response = self.client.get(self.login_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context.get('show_bootstrap_hint', False))
+
+    @patch('users.views.SetupWizardCompletedModel.setup_wizard_completed')
+    def test_bootstrap_hint_not_shown_after_setup_complete(self, mock_setup_completed: object) -> None:
+        """Bootstrap hint should not be shown after setup wizard is completed."""
+        mock_setup_completed.return_value = True
+        User.objects.create_user(username='admin', password='testpass123')
+
+        response = self.client.get(self.login_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context.get('show_bootstrap_hint', False))

--- a/trustpoint/users/views.py
+++ b/trustpoint/users/views.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth import get_user_model
 from django.contrib.auth.views import LoginView
+from django.db import DatabaseError
+
+from setup_wizard.models import SetupWizardCompletedModel
 
 if TYPE_CHECKING:
     from typing import Any
@@ -17,6 +22,25 @@ class TrustpointLoginView(LoginView):
     """Login view for the trustpoint application."""
 
     http_method_names = ('get', 'post')
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        """Add context about initial bootstrap login if applicable."""
+        context = super().get_context_data(**kwargs)
+
+        username = getattr(settings, 'TRUSTPOINT_BOOTSTRAP_USERNAME', 'admin')
+        user_model = get_user_model()
+
+        try:
+            setup_completed = SetupWizardCompletedModel.setup_wizard_completed()
+            if not setup_completed:
+                bootstrap_user = user_model.objects.get(username=username)
+                if bootstrap_user.last_login is None:
+                    context['show_bootstrap_hint'] = True
+                    context['bootstrap_username'] = username
+        except (user_model.DoesNotExist, DatabaseError):
+            pass
+
+        return context
 
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         """Redirects to the appropriate startup wizard section if the setup wizard is not completed.


### PR DESCRIPTION
- Updated login template to display a bootstrap hint for first-time users.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.