### PR TITLE
Potential fix for code scanning alert no. 142: Information exposure through an exception

### DIFF
--- a/trustpoint/agents/api_views.py
+++ b/trustpoint/agents/api_views.py
@@ -25,6 +25,9 @@ if TYPE_CHECKING:
     from rest_framework.request import Request
 
 
+_logger = LoggerMixin().logger
+
+
 def _parse_client_cert(request: Request) -> x509.Certificate | None:
     """Extract and parse the client certificate from the Django request META."""
     raw: str | None = request.META.get('HTTP_SSL_CLIENT_CERT')
@@ -35,7 +38,8 @@ def _parse_client_cert(request: Request) -> x509.Certificate | None:
         pem_bytes = urllib.parse.unquote(raw).encode('utf-8')
         return x509.load_pem_x509_certificate(pem_bytes)
     except Exception as exc:
-        msg = f'Invalid HTTP_SSL_CLIENT_CERT header: {exc}'
+        _logger.exception('Invalid HTTP_SSL_CLIENT_CERT header.')
+        msg = 'Invalid client certificate header.'
         raise AuthenticationFailed(msg) from exc
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/Trustpoint-Project/trustpoint/security/code-scanning/142](https://github.com/Trustpoint-Project/trustpoint/security/code-scanning/142)

The safest fix is to **avoid including `exc` in any client-facing message** and instead log the exception internally.

Best targeted change in `trustpoint/agents/api_views.py`:
- In `_parse_client_cert`, replace:
  - `msg = f'Invalid HTTP_SSL_CLIENT_CERT header: {exc}'`
  - `raise AuthenticationFailed(msg) from exc`
- With:
  - a server-side log call containing exception details (`logger.exception(...)` or equivalent),
  - a generic `AuthenticationFailed('Invalid client certificate header.')`.

Because `_parse_client_cert` is a module-level function (no `self.logger`), add a module logger via the existing `LoggerMixin` pattern:
- Define `_logger = LoggerMixin().logger` near the top-level declarations.
- Use `_logger.exception(...)` in the `except` block.

This preserves behavior (still rejects invalid certs with 401-style auth failure) while removing sensitive exception detail from external responses.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
