### PR TITLE
Domain-based AOKI implementation

### DIFF
--- a/trustpoint/aoki/management/commands/aoki_gen_test_certs.py
+++ b/trustpoint/aoki/management/commands/aoki_gen_test_certs.py
@@ -29,9 +29,9 @@ CERTS_DIR.mkdir(parents=True, exist_ok=True)
 
 
 class Command(BaseCommand):
-    """Command to check for certificates using insufficient RSA key lengths."""
+    """Command to generate testing IDevID and DevOwnerID certificates for AOKI."""
 
-    help = 'Check certificates with insufficient key lengths.'
+    help = 'Generate testing IDevID and DevOwnerID certificates for AOKI.'
 
     def handle(self, *args: Any, **kwargs: Any) -> None:
         """Entrypoint for the command.
@@ -42,7 +42,11 @@ class Command(BaseCommand):
         """
         del args, kwargs  # Unused
         idevid_cert = AokiTestCertGenerator.generate_idevid_pki()
-        AokiTestCertGenerator.generate_owner_id_cert(idevid_cert)
+        owner_ca_cert, owner_ca_key = AokiTestCertGenerator.generate_owner_id_ca()
+        AokiTestCertGenerator.generate_owner_id_cert(idevid_cert, owner_ca_cert=owner_ca_cert, owner_ca_key=owner_ca_key)
+        # AokiTestCertGenerator.generate_domain_ca_owner_id_cert(
+        #     domain_ca_cert=idevid_cert, owner_ca_cert=owner_ca_cert, owner_ca_key=owner_ca_key
+        # )
         print('Certificates generated successfully.')
 
 
@@ -103,16 +107,22 @@ class AokiTestCertGenerator:
         return idevid_cert
 
     @staticmethod
-    def generate_owner_id_cert(idevid_cert: x509.Certificate) -> None:
-        """Generate the DeviceOwnerID certificate."""
-        # It is RECOMMENDED that the same CA is used as for the IDevID cert,
-        # but here a separate CA is used to ascertain they can be different
+    def generate_owner_id_ca() -> tuple[x509.Certificate, PrivateKey]:
+        """Generate the CA used to sign DevOwnerIDs."""
         owner_ca_cert, owner_ca_key = CertificateGenerator.create_root_ca(
             'Owner_Test_Root_CA'
         )
         write_cert_pem(owner_ca_cert, CERTS_DIR / 'ownerid_ca.pem')
         write_private_key(owner_ca_key, CERTS_DIR / 'ownerid_ca_pk.pem')
+        return owner_ca_cert, owner_ca_key
 
+    @staticmethod
+    def generate_owner_id_cert(
+        idevid_cert: x509.Certificate,
+        owner_ca_cert: x509.Certificate,
+        owner_ca_key: PrivateKey,
+    ) -> None:
+        """Generate the DevOwnerID certificate."""
         idevid_sha256_fingerprint = idevid_cert.fingerprint(hashes.SHA256()).hex()
         # Build URI string "dev-owner:cert:<idevid_subj_sn>_<idevid_sha256_fingerprint>"
         # If the IDevID Subject Serial Number is not present, '' shall be used as a placeholder
@@ -142,3 +152,35 @@ class AokiTestCertGenerator:
         write_cert_pem(ownerid_cert, CERTS_DIR / 'owner_id.pem')
         write_private_key(ownerid_key, CERTS_DIR / 'owner_id_pk.pem')
 
