### PR TITLE
Add comprehensive tests for help page views and CSRF token filter

### DIFF
--- a/trustpoint/help_pages/tests/test_commands.py
+++ b/trustpoint/help_pages/tests/test_commands.py
@@ -3,15 +3,21 @@
 
 """Test cases for help_pages commands module."""
 
+from unittest.mock import Mock
+
 from django.test import SimpleTestCase
 from trustpoint_core import oid
 
 from ..commands import (
+    AokiCmpIDevIDCommandBuilder,
+    AokiEstIDevIDCommandBuilder,
     CmpClientCertificateCommandBuilder,
     CmpSharedSecretCommandBuilder,
     EstClientCertificateCommandBuilder,
     EstUsernamePasswordCommandBuilder,
     KeyGenCommandBuilder,
+    RestClientCertificateCommandBuilder,
+    RestUsernamePasswordCommandBuilder,
 )
 
 
@@ -88,6 +94,39 @@ class KeyGenCommandBuilderTests(SimpleTestCase):
         assert 'openssl ecparam' in cmd
         assert '-name secp384r1' in cmd
 
+    def test_get_key_gen_command_ecc_without_named_curve_raises(self) -> None:
+        """Test ECC key generation requires a named curve."""
+        public_key_info = Mock(public_key_algorithm_oid=oid.PublicKeyAlgorithmOid.ECC, named_curve=None)
+
+        with self.assertRaises(ValueError) as cm:
+            KeyGenCommandBuilder.get_key_gen_command(public_key_info, cred_number=1)
+
+        assert 'named curve' in str(cm.exception)
+
+    def test_get_key_gen_command_mldsa_variants(self) -> None:
+        """Test post-quantum ML-DSA key generation variants."""
+        expected_algorithms = {
+            oid.PublicKeyAlgorithmOid.ML_DSA_44: 'ML-DSA-44',
+            oid.PublicKeyAlgorithmOid.ML_DSA_65: 'ML-DSA-65',
+            oid.PublicKeyAlgorithmOid.ML_DSA_87: 'ML-DSA-87',
+        }
+
+        for algorithm_oid, openssl_algorithm in expected_algorithms.items():
+            public_key_info = oid.PublicKeyInfo(public_key_algorithm_oid=algorithm_oid)
+            cmd = KeyGenCommandBuilder.get_key_gen_command(public_key_info, cred_number=7)
+
+            assert f'openssl genpkey -algorithm {openssl_algorithm}' in cmd
+            assert '-out key-7.pem' in cmd
+
+    def test_get_key_gen_command_unsupported_algorithm_raises(self) -> None:
+        """Test unsupported key algorithms fail explicitly."""
+        public_key_info = oid.PublicKeyInfo(public_key_algorithm_oid=object())
+
+        with self.assertRaises(ValueError) as cm:
+            KeyGenCommandBuilder.get_key_gen_command(public_key_info, cred_number=1)
+
+        assert 'Unsupported public key algorithm' in str(cm.exception)
+
 
 class CmpSharedSecretCommandBuilderTests(SimpleTestCase):
     """Test cases for CmpSharedSecretCommandBuilder."""
@@ -155,6 +194,20 @@ class CmpSharedSecretCommandBuilderTests(SimpleTestCase):
         assert '-ref 789' in cmd
         assert cmd is not None
 
+    def test_get_app_cert_self_revoke_command(self) -> None:
+        """Test CMP self-revocation command uses local credential files."""
+        cmd = CmpSharedSecretCommandBuilder.get_app_cert_self_revoke_command(
+            host='https://127.0.0.1/.well-known/cmp/p/test/revocation',
+            cred_number=4,
+        )
+
+        assert '-cmd rr' in cmd
+        assert '-cert certificate-4.pem' in cmd
+        assert '-key key-4.pem' in cmd
+        assert '-oldcert certificate-4.pem' in cmd
+        assert '-revreason 0' in cmd
+        assert '-trusted full-chain-4.pem' in cmd
+
 
 class EstUsernamePasswordCommandBuilderTests(SimpleTestCase):
     """Test cases for EstUsernamePasswordCommandBuilder."""
@@ -212,6 +265,35 @@ class EstUsernamePasswordCommandBuilderTests(SimpleTestCase):
 
         assert 'certutil -f -decode certificate-1.p7c certificate-1.p7b' in cmd
         assert 'openssl pkcs7 -inform DER -in certificate-1.p7b -print_certs -out certificate-1.pem' in cmd
+
+    def test_get_curl_enroll_windows_command(self) -> None:
+        """Test Windows-friendly EST curl command."""
+        cmd = EstUsernamePasswordCommandBuilder.get_curl_enroll_windows_command(
+            est_username='device-1',
+            est_password='secret-value',
+            host='https://example.test/.well-known/est/domain/app/simpleenroll',
+            cred_number=5,
+        )
+
+        assert cmd.startswith('curl.exe --user "device-1:secret-value" ^')
+        assert '--data-binary "@csr-5.der"' in cmd
+        assert '-o certificate-5.p7c' in cmd
+
+    def test_get_domain_credential_est_commands(self) -> None:
+        """Test EST username/password domain credential command helpers."""
+        csr_cmd = EstUsernamePasswordCommandBuilder.get_domain_credential_profile_command()
+        enroll_cmd = EstUsernamePasswordCommandBuilder.get_curl_enroll_domain_credential_command(
+            est_username='device-1',
+            est_password='secret-value',
+            host='https://example.test/.well-known/est/domain/domain_credential/simpleenroll/',
+        )
+        convert_cmd = EstUsernamePasswordCommandBuilder.get_domain_credential_conversion_p7_pem_command()
+
+        assert '-out csr-domain-credential.der' in csr_cmd
+        assert '--user "device-1:secret-value"' in enroll_cmd
+        assert '@csr-domain-credential.der' in enroll_cmd
+        assert 'domain-credential-certificate.p7c' in enroll_cmd
+        assert 'domain-credential-certificate.pem' in convert_cmd
 
 
 class CmpClientCertificateCommandBuilderTests(SimpleTestCase):
@@ -293,3 +375,163 @@ class EstClientCertificateCommandBuilderTests(SimpleTestCase):
 
         assert 'curl' in cmd
         assert 'https://127.0.0.1/.well-known/est/test/cacerts' in cmd
