### PR TITLE
docs: explain every value in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,56 +4,141 @@
 #   cp .env.example .env
 #   $EDITOR .env
 #   docker compose up -d
+#
+# Every value below is optional: each one has a default, and Trustpoint starts
+# with none of them set. The defaults are chosen for local testing, so the ones
+# marked "development default" are the values to change before exposing an
+# instance to anything but your own machine.
+
+
+# ========================================================================
+# Startup phase
+# ========================================================================
+
+# Which phase the container entrypoint boots into.
+#   auto        - decide from the state on disk: operational if setup already
+#                 completed, bootstrap if not. This is what you want.
+#   bootstrap   - force the setup wizard, even if setup completed before.
+#   operational - force the normal application, skipping the wizard.
+# Any other value aborts startup. Leave this unset unless you are recovering
+# an instance whose on-disk state disagrees with what you expect.
+# TRUSTPOINT_PHASE=auto
+
+
+# ========================================================================
+# Database
+# ========================================================================
 
 # PostgreSQL connection used by the Trustpoint containers.
-# Development default: admin / testing321
-# Use a long, randomly generated password outside local testing:
+# DATABASE_PASSWORD is a development default. Use a long, randomly generated
+# password outside local testing:
 #   openssl rand -base64 32
+
+# Name of the database Trustpoint creates and connects to.
 POSTGRES_DB=trustpoint_db
+
+# Database role Trustpoint connects as. The postgres container creates this
+# role on first start, so changing it here changes both sides.
 DATABASE_USER=admin
+
+# Password for that role. Development default, change it.
 DATABASE_PASSWORD=testing321
+
+# Host to reach PostgreSQL on. `postgres` is the service name in
+# docker-compose.yml, which is what resolves inside the Compose network. Point
+# it at a hostname or address instead to use a database you run yourself.
 DATABASE_HOST=postgres
+
+# Port PostgreSQL listens on.
 DATABASE_PORT=5432
 
-# TLS Server Certificate Configuration
-# Comma-separated lists of addresses/names where Trustpoint is reachable.
+# Django database backend. The only reason to set this is to run against
+# something other than PostgreSQL, which is not a supported deployment.
+# DATABASE_ENGINE=django.db.backends.postgresql
+
+
+# ========================================================================
+# TLS server certificate and Django host checking
+# ========================================================================
+
+# Comma-separated lists of addresses and names where Trustpoint is reachable.
 # These are used for:
 # - Subject Alternative Names (SANs) in the TLS certificate
 # - Django ALLOWED_HOSTS and CSRF_TRUSTED_ORIGINS
+# A request arriving under a name that is not listed here is rejected by
+# Django before it reaches the application, so a deployment reachable under a
+# real hostname must list it or every request fails.
+# The values below are development defaults covering localhost only.
 # At least one value must be specified for production deployments.
 TP_TLS_IPV4_ADDRESSES=127.0.0.1
 TP_TLS_IPV6_ADDRESSES=::1
 TP_TLS_DNS_NAMES=localhost
 
-# HTTP and HTTPS ports for external access
-# Only include non-standard ports in CSRF_TRUSTED_ORIGINS (default: 80 for HTTP, 443 for HTTPS)
+# HTTP and HTTPS ports for external access. These set both the published
+# container ports and the ports used to build CSRF_TRUSTED_ORIGINS.
+# Only non-standard ports appear in CSRF_TRUSTED_ORIGINS (default: 80 for
+# HTTP, 443 for HTTPS).
 # TP_HTTP_PORT=80
 # TP_HTTPS_PORT=443
 
-# Optional mail settings. Leave EMAIL_HOST empty to use Django's console backend.
-# DEFAULT_FROM_EMAIL=no-reply@trustpoint.de
+
+# ========================================================================
+# Outgoing mail
+# ========================================================================
+
+# Mail is off by default: with EMAIL_HOST empty, Trustpoint uses Django's
+# console backend and prints messages to the log instead of sending them.
+# Setting EMAIL_HOST is what switches on the SMTP backend; the rest of the
+# values below are read only once it is set.
+
+# From address on messages Trustpoint sends.
+# DEFAULT_FROM_EMAIL=no-reply.trustpoint@localhost
+
+# SMTP server hostname. Empty means no mail is sent anywhere.
 # EMAIL_HOST=
+
+# SMTP port.
 # EMAIL_PORT=587
+
+# Transport security. Left unset, these follow the port: 587 implies STARTTLS
+# and 465 implies implicit TLS. Set one explicitly only if your server does
+# something else on that port.
 # EMAIL_USE_TLS=
 # EMAIL_USE_SSL=
+
+# SMTP credentials. Authentication is attempted only when both are non-empty,
+# so a relay that accepts unauthenticated mail needs neither.
 # EMAIL_HOST_USER=
 # EMAIL_HOST_PASSWORD=
+
+# Seconds to wait on the SMTP connection before giving up.
 # EMAIL_TIMEOUT=10
+
 
 # ========================================================================
 # Auto-Setup Configuration (Skip Setup Wizard)
 # ========================================================================
 # If TP_AUTO_SETUP=true, Trustpoint will automatically configure itself
 # from environment variables, bypassing the interactive setup wizard.
+# Intended for automated testing and repeatable demo environments. A normal
+# install should leave it off and use the wizard, which does not require the
+# admin password to be written to a file on disk.
 
 # Enable automatic setup from environment variables (true/false)
 # TP_AUTO_SETUP=false
 
 # Superuser credentials (REQUIRED if TP_AUTO_SETUP=true)