+    @staticmethod
+    def generate_domain_ca_owner_id_cert(
+        domain_ca_cert: x509.Certificate,
+        owner_ca_cert: x509.Certificate,
+        owner_ca_key: PrivateKey,
+    ) -> None:
+        """Generate the domain-based (CA pinning) DevOwnerID certificate."""
+        ca_sha256_fingerprint = domain_ca_cert.fingerprint(hashes.SHA256()).hex()
+        # Build URI string "dev-owner:ca:<idevid_sha256_fingerprint>"
+        ca_san_uri = f'dev-owner:ca:{ca_sha256_fingerprint}'
+        print(f'Domain CA DeviceOwnerID SAN URI: {ca_san_uri}')
+        san_ext_list = [x509.UniformResourceIdentifier(ca_san_uri)]
+
+        ownerid_cert, ownerid_key = CertificateGenerator.create_ee(
+            issuer_private_key=owner_ca_key,
+            issuer_name=owner_ca_cert.subject,
+            subject_name=x509.Name(
+                [
+                    x509.NameAttribute(x509.NameOID.COMMON_NAME, 'DomainBased_DevOwnerID_Test'),
+                    x509.NameAttribute(x509.NameOID.PSEUDONYM, 'DevOwnerID'),
+                ]
+            ),
+            private_key=None,
+            extensions=[
+                (x509.SubjectAlternativeName(san_ext_list), False),
+                # SAN should be critical for an OwnerID cert,
+                # but then the subject name should be empty according to RFC 5280
+            ],
+            validity_days=99999,
+        )
+        write_cert_pem(ownerid_cert, CERTS_DIR / 'domain_ca_owner_id.pem')
+        write_private_key(ownerid_key, CERTS_DIR / 'domain_ca_owner_id_pk.pem')

--- a/trustpoint/aoki/management/commands/aoki_gen_test_certs.py
+++ b/trustpoint/aoki/management/commands/aoki_gen_test_certs.py
@@ -44,9 +44,6 @@ class Command(BaseCommand):
         idevid_cert = AokiTestCertGenerator.generate_idevid_pki()
         owner_ca_cert, owner_ca_key = AokiTestCertGenerator.generate_owner_id_ca()
         AokiTestCertGenerator.generate_owner_id_cert(idevid_cert, owner_ca_cert=owner_ca_cert, owner_ca_key=owner_ca_key)
-        # AokiTestCertGenerator.generate_domain_ca_owner_id_cert(
-        #     domain_ca_cert=idevid_cert, owner_ca_cert=owner_ca_cert, owner_ca_key=owner_ca_key
-        # )
         print('Certificates generated successfully.')
 
 

--- a/trustpoint/aoki/management/commands/aoki_setup_idevid_test_env.py
+++ b/trustpoint/aoki/management/commands/aoki_setup_idevid_test_env.py
@@ -175,6 +175,10 @@ class Command(CertificateCreationCommandMixin, LoggerMixin, BaseCommand):
 
     def _get_or_create_domain_ca_owner_id_cert(self, domain_ca: CaModel) -> None:
         """Generates a domain-based DevOwnerID, pinning the certificate of the domain CA."""
+        if DOMAIN_BASED_OWNER_ID_CERT_PATH.exists() and DOMAIN_BASED_OWNER_ID_KEY_PATH.exists():
+            self.log_and_stdout('Domain-based DevOwnerID certificate files already exist, skipping generation.')
+            return
+
         domain_ca_cert = domain_ca.get_certificate()
         owner_ca_cert = x509.load_pem_x509_certificate(OWNER_CA_CERT_PATH.read_bytes())
         owner_ca_key = load_pem_private_key(OWNER_CA_KEY_PATH.read_bytes(), password=None)
@@ -184,7 +188,6 @@ class Command(CertificateCreationCommandMixin, LoggerMixin, BaseCommand):
             owner_ca_cert=owner_ca_cert,
             owner_ca_key=owner_ca_key,
         )
-
     def _get_or_create_idevid_truststore(self) -> TruststoreModel:
         """Return an existing IDevID truststore or create one from the generated IDevID CA cert."""
         if TruststoreModel.objects.filter(unique_name=IDEVID_TRUSTSTORE_UNIQUE_NAME).exists():

--- a/trustpoint/aoki/management/commands/aoki_setup_idevid_test_env.py
+++ b/trustpoint/aoki/management/commands/aoki_setup_idevid_test_env.py
@@ -18,6 +18,7 @@ from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from trustpoint_core.serializer import CredentialSerializer
 
+from aoki.management.commands.aoki_gen_test_certs import AokiTestCertGenerator
 from pki.management.commands.base_commands import CertificateCreationCommandMixin
 from pki.models import CaModel, CertificateModel, DevIdRegistration, DomainModel
 from pki.models.credential import OwnerCredentialModel