+
+    def test_get_idevid_enroll_and_conversion_commands(self) -> None:
+        """Test EST IDevID enrollment and conversion command helpers."""
+        enroll_cmd = EstClientCertificateCommandBuilder.get_idevid_enroll_domain_credential_command(
+            host='https://example.test/.well-known/est/domain/simpleenroll',
+        )
+        der_cmd = EstClientCertificateCommandBuilder.get_idevid_der_pem_conversion_command()
+        pkcs7_cmd = EstClientCertificateCommandBuilder.get_idevid_pkcs7_pem_conversion_command()
+
+        assert '--cert idevid.pem' in enroll_cmd
+        assert '--key idevid.key' in enroll_cmd
+        assert '@domain_credential_csr.der' in enroll_cmd
+        assert 'openssl x509' in der_cmd
+        assert '-inform der' in der_cmd
+        assert 'openssl pkcs7' in pkcs7_cmd
+        assert '-in cacerts.p7b' in pkcs7_cmd
+
+
+class AokiCmpIDevIDCommandBuilderTests(SimpleTestCase):
+    """Test cases for AOKI CMP command builders."""
+
+    def test_get_keygen_command(self) -> None:
+        """Test AOKI CMP domain credential key generation."""
+        cmd = AokiCmpIDevIDCommandBuilder.get_keygen_command()
+
+        assert 'openssl genrsa' in cmd
+        assert 'domain_credential_key.pem' in cmd
+        assert '2048' in cmd
+
+    def test_get_cmp_ir_command(self) -> None:
+        """Test AOKI CMP initial request command."""
+        cmd = AokiCmpIDevIDCommandBuilder.get_cmp_ir_command('https://example.test/cmp/init')
+
+        assert '-cmd ir' in cmd
+        assert '-server https://example.test/cmp/init' in cmd
+        assert '-cert idevid.pem' in cmd
+        assert '-trusted ownerid_ca.pem' in cmd
+
+
+class AokiEstIDevIDCommandBuilderTests(SimpleTestCase):
+    """Test cases for AOKI EST command builders."""
+
+    def test_get_aoki_init_command_and_response_example(self) -> None:
+        """Test AOKI EST initialization command and response sample."""
+        cmd = AokiEstIDevIDCommandBuilder.get_aoki_init_command('https://example.test')
+        response_example = AokiEstIDevIDCommandBuilder.get_aoki_init_response_example('domain_credential_custom')
+
+        assert 'curl --cert idevid.pem' in cmd
+        assert 'https://example.test/aoki/init' in cmd
+        assert '"protocol": "EST"' in response_example
+        assert 'domain_credential_custom/simpleenroll' in response_example
+
+    def test_get_est_enrollment_commands(self) -> None:
+        """Test AOKI EST key, CSR, and enrollment commands."""
+        key_cmd = AokiEstIDevIDCommandBuilder.get_keygen_command()
+        csr_cmd = AokiEstIDevIDCommandBuilder.get_csr_command()
+        enroll_cmd = AokiEstIDevIDCommandBuilder.get_curl_enroll_command('https://example.test/est/enroll')
+
+        assert 'domain_credential_key.pem' in key_cmd
+        assert '-outform DER' in csr_cmd
+        assert '-out domain_credential.der' in csr_cmd
+        assert '--cert domain-credential-cert.pem' in enroll_cmd
+        assert '@domain_credential.der' in enroll_cmd
+
+
+class RestUsernamePasswordCommandBuilderTests(SimpleTestCase):
+    """Test cases for REST username/password command builders."""
+
+    def test_get_dynamic_cert_profile_command_with_sans(self) -> None:
+        """Test REST CSR generation for application certificates."""
+        sample_request = {
+            'subject': {'CN': 'Device 1'},
+            'extensions': {
+                'subject_alternative_name': {
+                    'dns_names': ['device.example.test'],
+                },
+            },
+        }
+
+        cmd = RestUsernamePasswordCommandBuilder.get_dynamic_cert_profile_command(
+            cred_number=3,
+            sample_request=sample_request,
+        )
+
+        assert 'openssl req' in cmd
+        assert '-key key-3.pem' in cmd
+        assert '-out csr-3.pem' in cmd
+        assert 'subjectAltName' in cmd
+
+    def test_get_rest_enroll_and_extract_commands(self) -> None:
+        """Test REST username/password enrollment helpers."""
+        enroll_cmd = RestUsernamePasswordCommandBuilder.get_curl_enroll_command(
+            rest_username='device-1',
+            rest_password='secret-value',
+            host='https://example.test/rest/domain/profile/enroll/',
+            cred_number=3,
+        )
+        extract_cmd = RestUsernamePasswordCommandBuilder.get_extract_cert_command(cred_number=3)
+
+        assert '--user "device-1:secret-value"' in enroll_cmd
+        assert 'Content-Type: application/json' in enroll_cmd
+        assert 'csr-3.pem' in enroll_cmd
+        assert 'certificate-3.json' in enroll_cmd
+        assert extract_cmd == 'jq -r .certificate certificate-3.json > certificate-3.pem'
+
+    def test_get_domain_credential_rest_commands(self) -> None:
+        """Test REST username/password domain credential helpers."""
+        csr_cmd = RestUsernamePasswordCommandBuilder.get_domain_credential_csr_command()
+        enroll_cmd = RestUsernamePasswordCommandBuilder.get_curl_enroll_domain_credential_command(
+            rest_username='device-1',
+            rest_password='secret-value',
+            host='https://example.test/rest/domain/domain_credential/enroll/',
+        )
+        extract_cmd = RestUsernamePasswordCommandBuilder.get_extract_domain_credential_command()
+
+        assert 'csr-domain-credential.pem' in csr_cmd
+        assert '--user "device-1:secret-value"' in enroll_cmd
+        assert 'domain-credential-certificate.json' in enroll_cmd
+        assert extract_cmd.endswith('domain-credential-certificate.pem')
+
+
+class RestClientCertificateCommandBuilderTests(SimpleTestCase):
+    """Test cases for REST mTLS command builders."""
+
+    def test_get_dynamic_cert_profile_command_without_sans(self) -> None:
+        """Test REST mTLS CSR generation without SANs."""
+        cmd = RestClientCertificateCommandBuilder.get_dynamic_cert_profile_command(
+            cred_number=6,
+            sample_request={'subject': {'CN': 'Device 6'}},
+        )
+
+        assert '-key key-6.pem' in cmd
+        assert '-out csr-6.pem' in cmd
+        assert 'subjectAltName' not in cmd
+
+    def test_get_curl_enroll_and_reenroll_commands_include_dev_header(self) -> None:
+        """Test REST mTLS curl commands include the development client-cert header."""
+        enroll_cmd = RestClientCertificateCommandBuilder.get_curl_enroll_command(
+            host='https://example.test/rest/domain/profile/enroll/',
+            cred_number=6,
+        )
+        reenroll_cmd = RestClientCertificateCommandBuilder.get_curl_reenroll_command(
+            host='https://example.test/rest/domain/profile/reenroll/',
+            cred_number=6,
+        )
+
+        assert 'SSL-CLIENT-CERT: ${CERT_HEADER}' in enroll_cmd
+        assert 'certificate-6.json' in enroll_cmd
+        assert 'https://example.test/rest/domain/profile/enroll/' in enroll_cmd
+        assert 'SSL-CLIENT-CERT: ${CERT_HEADER}' in reenroll_cmd
+        assert 'https://example.test/rest/domain/profile/reenroll/' in reenroll_cmd
+
+    def test_get_extract_response_commands(self) -> None:
+        """Test REST mTLS JSON extraction commands."""
+        assert RestClientCertificateCommandBuilder.get_extract_cert_command(8) == (
+            'jq -r .certificate certificate-8.json > certificate-8.pem'
+        )
+        assert RestClientCertificateCommandBuilder.get_extract_cert_chain_command(8) == (
+            "jq -r '.certificate_chain[]' certificate-8.json > certificate-chain-8.pem"
+        )