+# Startup fails if auto-setup is on and either is missing. Both are
+# development defaults.
 # TP_ADMIN_USERNAME=admin
 # TP_ADMIN_PASSWORD=testing321
 
+# Email address on the superuser account. Optional, blank if unset.
+# TP_ADMIN_EMAIL=
+
 # Inject demo data for testing (true/false)
+# Creates example devices and certificates. Development and demo only, never
+# on an instance holding real data.
 # TP_INJECT_DEMO_DATA=false
 
 # Note: When auto-setup is enabled, the TLS certificate will be automatically

--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,10 @@
 #   $EDITOR .env
 #   docker compose up -d
 #
-# Every value below is optional: each one has a default, and Trustpoint starts
-# with none of them set. The defaults are chosen for local testing, so the ones
-# marked "development default" are the values to change before exposing an
-# instance to anything but your own machine.
+# Every value below is optional unless explicitly marked as required. Most
+# have defaults suitable for local testing, so the ones marked "example
+# development value" are the ones to change before exposing an instance to
+# anything but your own machine.
 
 
 # ========================================================================
@@ -30,8 +30,8 @@
 # ========================================================================
 
 # PostgreSQL connection used by the Trustpoint containers.
-# DATABASE_PASSWORD is a development default. Use a long, randomly generated
-# password outside local testing:
+# DATABASE_USER and DATABASE_PASSWORD are example development values. Use a
+# long, randomly generated password outside local testing:
 #   openssl rand -base64 32
 
 # Name of the database Trustpoint creates and connects to.
@@ -41,7 +41,7 @@ POSTGRES_DB=trustpoint_db
 # role on first start, so changing it here changes both sides.
 DATABASE_USER=admin
 
-# Password for that role. Development default, change it.
+# Password for that role. Example development value, change it.
 DATABASE_PASSWORD=testing321
 
 # Host to reach PostgreSQL on. `postgres` is the service name in
@@ -68,7 +68,7 @@ DATABASE_PORT=5432
 # A request arriving under a name that is not listed here is rejected by
 # Django before it reaches the application, so a deployment reachable under a
 # real hostname must list it or every request fails.
-# The values below are development defaults covering localhost only.
+# The values below are example development values covering localhost only.
 # At least one value must be specified for production deployments.
 TP_TLS_IPV4_ADDRESSES=127.0.0.1
 TP_TLS_IPV6_ADDRESSES=::1
@@ -128,8 +128,8 @@ TP_TLS_DNS_NAMES=localhost
 # TP_AUTO_SETUP=false
 
 # Superuser credentials (REQUIRED if TP_AUTO_SETUP=true)
-# Startup fails if auto-setup is on and either is missing. Both are
-# development defaults.
+# Startup fails if auto-setup is on and either is missing. Both are example
+# development values.
 # TP_ADMIN_USERNAME=admin
 # TP_ADMIN_PASSWORD=testing321
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -37,6 +37,7 @@ Full Name is required, all other fields are optional.
 ## Project Authors
 
 * Alexander Harig
+* Chirag Gupta (chiruu12)
 * Christian Schwinne (Aircoookie) <christian.schwinne A hshl.de> - Hamm-Lippstadt University of Applied Sciences
 * Dominik Isaak
 * Florian Handke (FHatCSW) <florian.handke A campus-schwarzwald.de> - Campus Schwarzwald gGmbH


### PR DESCRIPTION
Closes #876.

Every value in `.env.example` now says what it controls, and the ones whose defaults only make sense locally are marked as development defaults rather than left to look production-ready.

Three variables added, not seven. In my comment on the issue I listed seven that a normal deployment might want. Checking the Compose files rather than just the code, four of those were wrong.

Added:

- `TRUSTPOINT_PHASE`, substituted from `.env` by `docker-compose.yml`, with the three accepted values. Anything else exits 64 in `entrypoint.sh`.
- `DATABASE_ENGINE`, the only switch away from PostgreSQL.
- `TP_ADMIN_EMAIL`, read by `auto_setup_from_env` alongside the two admin variables already documented, and previously missing.

Not added: `TRUSTPOINT_HSM_ROOT` and the four `TRUSTPOINT_LOCAL_HSM_*` names. I claimed an operator meets these on the SoftHSM path with no explanation. They meet them, but they cannot set them. `docker-compose.softhsm.yml` hardcodes all five under `environment:` and has no `env_file:` at all, so a value put in `.env` is ignored. Documenting them here would teach a knob that does nothing. If they should be configurable that is a change to the Compose file and a separate issue.

One correction while going through the values. The example gave `no-reply@trustpoint.de` as the `DEFAULT_FROM_EMAIL` default. The real default is `no-reply.trustpoint@localhost` (`settings.py:337`). There is a second assignment at `settings.py:269` with a third value, inside the `else` branch of `if DEBUG`, but line 337 runs after it and overwrites it unconditionally, so 269 has no effect. I have only fixed the comment here and left the code alone.

Two behaviours documented that are not obvious from the variable names:

- `EMAIL_USE_TLS` and `EMAIL_USE_SSL` derive from `EMAIL_PORT` when unset, 587 meaning STARTTLS and 465 meaning implicit TLS.
- SMTP authentication is attempted only when `EMAIL_HOST_USER` and `EMAIL_HOST_PASSWORD` are both non-empty.

Structure and variable order are unchanged apart from the added section headers.

Added myself to `AUTHORS.md` per CONTRIBUTING.