@@ -32,11 +33,14 @@ CERTS_DIR = (Path(__file__).resolve().parents[2] / 'tests' / 'certs').resolve()
 IDEVID_CA_CERT_PATH = CERTS_DIR / 'idevid_ca.pem'
 OWNER_ID_CERT_PATH = CERTS_DIR / 'owner_id.pem'
 OWNER_ID_KEY_PATH = CERTS_DIR / 'owner_id_pk.pem'
+DOMAIN_BASED_OWNER_ID_CERT_PATH = CERTS_DIR / 'domain_ca_owner_id.pem'
+DOMAIN_BASED_OWNER_ID_KEY_PATH = CERTS_DIR / 'domain_ca_owner_id_pk.pem'
 OWNER_CA_CERT_PATH = CERTS_DIR / 'ownerid_ca.pem'
 
 IDEVID_TRUSTSTORE_UNIQUE_NAME = 'AokiIDevIDTruststore'
 DEVID_REGISTRATION_UNIQUE_NAME = 'AokiIDevIDRegistration'
 OWNER_CRED_UNIQUE_NAME = 'AokiOwnerCred'
+DOMAIN_BASED_OWNER_CRED_UNIQUE_NAME = 'DomainBasedAokiOwnerCred'
 
 ISSUING_CA_UNIQUE_NAME = 'aoki-issuing-ca'
 DOMAIN_UNIQUE_NAME = 'aoki'
@@ -79,18 +83,31 @@ class Command(CertificateCreationCommandMixin, LoggerMixin, BaseCommand):
 
         issuing_ca = self._get_or_create_issuing_ca()
         domain = self._get_or_create_domain(issuing_ca)
+        self._get_or_create_domain_ca_owner_id_cert(domain_ca=issuing_ca)
         truststore = self._get_or_create_idevid_truststore()
         self._get_or_create_devid_registration(truststore, domain)
-        self._get_or_create_owner_credential()
+        self._get_or_create_owner_credential(
+            unique_name=OWNER_CRED_UNIQUE_NAME,
+            cert_path=OWNER_ID_CERT_PATH,
+            key_path=OWNER_ID_KEY_PATH,
+            ca_cert_path=OWNER_CA_CERT_PATH
+        )
+        self._get_or_create_owner_credential(
+            unique_name=DOMAIN_BASED_OWNER_CRED_UNIQUE_NAME,
+            cert_path=DOMAIN_BASED_OWNER_ID_CERT_PATH,
+            key_path=DOMAIN_BASED_OWNER_ID_KEY_PATH,
+            ca_cert_path=OWNER_CA_CERT_PATH
+        )
 
         self.log_and_stdout('\n=== AOKI IDevID test environment ready ===')
-        self.log_and_stdout(f'  Issuing CA:              {ISSUING_CA_UNIQUE_NAME}')
-        self.log_and_stdout(f'  Domain:                  {DOMAIN_UNIQUE_NAME}')
-        self.log_and_stdout(f'  IDevID Truststore:       {IDEVID_TRUSTSTORE_UNIQUE_NAME}')
-        self.log_and_stdout(f'  DevID Registration:      {DEVID_REGISTRATION_UNIQUE_NAME}')
-        self.log_and_stdout(f'    Serial number pattern: {SERIAL_NUMBER_PATTERN}')
-        self.log_and_stdout(f'    Domain:                {domain.unique_name}')
-        self.log_and_stdout(f'  Owner Credential:        {OWNER_CRED_UNIQUE_NAME}')
+        self.log_and_stdout(f'  Issuing CA:               {ISSUING_CA_UNIQUE_NAME}')
+        self.log_and_stdout(f'  Domain:                   {DOMAIN_UNIQUE_NAME}')
+        self.log_and_stdout(f'  IDevID Truststore:        {IDEVID_TRUSTSTORE_UNIQUE_NAME}')
+        self.log_and_stdout(f'  DevID Registration:       {DEVID_REGISTRATION_UNIQUE_NAME}')
+        self.log_and_stdout(f'    Serial number pattern:  {SERIAL_NUMBER_PATTERN}')
+        self.log_and_stdout(f'    Domain:                 {domain.unique_name}')
+        self.log_and_stdout(f'  Owner Credential:         {OWNER_CRED_UNIQUE_NAME}')
+        self.log_and_stdout(f'  Domain-based Owner Cred.: {DOMAIN_BASED_OWNER_CRED_UNIQUE_NAME}')
 
     def _ensure_certs_exist(self) -> None:
         """Run ``aoki_gen_test_certs`` if any required certificate file is missing."""