--- a/trustpoint/help_pages/tests/test_csrf_token_filter.py
+++ b/trustpoint/help_pages/tests/test_csrf_token_filter.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026 The Trustpoint Project Authors
+# SPDX-License-Identifier: MIT
+
+"""Test cases for the help page CSRF template filter."""
+
+from unittest.mock import patch
+
+from django.template import Context, Template
+from django.test import RequestFactory, SimpleTestCase, override_settings
+from django.utils.safestring import SafeString
+
+from ..templatetags.csrf_token_filter import replace_csrf
+
+
+class ReplaceCsrfFilterTests(SimpleTestCase):
+    """Test cases for replacing CSRF placeholders in help page HTML."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.request = RequestFactory().post('/help/')
+
+    @patch('help_pages.templatetags.csrf_token_filter.get_token', return_value='csrf-token-value')
+    def test_replaces_placeholder_with_hidden_input(self, mock_get_token) -> None:  # type: ignore[no-untyped-def]
+        """Test a placeholder is replaced with the request CSRF token input."""
+        result = replace_csrf('<form>CSRF_TOKEN_PLACEHOLDER<button>Go</button></form>', self.request)
+
+        assert isinstance(result, SafeString)
+        assert 'CSRF_TOKEN_PLACEHOLDER' not in result
+        assert 'name="csrfmiddlewaretoken"' in result
+        assert 'value="csrf-token-value"' in result
+        mock_get_token.assert_called_once_with(self.request)
+
+    @patch('help_pages.templatetags.csrf_token_filter.get_token')
+    def test_value_without_placeholder_is_returned_safe_without_token_lookup(self, mock_get_token) -> None:  # type: ignore[no-untyped-def]
+        """Test values without placeholders are marked safe unchanged."""
+        result = replace_csrf('<p>No form here</p>', self.request)
+
+        assert isinstance(result, SafeString)
+        assert result == '<p>No form here</p>'
+        mock_get_token.assert_not_called()
+
+    @patch('help_pages.templatetags.csrf_token_filter.get_token', return_value='csrf-token-value')
+    def test_empty_value_is_safe_empty_string(self, mock_get_token) -> None:  # type: ignore[no-untyped-def]
+        """Test an empty value stays empty and does not request a token."""
+        result = replace_csrf('', self.request)
+
+        assert isinstance(result, SafeString)
+        assert result == ''
+        mock_get_token.assert_not_called()
+
+    @patch('help_pages.templatetags.csrf_token_filter.get_token', return_value='token<&>')
+    def test_csrf_token_value_is_escaped(self, mock_get_token) -> None:  # type: ignore[no-untyped-def]
+        """Test the inserted token is escaped before being marked safe."""
+        result = replace_csrf('CSRF_TOKEN_PLACEHOLDER', self.request)
+
+        assert 'token&lt;&amp;&gt;' in result
+        assert 'token<&>' not in result
+        mock_get_token.assert_called_once_with(self.request)
+
+    @override_settings(TEMPLATES=[{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'APP_DIRS': True}])
+    def test_filter_can_be_used_from_template(self) -> None:
+        """Test the registered filter works through Django's template engine."""
+        template = Template('{% load csrf_token_filter %}{{ value|replace_csrf:request }}')
+
+        with patch('help_pages.templatetags.csrf_token_filter.get_token', return_value='template-token'):
+            rendered = template.render(
+                Context({'value': '<form>CSRF_TOKEN_PLACEHOLDER</form>', 'request': self.request})
+            )
+
+        assert 'csrfmiddlewaretoken' in rendered
+        assert 'template-token' in rendered

--- a/trustpoint/help_pages/tests/test_devices_help_views.py
+++ b/trustpoint/help_pages/tests/test_devices_help_views.py
@@ -9,10 +9,19 @@ from unittest.mock import Mock, patch
 
 from django.http import Http404
 from django.test import RequestFactory, TestCase
+from trustpoint_core import oid
 
 from devices.models import DeviceModel
