### PR TITLE
docs: improve .env.example with per-variable explanations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,33 +4,62 @@
 #   cp .env.example .env
 #   $EDITOR .env
 #   docker compose up -d
+#
+# Notation:
+#   [dev]  Default value is intended for local development/testing only.
+#   [prod] Value should be changed for normal/production deployments.
 
+# ---------------------------------------------------------------------------
 # PostgreSQL connection used by the Trustpoint containers.
-# Development default: admin / testing321
-# Use a long, randomly generated password outside local testing:
-#   openssl rand -base64 32
+# ---------------------------------------------------------------------------
+# Database name. [prod] Keep, or rename to match your naming convention.
 POSTGRES_DB=trustpoint_db
+
+# Application database user. [prod] Use a dedicated user, not an admin superuser.
 DATABASE_USER=admin
+
+# Password for DATABASE_USER. [dev] Default "testing321" is for local testing ONLY.
+# [prod] Generate a long, random password:
+#   openssl rand -base64 32
 DATABASE_PASSWORD=testing321
+
+# PostgreSQL service hostname as seen from inside the Docker network.
+# [prod] Change only if you run PostgreSQL on a separate host.
 DATABASE_HOST=postgres
+
+# PostgreSQL port. [prod] Change only if PostgreSQL listens on a non-standard port.
 DATABASE_PORT=5432
 
+# ---------------------------------------------------------------------------
 # TLS Server Certificate Configuration
+# ---------------------------------------------------------------------------
 # Comma-separated lists of addresses/names where Trustpoint is reachable.
 # These are used for:
 # - Subject Alternative Names (SANs) in the TLS certificate
 # - Django ALLOWED_HOSTS and CSRF_TRUSTED_ORIGINS
 # At least one value must be specified for production deployments.
+# [dev] 127.0.0.1 / ::1 / localhost cover local access.
+# [prod] Replace with the real hostnames/IPs clients use to reach Trustpoint.
 TP_TLS_IPV4_ADDRESSES=127.0.0.1
 TP_TLS_IPV6_ADDRESSES=::1
 TP_TLS_DNS_NAMES=localhost
 
+# ---------------------------------------------------------------------------
 # HTTP and HTTPS ports for external access
-# Only include non-standard ports in CSRF_TRUSTED_ORIGINS (default: 80 for HTTP, 443 for HTTPS)
+# ---------------------------------------------------------------------------
+# Only include non-standard ports in CSRF_TRUSTED_ORIGINS
+# (default: 80 for HTTP, 443 for HTTPS).
+# [dev] Leave commented out to use the defaults.
+# [prod] Uncomment and set to your published ports if they differ from 80/443.
 # TP_HTTP_PORT=80
 # TP_HTTPS_PORT=443
 
-# Optional mail settings. Leave EMAIL_HOST empty to use Django's console backend.
+# ---------------------------------------------------------------------------
+# Optional mail settings
+# ---------------------------------------------------------------------------
+# Leave EMAIL_HOST empty to use Django's console backend (logs emails to stdout).
+# [dev] Console backend is the default — no real emails are sent.
+# [prod] Fill in a real SMTP server and set EMAIL_USE_TLS=1 (or EMAIL_USE_SSL=1).
 # DEFAULT_FROM_EMAIL=no-reply@trustpoint.de
 # EMAIL_HOST=
 # EMAIL_PORT=587
@@ -39,7 +68,6 @@ TP_TLS_DNS_NAMES=localhost
 # EMAIL_HOST_USER=
 # EMAIL_HOST_PASSWORD=
 # EMAIL_TIMEOUT=10
-
 # ========================================================================
 # Auto-Setup Configuration (Skip Setup Wizard)
 # ========================================================================


### PR DESCRIPTION
## Summary

Improves `.env.example` readability for first-time installers per the task requirements:
- Adds a short explanation for each configurable value
- Clarifies options whose purpose is not obvious from the variable name (e.g. `DATABASE_HOST`, `TP_TLS_*`, mail settings)
- Marks every default as `[dev]` (development/testing) or `[prod]` (change for production), e.g. `DATABASE_PASSWORD` default is explicitly called out as local-testing-only with an `openssl rand` command for production
- Groups related variables under section headers

## Changes

- `.env.example`: restructured comments, added per-variable docs, `[dev]`/`[prod]` markers, kept all variable names and values identical

## Acceptance criteria

- [x] Short explanation for each configurable value added
- [x] Purpose clarified where not obvious from the name
- [x] Defaults marked as dev vs production intent
- [x] No variable names or values changed (comment-only diff)