@@ -155,6 +172,18 @@ class Command(CertificateCreationCommandMixin, LoggerMixin, BaseCommand):
             self.log_and_stdout(f'Domain "{DOMAIN_UNIQUE_NAME}" already exists, skipping creation.')
         return domain
 
+    def _get_or_create_domain_ca_owner_id_cert(self, domain_ca: CaModel) -> None:
+        """Generates a domain-based DevOwnerID, pinning the certificate of the domain CA."""
+        domain_ca_cert = domain_ca.get_certificate()
+        owner_ca_cert = x509.load_pem_x509_certificate(OWNER_CA_CERT_PATH.read_bytes())
+        owner_ca_key = load_pem_private_key(OWNER_ID_KEY_PATH.read_bytes(), password=None)
+
+        AokiTestCertGenerator.generate_domain_ca_owner_id_cert(
+            domain_ca_cert=domain_ca_cert,
+            owner_ca_cert=owner_ca_cert,
+            owner_ca_key=owner_ca_key,
+        )
+
     def _get_or_create_idevid_truststore(self) -> TruststoreModel:
         """Return an existing IDevID truststore or create one from the generated IDevID CA cert."""
         if TruststoreModel.objects.filter(unique_name=IDEVID_TRUSTSTORE_UNIQUE_NAME).exists():
@@ -203,17 +232,17 @@ class Command(CertificateCreationCommandMixin, LoggerMixin, BaseCommand):
         )
         return registration
 
-    def _get_or_create_owner_credential(self) -> OwnerCredentialModel:
+    def _get_or_create_owner_credential(self, unique_name: str, cert_path: Path, key_path: Path, ca_cert_path: Path) -> OwnerCredentialModel:
         """Return an existing owner credential or create one from the generated DevOwnerID files."""
-        if OwnerCredentialModel.objects.filter(unique_name=OWNER_CRED_UNIQUE_NAME).exists():
+        if OwnerCredentialModel.objects.filter(unique_name=unique_name).exists():
             self.log_and_stdout(
-                f'Owner credential "{OWNER_CRED_UNIQUE_NAME}" already exists, skipping creation.'
+                f'Owner credential "{unique_name}" already exists, skipping creation.'
             )
-            return OwnerCredentialModel.objects.get(unique_name=OWNER_CRED_UNIQUE_NAME)
+            return OwnerCredentialModel.objects.get(unique_name=unique_name)
 
-        owner_cert = x509.load_pem_x509_certificate(OWNER_ID_CERT_PATH.read_bytes())
-        raw_key = load_pem_private_key(OWNER_ID_KEY_PATH.read_bytes(), password=None)
-        owner_ca_cert = x509.load_pem_x509_certificate(OWNER_CA_CERT_PATH.read_bytes())
+        owner_cert = x509.load_pem_x509_certificate(cert_path.read_bytes())
+        raw_key = load_pem_private_key(key_path.read_bytes(), password=None)
+        owner_ca_cert = x509.load_pem_x509_certificate(ca_cert_path.read_bytes())
 
         if not isinstance(
             raw_key,
@@ -229,10 +258,10 @@ class Command(CertificateCreationCommandMixin, LoggerMixin, BaseCommand):
         )
 
         owner_credential = OwnerCredentialModel.create_new_owner_credential(
-            unique_name=OWNER_CRED_UNIQUE_NAME,
+            unique_name=unique_name,
             credential_serializer=credential_serializer,
         )
-        self.log_and_stdout(f'Created owner credential "{OWNER_CRED_UNIQUE_NAME}".')
+        self.log_and_stdout(f'Created owner credential "{unique_name}".')
         return owner_credential
 
     @staticmethod