+from ..base import HelpContext
 from ..devices_help_views import (
+    AgentSetupProfileStrategy,
+    ApplicationCertificateWithCmpDomainCredentialStrategy,
+    ApplicationCertificateWithEstDomainCredentialStrategy,
+    ApplicationCertificateWithRestDomainCredentialStrategy,
+    AokiCmpIDevIDStrategy,
+    AokiEstIDevIDStrategy,
     BaseHelpView,
+    CmpRevocationStrategy,
     DeviceApplicationCertificateWithCmpDomainCredentialHelpView,
     DeviceApplicationCertificateWithEstDomainCredentialHelpView,
     DeviceNoOnboardingCmpSharedSecretHelpView,
@@ -21,13 +30,98 @@ from ..devices_help_views import (
     DeviceOnboardingDomainCredentialEstUsernamePasswordHelpView,
     NoOnboardingCmpSharedSecretStrategy,
     NoOnboardingEstUsernamePasswordStrategy,
+    NoOnboardingRestUsernamePasswordStrategy,
     OnboardingDomainCredentialCmpSharedSecretStrategy,
     OnboardingDomainCredentialEstUsernamePasswordStrategy,
+    OnboardingDomainCredentialRestUsernamePasswordStrategy,
+    OpcUaGdsPushApplicationCertificateStrategy,
     OpcUaGdsPushApplicationCertificateHelpView,
     OpcUaGdsPushOnboardingHelpView,
     OpcUaGdsPushOnboardingStrategy,
+    _agent_get_est_password,
 )
-from ..help_section import ValueRenderType
+from ..help_section import HelpSection, ValueRenderType
+
+
+def _public_key_info() -> oid.PublicKeyInfo:
+    """Return a reusable RSA public-key descriptor for help contexts."""
+    return oid.PublicKeyInfo(
+        public_key_algorithm_oid=oid.PublicKeyAlgorithmOid.RSA,
+        key_size=2048,
+    )
+
+
+def _sample_request() -> dict[str, object]:
+    """Return a representative certificate profile sample request."""
+    return {
+        'subject': {'CN': 'Device 1'},
+        'validity': {'days': 30},
+        'extensions': {
+            'subject_alternative_name': {
+                'dns_names': ['device.example.test'],
+            },
+        },
+    }
+
+
+def _profile(unique_name: str = 'tls_server', display_name: str = 'TLS Server', alias: str | None = None) -> Mock:
+    """Return a lightweight allowed certificate profile mock."""
+    profile = Mock()
+    profile.alias = alias
+    profile.certificate_profile.unique_name = unique_name
+    profile.certificate_profile.display_name = display_name
+    profile.certificate_profile.profile = {'profile': unique_name}
+    return profile
+
+
+def _domain() -> Mock:
+    """Return a lightweight domain mock."""
+    domain = Mock()
+    domain.unique_name = 'test-domain'
+    domain.public_key_info = _public_key_info()
+    domain.get_domain_credential_profile_name.return_value = 'domain_credential'
+    return domain
+
+
+def _device(domain: Mock, *, no_onboarding: bool = False, onboarding: bool = False) -> Mock:
+    """Return a lightweight device mock with optional onboarding configs."""
+    device = Mock()
+    device.pk = 123
+    device.common_name = 'device-1'
+    device.domain = domain
+    device.no_onboarding_config = None
+    device.onboarding_config = None
+    if no_onboarding:
+        device.no_onboarding_config = Mock(cmp_shared_secret='cmp-secret', est_password='rest-secret')
+    if onboarding:
+        device.onboarding_config = Mock(cmp_shared_secret='cmp-secret', est_password='rest-secret')
+    return device
+
+
+def _help_context(
+    device: Mock,
+    domain: Mock | None,
+    profiles: list[Mock] | None = None,
+    *,
+    cred_count: int = 2,
+) -> HelpContext:
+    """Return a realistic help context for strategy tests."""
+    return HelpContext(
+        device=device,
+        domain=domain,
+        domain_unique_name='test-domain',
+        allowed_app_profiles=profiles or [],
+        public_key_info=_public_key_info(),
+        host_base='https://trustpoint.test:8443',
+        host_cmp_path='https://trustpoint.test:8443/.well-known/cmp/p/test-domain',
+        host_est_path='https://trustpoint.test:8443/.well-known/est/test-domain',
+        cred_count=cred_count,
+    )
+
+
+def _section(heading: str = 'Patched Section') -> HelpSection:
+    """Return a simple replacement for helper sections that hit unrelated database state."""
+    return HelpSection(heading, [])
 
 
 class BaseHelpViewTests(TestCase):
@@ -646,3 +740,345 @@ class OpcUaGdsPushOnboardingHelpViewTests(TestCase):
         view = OpcUaGdsPushOnboardingHelpView()
         assert isinstance(view.strategy, OpcUaGdsPushOnboardingStrategy)
         assert view.page_name == 'devices'
+
+
+class DeviceStrategyGeneratedContentTests(TestCase):
+    """Test generated help content for device strategies without masking the strategy code."""
+
+    @patch('help_pages.devices_help_views.JSONProfileVerifier')
+    def test_no_onboarding_cmp_shared_secret_builds_profile_commands(self, mock_verifier: Mock) -> None:
+        """Test CMP shared-secret sections include profile-specific commands and hidden state."""
+        mock_verifier.return_value.get_sample_request.return_value = _sample_request()
+        domain = _domain()
+        device = _device(domain, no_onboarding=True)
+        profiles = [_profile(alias='server_alias'), _profile('client_auth', 'Client Auth')]
+
+        sections, heading = NoOnboardingCmpSharedSecretStrategy().build_sections(_help_context(device, domain, profiles))
+
+        assert 'CMP with a shared-secret' in heading
+        assert sections[0].rows[3].value == 'cmp-secret'
+        assert sections[3].css_id == 'server_alias'
+        assert sections[3].hidden is False
+        assert sections[4].css_id == 'client_auth'
+        assert sections[4].hidden is True
+        assert 'server_alias/certification' in sections[3].rows[0].value
+        assert '-secret pass:cmp-secret' in sections[3].rows[0].value
+
+    @patch('help_pages.devices_help_views.JSONProfileVerifier', side_effect=ValueError('invalid profile'))
+    def test_no_onboarding_cmp_shared_secret_reports_malformed_profile(self, mock_verifier: Mock) -> None:
+        """Test malformed CMP profiles produce a visible error row instead of a command."""
+        domain = _domain()
+        device = _device(domain, no_onboarding=True)
+
+        sections, _heading = NoOnboardingCmpSharedSecretStrategy().build_sections(
+            _help_context(device, domain, [_profile()])
+        )
+
+        assert sections[3].rows[0].value_render_type == ValueRenderType.PLAIN
+        assert 'Certificate Profile is malformed' in sections[3].rows[0].value
+        mock_verifier.assert_called_once()
+
+    @patch('help_pages.devices_help_views.build_tls_trust_store_section', return_value=_section('TLS'))
+    @patch('help_pages.devices_help_views.JSONProfileVerifier')
+    def test_no_onboarding_est_username_password_builds_linux_and_windows_steps(
+        self, mock_verifier: Mock, mock_tls: Mock
+    ) -> None:
+        """Test EST username/password help includes enrollment and platform conversion commands."""
+        mock_verifier.return_value.get_sample_request.return_value = _sample_request()
+        domain = _domain()
+        device = _device(domain, no_onboarding=True)
+
+        sections, heading = NoOnboardingEstUsernamePasswordStrategy().build_sections(
+            _help_context(device, domain, [_profile(alias='server_alias')], cred_count=4)
+        )
+
+        assert 'EST with username and password' in heading
+        assert mock_tls.called
+        profile_section = sections[4]
+        assert profile_section.css_id == 'server_alias'
+        assert [row.key for row in profile_section.rows] == [
+            'Generate CSR with OpenSSL',
+            'Enroll certificate with curl',
+            'Convert certificate to PEM (Linux/OpenSSL)',
+            'Convert certificate to PEM (Windows, certutil & OpenSSL)',
+            'Install certificate into Windows store (certutil)',
+        ]
+        assert '--user "device-1:rest-secret"' in profile_section.rows[1].value
+        assert 'certificate-4.p7c' in profile_section.rows[1].value
+        assert sections[-1].css_class == 'platform-linux'
+
+    @patch('help_pages.devices_help_views.build_cmp_signer_trust_store_section', return_value=_section('CMP Signer'))
+    @patch('help_pages.devices_help_views.JSONProfileVerifier')
+    def test_application_cmp_domain_credential_builds_commands(self, mock_verifier: Mock, mock_cmp: Mock) -> None:
+        """Test application CMP help builds mTLS profile commands."""
+        mock_verifier.return_value.get_sample_request.return_value = _sample_request()
+        domain = _domain()
+        device = _device(domain, onboarding=True)
+
+        sections, heading = ApplicationCertificateWithCmpDomainCredentialStrategy().build_sections(
+            _help_context(device, domain, [_profile()], cred_count=5)
+        )
+
+        assert 'CMP with a Domain Credential' in heading
+        assert mock_cmp.called
+        assert sections[4].heading == 'Certificate Request for a TLS Server Certificate'
+        assert '-cert domain-credential-certificate.pem' in sections[4].rows[0].value
+        assert '-newkey key-5.pem' in sections[4].rows[0].value
+
+    @patch('help_pages.devices_help_views.build_tls_trust_store_section', return_value=_section('TLS'))
+    @patch('help_pages.devices_help_views.JSONProfileVerifier')
+    def test_application_est_domain_credential_builds_enroll_and_convert_steps(
+        self, mock_verifier: Mock, mock_tls: Mock
+    ) -> None:
+        """Test application EST help builds CSR, mTLS curl, and conversion steps."""
+        mock_verifier.return_value.get_sample_request.return_value = _sample_request()
+        domain = _domain()
+        device = _device(domain, onboarding=True)
+
+        sections, heading = ApplicationCertificateWithEstDomainCredentialStrategy().build_sections(
+            _help_context(device, domain, [_profile(alias='server_alias')], cred_count=6)
+        )
+
+        assert 'EST with a Domain Credential' in heading
+        assert mock_tls.called
+        assert sections[4].css_id == 'server_alias'
+        assert 'csr-6.der' in sections[4].rows[0].value
+        assert '--cert domain-credential-certificate.pem' in sections[4].rows[1].value
+        assert 'server_alias/simpleenroll' in sections[4].rows[1].value
+        assert 'certificate-6.pem' in sections[-1].rows[0].value
+
+    @patch('help_pages.devices_help_views.build_tls_trust_store_section', return_value=_section('TLS'))
+    @patch('help_pages.devices_help_views.JSONProfileVerifier')
+    def test_no_onboarding_rest_username_password_builds_json_enrollment(
+        self, mock_verifier: Mock, mock_tls: Mock
+    ) -> None:
+        """Test REST username/password app-certificate help commands."""
+        mock_verifier.return_value.get_sample_request.return_value = _sample_request()
+        domain = _domain()
+        device = _device(domain, no_onboarding=True)
+
+        sections, heading = NoOnboardingRestUsernamePasswordStrategy().build_sections(
+            _help_context(device, domain, [_profile()], cred_count=7)
+        )
+
+        assert 'REST with username and password' in heading
+        assert mock_tls.called
+        assert '/rest/test-domain/<certificate_profile>/enroll/' in sections[0].rows[0].value
+        assert '--user "device-1:rest-secret"' in sections[4].rows[1].value
+        assert 'certificate-7.json' in sections[4].rows[1].value
+        assert 'certificate-7.pem' in sections[4].rows[2].value
+
+    @patch('help_pages.devices_help_views.build_tls_trust_store_section', return_value=_section('TLS'))
+    def test_onboarding_rest_username_password_builds_domain_credential_steps(self, mock_tls: Mock) -> None:
+        """Test REST username/password domain credential help commands."""
+        domain = _domain()
+        device = _device(domain, onboarding=True)
+
+        sections, heading = OnboardingDomainCredentialRestUsernamePasswordStrategy().build_sections(
+            _help_context(device, domain)
+        )
+
+        assert 'Domain Credential using REST' in heading
+        assert mock_tls.called
+        assert '/rest/test-domain/domain_credential/enroll/' in sections[0].rows[0].value
+        assert 'csr-domain-credential.pem' in sections[3].rows[0].value
+        assert '--user "device-1:rest-secret"' in sections[3].rows[1].value
+        assert 'domain-credential-certificate.pem' in sections[3].rows[2].value
+
+    @patch('help_pages.devices_help_views.build_tls_trust_store_section', return_value=_section('TLS'))
+    @patch('help_pages.devices_help_views.JSONProfileVerifier')
+    def test_application_rest_domain_credential_builds_enroll_reenroll_and_extract_steps(
+        self, mock_verifier: Mock, mock_tls: Mock
+    ) -> None:
+        """Test REST mTLS app-certificate help commands."""
+        mock_verifier.return_value.get_sample_request.return_value = _sample_request()
+        domain = _domain()
+        device = _device(domain, onboarding=True)
+
+        sections, heading = ApplicationCertificateWithRestDomainCredentialStrategy().build_sections(
+            _help_context(device, domain, [_profile(alias='server_alias')], cred_count=8)
+        )
+
+        assert 'REST with a Domain Credential' in heading
+        assert mock_tls.called
+        profile_section = sections[4]
+        assert 'server_alias/enroll/' in profile_section.rows[1].value
+        assert 'server_alias/reenroll/' in profile_section.rows[2].value
+        assert 'previously issued certificate' in profile_section.rows[3].value
+        assert 'certificate-8.pem' in profile_section.rows[4].value
+        assert 'certificate-chain-8.pem' in profile_section.rows[5].value
+
+    @patch('help_pages.devices_help_views.build_tls_trust_store_section', return_value=_section('TLS'))
+    @patch('help_pages.devices_help_views.JSONProfileVerifier', side_effect=ValueError('invalid profile'))
+    def test_rest_malformed_profile_paths_report_plain_errors(self, mock_verifier: Mock, mock_tls: Mock) -> None:
+        """Test REST strategies report malformed certificate profiles."""
+        domain = _domain()
+        no_onboarding_device = _device(domain, no_onboarding=True)
+        onboarding_device = _device(domain, onboarding=True)
+
+        no_onboarding_sections, _heading = NoOnboardingRestUsernamePasswordStrategy().build_sections(
+            _help_context(no_onboarding_device, domain, [_profile()])
+        )
+        app_sections, _heading = ApplicationCertificateWithRestDomainCredentialStrategy().build_sections(
+            _help_context(onboarding_device, domain, [_profile()])
+        )
+
+        assert no_onboarding_sections[4].rows[0].value_render_type == ValueRenderType.PLAIN
+        assert 'Certificate Profile is malformed' in no_onboarding_sections[4].rows[0].value
+        assert app_sections[4].rows[0].value_render_type == ValueRenderType.PLAIN
+        assert 'Certificate Profile is malformed' in app_sections[4].rows[0].value
+        assert mock_verifier.call_count == 2
+        assert mock_tls.call_count == 2
+
+    def test_strategies_raise_when_required_domain_or_config_is_missing(self) -> None:
+        """Test important Http404 branches for missing domain and onboarding state."""
+        domain = _domain()
+        missing_domain_device = _device(domain, no_onboarding=True)
+        missing_config_device = _device(domain)
+
+        with self.assertRaises(Http404):
+            NoOnboardingCmpSharedSecretStrategy().build_sections(_help_context(missing_domain_device, None))
+        with self.assertRaises(Http404):
+            NoOnboardingEstUsernamePasswordStrategy().build_sections(_help_context(missing_domain_device, None))
+        with self.assertRaises(Http404):
+            ApplicationCertificateWithCmpDomainCredentialStrategy().build_sections(
+                _help_context(missing_config_device, domain)
+            )
+        with self.assertRaises(Http404):
+            ApplicationCertificateWithEstDomainCredentialStrategy().build_sections(
+                _help_context(missing_config_device, domain)
+            )
+        with self.assertRaises(Http404):
+            NoOnboardingRestUsernamePasswordStrategy().build_sections(_help_context(missing_config_device, domain))
+        with self.assertRaises(Http404):
+            OnboardingDomainCredentialRestUsernamePasswordStrategy().build_sections(
+                _help_context(missing_config_device, domain)
+            )
+        with self.assertRaises(Http404):
+            ApplicationCertificateWithRestDomainCredentialStrategy().build_sections(
+                _help_context(missing_config_device, domain)
+            )
+
+    @patch('help_pages.devices_help_views.CmpSharedSecretCommandBuilder.get_app_cert_self_revoke_command')
+    @patch('help_pages.devices_help_views.IssuedCredentialModel.objects.filter')
+    @patch('help_pages.devices_help_views.reverse')
+    def test_cmp_revocation_lists_credentials_and_reason_commands(
+        self, mock_reverse: Mock, mock_filter: Mock, mock_revoke_command: Mock
+    ) -> None:
+        """Test CMP revocation help includes credentials and reason-specific commands."""
+        mock_reverse.side_effect = lambda name, kwargs: f'/{name}/{kwargs["pk"]}/'
+        mock_revoke_command.return_value = 'openssl cmp -cmd rr -revreason 0 -trusted full-chain-3.pem'
+        app_credential = Mock()
+        app_credential.id = 17
+        app_credential.common_name = 'app-cert-1'
+        app_credential.credential.certificate_or_error.pk = 55
+        mock_filter.return_value.select_related.return_value = [app_credential]
+        domain = _domain()
+        device = _device(domain, no_onboarding=True)
+
+        sections, heading = CmpRevocationStrategy().build_sections(_help_context(device, domain, cred_count=3))
+
+        assert 'Revoke CMP Application Credential' in heading
+        assert 'app-cert-1' in sections[0].rows[1].value
+        assert sections[1].heading == 'Credential Files'
+        assert sections[2].heading == 'Revocation Reason'
+        assert any('-revreason 1' in section.rows[0].value for section in sections[3:])
+        mock_revoke_command.assert_called_once_with(
+            host='https://trustpoint.test:8443/.well-known/cmp/p/test-domain/revocation',
+            cred_number=3,
+        )
+
+    @patch('help_pages.devices_help_views.IssuedCredentialModel.objects.filter')
+    @patch('help_pages.devices_help_views.reverse')
+    def test_cmp_revocation_without_credentials_shows_empty_state(self, mock_reverse: Mock, mock_filter: Mock) -> None:
+        """Test CMP revocation help shows an empty state when no app credentials exist."""
+        mock_reverse.return_value = '/certificate/55/'
+        mock_filter.return_value.select_related.return_value = []
+        domain = _domain()
+        device = _device(domain, no_onboarding=True)
+
+        sections, _heading = CmpRevocationStrategy().build_sections(_help_context(device, domain, cred_count=1))
+
+        assert sections[0].rows[1].key == 'No Credentials'
+        assert 'No application credentials found' in sections[0].rows[1].value
+
+    def test_aoki_cmp_and_est_strategies_build_instruction_sections(self) -> None:
+        """Test AOKI strategies generate requirement, workflow, and command sections."""
+        domain = _domain()
+        context = _help_context(_device(domain), domain)
+
+        cmp_sections, cmp_heading = AokiCmpIDevIDStrategy().build_sections(context)
+        est_sections, est_heading = AokiEstIDevIDStrategy().build_sections(context)
+
+        assert cmp_heading == 'AOKI with CMP - IDevID Authentication'
+        assert [section.heading for section in cmp_sections] == [
+            'Device Requirements',
+            'Trustpoint Requirements',
+            'How AOKI with CMP Works',
+            'Example Commands',
+        ]
+        assert '-server https://trustpoint.test:8443/.well-known/cmp/p/test-domain' in cmp_sections[3].rows[1].value
+        assert est_heading == 'AOKI with EST - IDevID Authentication (mTLS)'
+        assert '"protocol": "EST"' in est_sections[3].rows[1].value
+        assert 'domain_credential/simpleenroll' in est_sections[3].rows[1].value
+
+    def test_aoki_est_strategy_requires_domain_for_response_profile(self) -> None:
+        """Test AOKI EST fails when no domain is available for the domain credential profile."""
+        domain = _domain()
+
+        with self.assertRaises(Http404):
+            AokiEstIDevIDStrategy().build_sections(_help_context(_device(domain), None))
+
+    @patch('help_pages.devices_help_views.reverse')
+    def test_agent_setup_profile_uses_onboarding_or_no_onboarding_password(self, mock_reverse: Mock) -> None:
+        """Test agent setup profile content and password-source fallback behavior."""
+        mock_reverse.side_effect = lambda name, kwargs: f'/{name}/{kwargs["pk"]}/'
+        domain = _domain()
+        onboarding_device = _device(domain, onboarding=True)
+        no_onboarding_device = _device(domain, no_onboarding=True)
+
+        assert _agent_get_est_password(onboarding_device) == 'rest-secret'
+        assert _agent_get_est_password(no_onboarding_device) == 'rest-secret'
+
+        sections, heading = AgentSetupProfileStrategy().build_sections(_help_context(onboarding_device, domain))
+
+        assert heading == 'Help - Issue a Domain Credential for Agent'
+        assert sections[0].rows[0].value == 'https://trustpoint.test:8443/rest/test-domain/domain_credential/enroll/'
+        assert 'host_ip=trustpoint.test' in sections[0].rows[3].value
+        assert 'python agent.py --profile agent_setup.json' in sections[0].rows[5].value
+
+        with self.assertRaises(Http404):
+            _agent_get_est_password(_device(domain))
+
+    @patch('help_pages.devices_help_views.reverse', return_value='/renewal/123/')
+    @patch('help_pages.devices_help_views.timezone')
+    def test_opc_ua_gds_renewal_settings_render_enabled_pending_and_disabled(
+        self, mock_timezone: Mock, mock_reverse: Mock
+    ) -> None:
+        """Test OPC UA renewal settings render the important scheduling states."""
+        strategy = OpcUaGdsPushApplicationCertificateStrategy()
+        device = Mock(pk=123, opc_gds_push_renewal_interval=12)
+        now = Mock()
+        future = Mock()
+        future.__gt__ = Mock(return_value=True)
+        future.strftime.return_value = '2026-09-04 12:00 UTC'
+        mock_timezone.now.return_value = now
+
+        device.opc_gds_push_enable_periodic_update = True
+        device.opc_gds_push_last_update_scheduled_at = future
+        enabled_section = strategy._build_renewal_settings_section(device)
+
+        future.__gt__.return_value = False
+        pending_section = strategy._build_renewal_settings_section(device)
+
+        device.opc_gds_push_enable_periodic_update = False
+        device.opc_gds_push_last_update_scheduled_at = None
+        disabled_section = strategy._build_renewal_settings_section(device)
+
+        assert 'Enabled' in enabled_section.rows[0].value
+        assert '2026-09-04 12:00 UTC' in enabled_section.rows[0].value
+        assert 'checked' in enabled_section.rows[1].value
+        assert 'Pending' in pending_section.rows[0].value
+        assert 'Disabled' in disabled_section.rows[0].value
+        assert 'name="opc_gds_push_renewal_interval"' in disabled_section.rows[1].value
+        assert mock_reverse.called

--- a/trustpoint/help_pages/tests/test_pki_help_views.py
+++ b/trustpoint/help_pages/tests/test_pki_help_views.py
@@ -7,17 +7,60 @@ from unittest.mock import Mock, patch
 
 from django.http import Http404
 from django.test import RequestFactory, TestCase
+from trustpoint_core import oid
 
 from pki.models import CaModel
-from ..help_section import ValueRenderType
+from ..help_section import HelpSection, ValueRenderType
 from ..pki_help_views import (
     BaseHelpView,
+    CaDetailView,
+    CaHelpView,
     CrlDownloadHelpView,
+    DevIdRegistrationDetailView,
+    DevIdRegistrationHelpView,
+    DomainDetailView,
+    DomainHelpView,
+    IssuedCredentialDetailView,
+    IssuedCredentialHelpView,
     OnboardingCmpIdevidRegistrationHelpView,
     OnboardingCmpIdevIdDomainCredentialStrategy,
     OnboardingEstIdevidRegistrationHelpView,
     OnboardingEstIdevIdDomainCredentialStrategy,
+    OwnerCredentialDetailView,
+    OwnerCredentialHelpView,
 )
+
+
+def _public_key_info() -> oid.PublicKeyInfo:
+    """Return a reusable RSA public-key descriptor for PKI help contexts."""
+    return oid.PublicKeyInfo(
+        public_key_algorithm_oid=oid.PublicKeyAlgorithmOid.RSA,
+        key_size=2048,
+    )
+
+
+def _domain() -> Mock:
+    """Return a lightweight domain mock."""
+    domain = Mock()
+    domain.unique_name = 'test-domain'
+    domain.public_key_info = _public_key_info()
+    domain.get_allowed_cert_profiles.return_value = []
+    domain.issuing_ca = Mock(pk=77)
+    return domain
+
+
+def _device(domain: Mock) -> Mock:
+    """Return a lightweight device mock."""
+    device = Mock()
+    device.common_name = 'device-1'
+    device.domain = domain
+    device.public_key_info = _public_key_info()
+    return device
+
+
+def _section(heading: str = 'Patched Section') -> HelpSection:
+    """Return a simple section for patched shared helpers."""
+    return HelpSection(heading, [])
 
 
 class BaseHelpViewTests(TestCase):
@@ -341,3 +384,216 @@ class CrlDownloadHelpViewTests(TestCase):
         assert 'curl' in der_row.value
         assert 'test-ca.der.crl' in der_row.value
         assert 'encoding=der' in der_row.value
+
+
+class PkiDetailAndHelpContextTests(TestCase):
+    """Test concrete PKI detail/help context builders."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.factory = RequestFactory()
+
+    def _prepare_view(self, view: object, obj: Mock) -> object:
+        view.object = obj
+        view.request = self.factory.get('/', HTTP_X_FORWARDED_PORT='9443')
+        return view
+
+    @patch('help_pages.pki_help_views.TlsSettings.get_first_ipv4_address', return_value='192.0.2.10')
+    def test_devid_registration_detail_context_contains_domain_endpoint_data(self, mock_ip: Mock) -> None:
+        """Test DevID registration detail context exposes domain and host details."""
+        domain = _domain()
+        registration = Mock(domain=domain)
+        view = self._prepare_view(DevIdRegistrationDetailView(), registration)
+
+        context = view.get_context_data()
+
+        assert context['devid_registration'] == registration
+        assert context['domain'] == domain
+        assert context['domain_unique_name'] == 'test-domain'
+        assert context['host_base'] == 'https://192.0.2.10:9443'
+        assert context['help_sections'] == []
+        assert mock_ip.called
+
+    @patch('help_pages.pki_help_views.build_tls_trust_store_section', return_value=_section('TLS'))
+    @patch('help_pages.pki_help_views.build_issuing_ca_cert_section', return_value=_section('Issuing CA'))
+    @patch('help_pages.pki_help_views.TlsSettings.get_first_ipv4_address', return_value='192.0.2.10')
+    def test_devid_registration_help_context_builds_help_sections(
+        self, mock_ip: Mock, mock_issuing_ca: Mock, mock_tls: Mock
+    ) -> None:
+        """Test DevID registration help context includes generated helper sections."""
+        domain = _domain()
+        view = self._prepare_view(DevIdRegistrationHelpView(), Mock(domain=domain))
+
+        help_context = view._make_context()
+
+        assert [section.heading for section in help_context.help_sections] == [
+            'Key Generation',
+            'Issuing CA',
+            'TLS',
+        ]
+        assert 'idevid' in help_context.help_sections[0].rows[0].value
+        assert mock_ip.called
+        assert mock_issuing_ca.called
+        assert mock_tls.called
+
+    @patch('help_pages.pki_help_views.TlsSettings.get_first_ipv4_address', return_value='192.0.2.20')
+    def test_domain_detail_context_contains_allowed_profiles(self, mock_ip: Mock) -> None:
+        """Test domain detail context exposes allowed application profiles."""
+        domain = _domain()
+        allowed_profile = Mock()
+        domain.get_allowed_cert_profiles.return_value = [allowed_profile]
+        view = self._prepare_view(DomainDetailView(), domain)
+
+        context = view.get_context_data()
+
+        assert context['domain'] == domain
+        assert context['allowed_app_profiles'] == [allowed_profile]
+        assert context['host_base'] == 'https://192.0.2.20:9443'
+        assert mock_ip.called
+
+    @patch('help_pages.pki_help_views.build_tls_trust_store_section', return_value=_section('TLS'))
+    @patch('help_pages.pki_help_views.build_issuing_ca_cert_section', return_value=_section('Issuing CA'))
+    @patch('help_pages.pki_help_views.TlsSettings.get_first_ipv4_address', return_value='192.0.2.20')
+    def test_domain_help_context_builds_application_certificate_sections(
+        self, mock_ip: Mock, mock_issuing_ca: Mock, mock_tls: Mock
+    ) -> None:
+        """Test domain help context includes app-certificate guidance sections."""
+        domain = _domain()
+        view = self._prepare_view(DomainHelpView(), domain)
+
+        help_context = view._make_context()
+
+        assert [section.heading for section in help_context.help_sections] == [
+            'Key Generation',
+            'Issuing CA',
+            'TLS',
+        ]
+        assert 'app_cert' in help_context.help_sections[0].rows[0].value
+        assert mock_ip.called
+        assert mock_issuing_ca.called
+        assert mock_tls.called
+
+    @patch('help_pages.pki_help_views.TlsSettings.get_first_ipv4_address', return_value='192.0.2.30')
+    def test_issued_credential_detail_context_contains_device_and_credential(self, mock_ip: Mock) -> None:
+        """Test issued credential detail context exposes device, domain, and credential."""
+        domain = _domain()
+        device = _device(domain)
+        issued_credential = Mock(device=device)
+        view = self._prepare_view(IssuedCredentialDetailView(), issued_credential)
+
+        context = view.get_context_data()
+
+        assert context['issued_credential'] == issued_credential
+        assert context['device'] == device
+        assert context['domain'] == domain
+        assert context['host_base'] == 'https://192.0.2.30:9443'
+        assert mock_ip.called
+
+    @patch('help_pages.pki_help_views.build_tls_trust_store_section', return_value=_section('TLS'))
+    @patch('help_pages.pki_help_views.build_issuing_ca_cert_section', return_value=_section('Issuing CA'))
+    @patch('help_pages.pki_help_views.TlsSettings.get_first_ipv4_address', return_value='192.0.2.30')
+    def test_issued_credential_help_context_builds_app_certificate_sections(
+        self, mock_ip: Mock, mock_issuing_ca: Mock, mock_tls: Mock
+    ) -> None:
+        """Test issued credential help context includes app certificate helper sections."""
+        domain = _domain()
+        device = _device(domain)
+        view = self._prepare_view(IssuedCredentialHelpView(), Mock(device=device))
+
+        help_context = view._make_context()
+
+        assert [section.heading for section in help_context.help_sections] == [
+            'Key Generation',
+            'Issuing CA',
+            'TLS',
+        ]
+        assert 'app_cert' in help_context.help_sections[0].rows[0].value
+        assert mock_ip.called
+        assert mock_issuing_ca.called
+        assert mock_tls.called
+
+    @patch('help_pages.pki_help_views.TlsSettings.get_first_ipv4_address', return_value='192.0.2.40')
+    def test_owner_credential_detail_context_contains_device_and_credential(self, mock_ip: Mock) -> None:
+        """Test owner credential detail context exposes device, domain, and credential."""
+        domain = _domain()
+        device = _device(domain)
+        owner_credential = Mock(device=device)
+        view = self._prepare_view(OwnerCredentialDetailView(), owner_credential)
+
+        context = view.get_context_data()
+
+        assert context['owner_credential'] == owner_credential
+        assert context['device'] == device
+        assert context['domain_unique_name'] == 'test-domain'
+        assert context['host_base'] == 'https://192.0.2.40:9443'
+        assert mock_ip.called
+
+    @patch('help_pages.pki_help_views.build_tls_trust_store_section', return_value=_section('TLS'))
+    @patch('help_pages.pki_help_views.build_issuing_ca_cert_section', return_value=_section('Issuing CA'))
+    @patch('help_pages.pki_help_views.TlsSettings.get_first_ipv4_address', return_value='192.0.2.40')
+    def test_owner_credential_help_context_builds_owner_certificate_sections(
+        self, mock_ip: Mock, mock_issuing_ca: Mock, mock_tls: Mock
+    ) -> None:
+        """Test owner credential help context includes owner certificate helper sections."""
+        domain = _domain()
+        device = _device(domain)
+        view = self._prepare_view(OwnerCredentialHelpView(), Mock(device=device))
+
+        help_context = view._make_context()
+
+        assert [section.heading for section in help_context.help_sections] == [
+            'Key Generation',
+            'Issuing CA',
+            'TLS',
+        ]
+        assert 'owner_cert' in help_context.help_sections[0].rows[0].value
+        assert mock_ip.called
+        assert mock_issuing_ca.called
+        assert mock_tls.called
+
+    @patch('help_pages.pki_help_views.TlsSettings.get_first_ipv4_address', return_value='192.0.2.50')
+    def test_ca_detail_context_uses_minimal_help_context(self, mock_ip: Mock) -> None:
+        """Test CA detail context exposes CA and host details without domain data."""
+        ca = Mock(pk=99)
+        view = self._prepare_view(CaDetailView(), ca)
+
+        context = view.get_context_data()
+
+        assert context['ca'] == ca
+        assert context['host_base'] == 'https://192.0.2.50:9443'
+        assert context['help_sections'] == []
+        assert mock_ip.called
+
+    @patch('help_pages.pki_help_views.reverse')
+    @patch('help_pages.pki_help_views.TlsSettings.get_first_ipv4_address', return_value='192.0.2.50')
+    def test_ca_help_context_builds_certificate_download_links(self, mock_ip: Mock, mock_reverse: Mock) -> None:
+        """Test CA help context includes CA certificate and chain download links."""
+        mock_reverse.side_effect = lambda name, kwargs: f'/{name}/{kwargs["pk"]}/{kwargs.get("file_format", "")}'
+        ca = Mock(pk=99)
+        view = self._prepare_view(CaHelpView(), ca)
+
+        help_context = view._make_context()
+
+        section = help_context.help_sections[0]
+
+        assert section.heading == 'CA Certificate'
+        assert 'Download CA Certificate (PEM)' in section.rows[0].value
+        assert 'Download CA Certificate Chain (PEM)' in section.rows[1].value
+        assert mock_ip.called
+
+    def test_detail_views_raise_for_missing_device_or_public_key_info(self) -> None:
+        """Test important error paths for credential detail contexts."""
+        domain = _domain()
+        device = _device(domain)
+        device.public_key_info = None
+
+        issued_view = self._prepare_view(IssuedCredentialDetailView(), Mock(device=None))
+        owner_view = self._prepare_view(OwnerCredentialDetailView(), Mock(device=None))
+        issued_missing_key_view = self._prepare_view(IssuedCredentialDetailView(), Mock(device=device))
+
+        with self.assertRaises(Http404):
+            issued_view._make_context()
+        with self.assertRaises(Http404):
+            owner_view._make_context()
+        with self.assertRaises(Http404):
+            issued_missing_key_view._make_context()


### PR DESCRIPTION
- Enhance device help view tests with additional strategies and context builders.
- Introduce new tests for PKI help views, ensuring proper context and section generation.


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.