--- a/trustpoint/aoki/management/commands/aoki_setup_idevid_test_env.py
+++ b/trustpoint/aoki/management/commands/aoki_setup_idevid_test_env.py
@@ -36,6 +36,7 @@ OWNER_ID_KEY_PATH = CERTS_DIR / 'owner_id_pk.pem'
 DOMAIN_BASED_OWNER_ID_CERT_PATH = CERTS_DIR / 'domain_ca_owner_id.pem'
 DOMAIN_BASED_OWNER_ID_KEY_PATH = CERTS_DIR / 'domain_ca_owner_id_pk.pem'
 OWNER_CA_CERT_PATH = CERTS_DIR / 'ownerid_ca.pem'
+OWNER_CA_KEY_PATH = CERTS_DIR / 'ownerid_ca_pk.pem'
 
 IDEVID_TRUSTSTORE_UNIQUE_NAME = 'AokiIDevIDTruststore'
 DEVID_REGISTRATION_UNIQUE_NAME = 'AokiIDevIDRegistration'
@@ -176,7 +177,7 @@ class Command(CertificateCreationCommandMixin, LoggerMixin, BaseCommand):
         """Generates a domain-based DevOwnerID, pinning the certificate of the domain CA."""
         domain_ca_cert = domain_ca.get_certificate()
         owner_ca_cert = x509.load_pem_x509_certificate(OWNER_CA_CERT_PATH.read_bytes())
-        owner_ca_key = load_pem_private_key(OWNER_ID_KEY_PATH.read_bytes(), password=None)
+        owner_ca_key = load_pem_private_key(OWNER_CA_KEY_PATH.read_bytes(), password=None)
 
         AokiTestCertGenerator.generate_domain_ca_owner_id_cert(
             domain_ca_cert=domain_ca_cert,

--- a/trustpoint/aoki/management/commands/aoki_setup_idevid_test_env.py
+++ b/trustpoint/aoki/management/commands/aoki_setup_idevid_test_env.py
@@ -117,6 +117,7 @@ class Command(CertificateCreationCommandMixin, LoggerMixin, BaseCommand):
             OWNER_ID_CERT_PATH,
             OWNER_ID_KEY_PATH,
             OWNER_CA_CERT_PATH,
+            OWNER_CA_KEY_PATH,
         ]
         if not all(f.exists() for f in required_files):
             self.log_and_stdout('Test certificates not found - running aoki_gen_test_certs...')
@@ -188,6 +189,7 @@ class Command(CertificateCreationCommandMixin, LoggerMixin, BaseCommand):
             owner_ca_cert=owner_ca_cert,
             owner_ca_key=owner_ca_key,
         )
+
     def _get_or_create_idevid_truststore(self) -> TruststoreModel:
         """Return an existing IDevID truststore or create one from the generated IDevID CA cert."""
         if TruststoreModel.objects.filter(unique_name=IDEVID_TRUSTSTORE_UNIQUE_NAME).exists():

--- a/trustpoint/aoki/tests/cmp_client.py
+++ b/trustpoint/aoki/tests/cmp_client.py
@@ -109,6 +109,21 @@ class AokiCmpClient:
         return owner_san_uris or None
 
 
+    def _verify_matches_domain_ca_cert(self, owner_id_cert: x509.Certificate) -> None:
+        """Verify the Owner ID certificate is valid for the domain issuing CA certificate."""
+        print('Verifying Owner ID certificate matches Domain CA certificate')
+        candidate_ca_certs = self._load_certificates(CERTS_DIR / 'full_chain.pem')
+        for domain_ca_cert in candidate_ca_certs:
+            ca_sha256_fingerprint = domain_ca_cert.fingerprint(hashes.SHA256()).hex()
+            expected_san_uri = f'dev-owner:ca:{ca_sha256_fingerprint}'
+            for san in owner_id_cert.extensions.get_extension_for_oid(x509.ExtensionOID.SUBJECT_ALTERNATIVE_NAME).value:
+                if isinstance(san, x509.UniformResourceIdentifier) and san.value == expected_san_uri:
+                    print(f'Domain-based Owner ID certificate SAN URI matches Domain CA certificate {ca_sha256_fingerprint}!')
+                    return
+        exc_msg = 'Owner ID certificate does not match Domain CA certificate.'
+        raise AokiClientOwnerIdCertVerificationError(exc_msg)
+
+
     def _verify_matches_idevid_cert(self, owner_id_cert: x509.Certificate, idevid_cert: x509.Certificate) -> None:
         """Verify the Owner ID certificate is valid for the device IDevID."""
         print('Verifying Owner ID certificate matches IDevID certificate')
@@ -122,6 +137,7 @@ class AokiCmpClient:
                 print('Owner ID certificate SAN URI matches IDevID certificate!')
                 return
         exc_msg = 'Owner ID certificate does not match IDevID certificate.'
+        print(exc_msg)
         raise AokiClientOwnerIdCertVerificationError(exc_msg)
     
     def _discover_aoki_owner_service_mdns(self) -> None:
@@ -204,7 +220,10 @@ class AokiCmpClient:
         # Assuming first extraCert is the OwnerID / CMP signer cert, this is the case in the Trustpoint implementation
         owner_id_cert = self._load_certificates(CERTS_DIR / 'full_chain.pem')[0]
         idevid_cert = self._load_certificate(CERTS_DIR / self.cert_file)
-        self._verify_matches_idevid_cert(owner_id_cert, idevid_cert)
+        try:
+            self._verify_matches_idevid_cert(owner_id_cert, idevid_cert)
+        except AokiClientOwnerIdCertVerificationError as e:
+            self._verify_matches_domain_ca_cert(owner_id_cert)
 
         print('AOKI-CMP Client Onboarding completed successfully!')
         self.onboarding_completed = True

--- a/trustpoint/aoki/views.py
+++ b/trustpoint/aoki/views.py
@@ -25,6 +25,8 @@ from trustpoint.views.base import LoggedHttpResponse
 if TYPE_CHECKING:
     from django.http import HttpRequest
 
+    from pki.models.domain import DomainModel
+
 
 class AokiServiceMixin:
     """Mixin for AOKI functionality."""
@@ -68,6 +70,25 @@ class AokiServiceMixin:
             if not uri_refs:
                 return None
             owner_cred_ref = IDevIDReferenceModel.objects.filter(idevid_ref__in=uri_refs).first()
+        if not owner_cred_ref:
+            return None
+        owner_cred = owner_cred_ref.dev_owner_id
+        issued = owner_cred.dev_owner_id_credential
+        if issued is None:
+            return None
+        return issued.credential
+
+    @staticmethod
+    def get_domain_based_owner_credential(domain: DomainModel | None) -> CredentialModel | None:
+        """Get the domain-based (CA pinning) DevOwnerID credential for a given domain, or None if it does not exist."""
+        if not domain:
+            return None
+        try:
+            domain_ca_cert = domain.get_issuing_ca_or_value_error().get_certificate()
+        except ValueError:
+            return None
+        ca_sha256_fingerprint = domain_ca_cert.fingerprint(hashes.SHA256()).hex()
+        owner_cred_ref = IDevIDReferenceModel.objects.filter(idevid_ref=f'dev-owner:ca:{ca_sha256_fingerprint}').first()
         if not owner_cred_ref:
             return None
         owner_cred = owner_cred_ref.dev_owner_id

--- a/trustpoint/aoki/views.py
+++ b/trustpoint/aoki/views.py
@@ -87,6 +87,8 @@ class AokiServiceMixin:
             domain_ca_cert = domain.get_issuing_ca_or_value_error().get_certificate()
         except ValueError:
             return None
+        if not domain_ca_cert:
+            return None
         ca_sha256_fingerprint = domain_ca_cert.fingerprint(hashes.SHA256()).hex()
         owner_cred_ref = IDevIDReferenceModel.objects.filter(idevid_ref=f'dev-owner:ca:{ca_sha256_fingerprint}').first()
         if not owner_cred_ref:

--- a/trustpoint/help_pages/devices_help_views.py
+++ b/trustpoint/help_pages/devices_help_views.py
@@ -2039,6 +2039,8 @@ _AOKI_DEMO_CERT_FILES: list[tuple[str, str]] = [
     ('owner_id.pem', 'DevOwnerID Certificate'),
     ('owner_id_pk.pem', 'DevOwnerID Private Key'),
     ('ownerid_ca.pem', 'Owner CA Certificate'),
+    ('domain_ca_owner_id.pem', 'DevOwnerID (domain-based) Certificate'),
+    ('domain_ca_owner_id_pk.pem', 'DevOwnerID (domain-based) Private Key'),
 ]
 
 _AOKI_DEMO_CERTS_DIR: Path = (

--- a/trustpoint/pki/models/credential.py
+++ b/trustpoint/pki/models/credential.py
@@ -829,7 +829,7 @@ class IDevIDReferenceModel(models.Model):
             return ''
 
     @property
-def domain_ca_sha256_fingerprint(self) -> str:
+    def domain_ca_sha256_fingerprint(self) -> str:
         """Return the pinned domain CA SHA256 fingerprint from a ``dev-owner:ca:<sha256_hex>`` reference."""
         if not self.idevid_ref.startswith('dev-owner:ca:'):
             return ''

--- a/trustpoint/pki/models/credential.py
+++ b/trustpoint/pki/models/credential.py
@@ -828,6 +828,31 @@ class IDevIDReferenceModel(models.Model):
         except IndexError:
             return ''
 
+    @property
+    def domain_ca_sha256_fingerprint(self) -> str:
+        """Returns the domain pinned-CA SHA256 Fingerprint from the SAN of the DevOwnerID certificate.
+
+        Third dot-separated segment after stripping the ``dev-owner:`` prefix.
+        """
+        if not self.idevid_ref.startswith('dev-owner:ca:'):
+            return ''
+        try:
+            return self.idevid_ref.removeprefix('dev-owner:ca:')
+        except IndexError:
+            return ''
+
+    @property
+    def sha256_fingerprint_display(self) -> str:
+        """Returns the SHA256 Fingerprint for display purposes.
+
+        This property returns the SHA256 Fingerprint of the IDevID if available, otherwise that of the domain CA.
+        """
+        if fingerprint := self.idevid_sha256_fingerprint:
+            return fingerprint
+        if domain_fp := self.domain_ca_sha256_fingerprint:
+            return f'Pinned CA: {domain_fp}'
+        return ''
+
 
 class OwnerCredentialModel(LoggerMixin, CustomDeleteActionModel):
     """Device owner credential model.

--- a/trustpoint/pki/models/credential.py
+++ b/trustpoint/pki/models/credential.py
@@ -829,17 +829,11 @@ class IDevIDReferenceModel(models.Model):
             return ''
 
     @property
-    def domain_ca_sha256_fingerprint(self) -> str:
-        """Returns the domain pinned-CA SHA256 Fingerprint from the SAN of the DevOwnerID certificate.
-
-        Third dot-separated segment after stripping the ``dev-owner:`` prefix.
-        """
+def domain_ca_sha256_fingerprint(self) -> str:
+        """Return the pinned domain CA SHA256 fingerprint from a ``dev-owner:ca:<sha256_hex>`` reference."""
         if not self.idevid_ref.startswith('dev-owner:ca:'):
             return ''
-        try:
-            return self.idevid_ref.removeprefix('dev-owner:ca:')
-        except IndexError:
-            return ''
+        return self.idevid_ref.removeprefix('dev-owner:ca:')
 
     @property
     def sha256_fingerprint_display(self) -> str:

--- a/trustpoint/request/authorization/base.py
+++ b/trustpoint/request/authorization/base.py
@@ -228,7 +228,10 @@ class DevOwnerIDAuthorization(AuthorizationComponent, LoggerMixin):
             self.logger.warning('DevOwnerID authorization failed: Client certificate is missing')
             raise ValueError(error_message)
 
-        owner_credential = AokiServiceMixin.get_owner_credential(client_cert)
+        owner_credential = (
+            AokiServiceMixin.get_owner_credential(client_cert)
+            or AokiServiceMixin.get_domain_based_owner_credential(context.domain)
+        )
         if not owner_credential:
             err_msg = 'No DevOwnerID credential present for this IDevID.'
             context.http_response_content = err_msg

--- a/trustpoint/templates/devices/zero_touch_credentials/define_cert_content_est.html
+++ b/trustpoint/templates/devices/zero_touch_credentials/define_cert_content_est.html
@@ -61,7 +61,7 @@
                                             referencing an IDevID in the format:<br>
                                             <code>dev-owner:cert:&lt;IDevID_Subject_SN&gt;_&lt;IDevID_SHA256_Fingerprint&gt;</code> or<br>
                                             <code>dev-owner:uri:urn:uuid:&lt;Device UUID&gt;</code><br>
-                                            Example: <code>dev-owner:cert:SN-12345678_8a58abcdef123456789</code>
+                                            Example: <code>dev-owner:cert:SN-12345678_8a58abcdef123456789...</code>
                                             {% endblocktrans %}
                                         </small>
                                         {% endif %}

--- a/trustpoint/templates/devices/zero_touch_credentials/define_cert_content_est.html
+++ b/trustpoint/templates/devices/zero_touch_credentials/define_cert_content_est.html
@@ -59,8 +59,9 @@
                                             {% blocktrans %}
                                             One URI per line. The Zero-Touch Credential profile requires at least one URI
                                             referencing an IDevID in the format:<br>
-                                            <code>dev-owner:&lt;IDevID_Subject_SN&gt;.&lt;IDevID_X509_SN&gt;.&lt;IDevID_SHA256_Fingerprint&gt;</code><br>
-                                            Example: <code>dev-owner:SN-12345678.0123456789ABCDEF.AA:BB:CC:DD:EE:FF</code>
+                                            <code>dev-owner:cert:&lt;IDevID_Subject_SN&gt;_&lt;IDevID_SHA256_Fingerprint&gt;</code> or<br>
+                                            <code>dev-owner:uri:urn:uuid:&lt;Device UUID&gt;</code><br>
+                                            Example: <code>dev-owner:cert:SN-12345678_8a58abcdef123456789</code>
                                             {% endblocktrans %}
                                         </small>
                                         {% endif %}

--- a/trustpoint/templates/devices/zero_touch_credentials/details.html
+++ b/trustpoint/templates/devices/zero_touch_credentials/details.html
@@ -57,7 +57,7 @@
                 <tr>
                     <td>{{ ref.idevid_subject_serial_number|default:"—" }}</td>
                     <td>{{ ref.idevid_san_uri|default:"—" }}</td>
-                    <td class="small text-break">{{ ref.idevid_sha256_fingerprint|default:"—" }}</td>
+                    <td class="small text-break">{{ ref.sha256_fingerprint_display|default:"—" }}</td>
                     <td>
                         {% if ref.dev_owner_id_certificate %}
                             <a href="{% url 'pki:certificate-detail' pk=ref.dev_owner_id_certificate.pk %}">

--- a/trustpoint/templates/trustpoint/base.html
+++ b/trustpoint/templates/trustpoint/base.html
@@ -63,7 +63,7 @@
                 <a href="{% url 'devices:devices' %}" class="tp-menu-head {% if page_category == 'devices' %}tp-menu-active{% endif %}">
                     <svg class="bi" fill="currentColor" role="img">
                         <use href="{% static 'img/icons.svg' %}#icon-boxes"></use></svg>
-                    {% translate "Endpoints" %}
+                    {% translate "Devices" %}
                     <div class="btn-collapse" data-category="devices"
                         aria-expanded="{% if page_category == 'devices' %}true{% else %}false{% endif %}">
                     </div>


### PR DESCRIPTION
**Description of changes**
- [x] Generate domain-based CA pinning DevOwnerID in the test setup command
- [x] Dynamically use domain-based DevOwnerIDs if no DevOwnerID is present for the device IDevID
- [ ] Support requesting domain-based DevOwnerIDs externally via EST/CMP

**Notes** <!-- optional -->


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [x] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.