### PR TITLE
Increase request test coverage

### DIFF
--- a/trustpoint/request/tests/test_authentication_branches.py
+++ b/trustpoint/request/tests/test_authentication_branches.py
@@ -1,0 +1,653 @@
+"""Focused branch tests for request authentication components."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, hmac
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.x509.oid import NameOID
+from pyasn1_modules import rfc4210
+from trustpoint_core.oid import HashAlgorithm
+
+from devices.models import DeviceModel
+from pki.models import IssuedCredentialModel
+from request.authentication.base import (
+    ClientCertificateAuthentication,
+    CompositeAuthentication,
+    IDevIDAuthentication,
+    ReenrollmentAuthentication,
+)
+from request.authentication.cmp import (
+    CmpCertConfAuthentication,
+    CmpSharedSecretAuthentication,
+    CmpSignatureBasedCertificationAuthentication,
+    CmpSignatureBasedInitializationAuthentication,
+    CmpSignatureBasedPollAuthentication,
+)
+from request.authentication.est import UsernamePasswordAuthentication
+from request.authentication.rest import RestUsernamePasswordAuthentication
+from request.request_context import (
+    BaseCertificateRequestContext,
+    BaseRequestContext,
+    CmpBaseRequestContext,
+    CmpCertificateRequestContext,
+    CmpCertConfRequestContext,
+    CmpPollRequestContext,
+    EstBaseRequestContext,
+    HttpBaseRequestContext,
+    RestBaseRequestContext,
+)
+from onboarding.models import OnboardingProtocol
+
+
+def _certificate_and_csr() -> tuple[x509.Certificate, x509.CertificateSigningRequest]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'device')])
+    san = x509.SubjectAlternativeName([x509.DNSName('device.example')])
+    csr = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(subject)
+        .add_extension(san, critical=False)
+        .sign(key, hashes.SHA256())
+    )
+    now = datetime.now(timezone.utc)
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=1))
+        .add_extension(san, critical=False)
+        .sign(key, hashes.SHA256())
+    )
+    return certificate, csr
+
+
+def _cmp_pbm_message(parameters: object, protection: bytes) -> MagicMock:
+    protection_algorithm = MagicMock()
+    protection_algorithm.__getitem__.side_effect = lambda key: parameters if key == 'parameters' else Mock()
+    header = MagicMock()
+    header.__getitem__.side_effect = lambda key: protection_algorithm if key == 'protectionAlg' else Mock()
+    message = MagicMock()
+    message.__getitem__.side_effect = lambda key: (
+        header if key == 'header' else (Mock(asOctets=Mock(return_value=protection)) if key == 'protection' else Mock())
+    )
+    return message
+
+
+def test_client_certificate_authentication_accepts_non_domain_credential() -> None:
+    issued = Mock(device=Mock())
+    issued.credential.is_valid_issued_credential.return_value = (True, '')
+    with patch.object(IssuedCredentialModel, 'get_credential_for_certificate', return_value=issued):
+        context = BaseRequestContext(client_certificate=Mock())
+        ClientCertificateAuthentication(domain_credential_only=False).authenticate(context)
+    issued.credential.is_valid_issued_credential.assert_called_once_with()
+    assert context.device is issued.device
+
+
+def test_client_certificate_authentication_unexpected_error_is_normalized() -> None:
+    with patch.object(IssuedCredentialModel, 'get_credential_for_certificate', side_effect=RuntimeError('database')):
+        with pytest.raises(ValueError, match='Certificate authentication failed'):
+            ClientCertificateAuthentication().authenticate(BaseRequestContext(client_certificate=Mock()))
+
+
+def test_reenrollment_validates_real_subject_and_san() -> None:
+    certificate, csr = _certificate_and_csr()
+    credential_certificate = Mock()
+    credential_certificate.subjects_match.side_effect = lambda subject: subject == certificate.subject
+    credential_certificate.get_certificate_serializer.return_value.as_crypto.return_value = certificate
+    credential = Mock(certificate_or_error=credential_certificate)
+    credential.is_valid_issued_credential.return_value = (True, '')
+    issued = Mock(credential=credential, device=Mock())
+    context = BaseCertificateRequestContext(client_certificate=certificate, cert_requested=csr)
+    with patch.object(IssuedCredentialModel, 'get_credential_for_certificate', return_value=issued):
+        ReenrollmentAuthentication().authenticate(context)
+    assert context.device is issued.device
+
+
+@pytest.mark.parametrize(
+    ('context', 'error'),
+    [
+        (BaseRequestContext(), None),
+        (
+            BaseCertificateRequestContext(client_certificate='bad', cert_requested=Mock()),
+            'Invalid client certificate type',
+        ),
+    ],
+)
+def test_reenrollment_context_validation(context: BaseRequestContext, error: str | None) -> None:
+    if error:
+        with pytest.raises((TypeError, ValueError), match=error):
+            ReenrollmentAuthentication().authenticate(context)
+    else:
+        assert ReenrollmentAuthentication().authenticate(context) is None
+
+
+def test_reenrollment_rejects_missing_csr() -> None:
+    certificate, _ = _certificate_and_csr()
+    with pytest.raises(ValueError, match='CSR is missing'):
+        ReenrollmentAuthentication().authenticate(BaseCertificateRequestContext(client_certificate=certificate))
+
+
+def test_reenrollment_missing_credential_and_invalid_subject_are_rejected() -> None:
+    certificate, csr = _certificate_and_csr()
+    context = BaseCertificateRequestContext(client_certificate=certificate, cert_requested=csr)
+    with patch.object(
+        IssuedCredentialModel, 'get_credential_for_certificate', side_effect=IssuedCredentialModel.DoesNotExist
+    ):
+        with pytest.raises(ValueError, match='Issued credential not found'):
+            ReenrollmentAuthentication().authenticate(context)
+
+    credential_certificate = Mock()
+    credential_certificate.subjects_match.return_value = False
+    credential = Mock(certificate_or_error=credential_certificate)
+    credential.is_valid_issued_credential.return_value = (True, '')
+    issued = Mock(credential=credential, device=Mock())
+    with patch.object(IssuedCredentialModel, 'get_credential_for_certificate', return_value=issued):
+        with pytest.raises(ValueError, match='subject does not match'):
+            ReenrollmentAuthentication().authenticate(context)
+
+
+def test_idevid_unexpected_error_is_normalized() -> None:
+    context = HttpBaseRequestContext(raw_message=Mock())
+    with patch('request.authentication.base.IDevIDAuthenticator.authenticate_idevid', side_effect=RuntimeError('boom')):
+        with pytest.raises(ValueError, match='unexpected error'):
+            IDevIDAuthentication().authenticate(context)
+
+
+def test_composite_rejects_invalid_ips_and_sets_http_error() -> None:
+    auth = CompositeAuthentication()
+    context = HttpBaseRequestContext(raw_message=Mock(META={'HTTP_X_FORWARDED_FOR': 'bad', 'REMOTE_ADDR': 'also-bad'}))
+    assert auth._resolve_request_ip(context) is None
+    auth.add(Mock(authenticate=Mock(side_effect=ValueError('no'))))
+    with pytest.raises(ValueError, match='All authentication methods'):
+        auth.authenticate(context)
+    assert context.http_response_status == 403
+    assert context.http_response_content == 'Authentication failed.'
+
+
+def test_composite_keeps_unchanged_ip_and_removes_component() -> None:
+    component = Mock()
+    auth = CompositeAuthentication()
+    auth.add(component)
+    auth.remove(component)
+    device = Mock(ip_address='127.0.0.1', common_name='device')
+    context = HttpBaseRequestContext(raw_message=Mock(META={'REMOTE_ADDR': '127.0.0.1'}), device=device)
+    auth._update_device_ip_from_request(context)
+    device.save.assert_not_called()
+
+
+@pytest.mark.parametrize('exception', [ValueError('bad'), RuntimeError('boom')])
+def test_composite_continues_after_component_errors(exception: Exception) -> None:
+    auth = CompositeAuthentication()
+    auth.add(Mock(authenticate=Mock(side_effect=exception)))
+    auth.add(Mock(authenticate=Mock(side_effect=ValueError('second'))))
+    with pytest.raises(ValueError, match='All authentication methods'):
+        auth.authenticate(BaseRequestContext())
+
+
+def test_cmp_shared_secret_hmac_success_stores_secret_and_context() -> None:
+    auth = CmpSharedSecretAuthentication()
+    device = Mock(domain=Mock())
+    config = Mock(cmp_shared_secret='secret')
+    context = CmpBaseRequestContext(protocol='cmp', parsed_message=Mock())
+    with (
+        patch.object(auth, '_validate_context', return_value=True),
+        patch.object(auth, '_extract_sender_kid', return_value=1),
+        patch.object(auth, '_get_device', return_value=device),
+        patch.object(auth, '_validate_device_configuration', return_value=config),
+        patch.object(auth, '_verify_hmac_protection'),
+    ):
+        auth.authenticate(context)
+    assert context.device is device
+    assert context.domain is device.domain
+
+
+@pytest.mark.parametrize('failure', [ValueError('invalid PBM'), TypeError('invalid HMAC'), RuntimeError('invalid OWF')])
+def test_cmp_shared_secret_protection_errors_are_rejected(failure: Exception) -> None:
+    auth = CmpSharedSecretAuthentication()
+    with (
+        patch.object(auth, '_validate_context', return_value=True),
+        patch.object(auth, '_extract_sender_kid', return_value=1),
+        patch.object(auth, '_get_device', side_effect=failure),
+    ):
+        with pytest.raises(ValueError, match='CMP shared secret authentication'):
+            auth.authenticate(CmpBaseRequestContext(protocol='cmp', parsed_message=Mock()))
+
+
+def test_cmp_shared_secret_missing_device_and_wrong_configuration() -> None:
+    auth = CmpSharedSecretAuthentication()
+    with patch.object(DeviceModel.objects, 'get', side_effect=DeviceModel.DoesNotExist):
+        with pytest.raises(ValueError, match='Device with ID'):
+            auth._get_device(99)
+    with pytest.raises(ValueError, match='no shared secret'):
+        auth._validate_device_configuration(
+            Mock(common_name='device', onboarding_config=None, no_onboarding_config=None), 1
+        )
+
+
+def test_cmp_shared_secret_verifies_real_pbm_hmac() -> None:
+    salt = b'salt'
+    protected_part = b'protected-part'
+    secret = b'secret'
+    key = hashes.Hash(hashes.SHA256())
+    key.update(secret + salt)
+    hmac_key = key.finalize()
+    protection = hmac.HMAC(hmac_key, hashes.SHA256())
+    protection.update(protected_part)
+    decoded = MagicMock(
+        salt=Mock(asOctets=Mock(return_value=salt)),
+        owf=MagicMock(algorithm=Mock(prettyPrint=Mock(return_value='2.16.840.1.101.3.4.2.1'))),
+        iterationCount=1,
+        mac=MagicMock(algorithm=Mock(prettyPrint=Mock(return_value='1.3.6.1.5.5.8.1.5'))),
+    )
+    decoded.__getitem__.side_effect = lambda key: {
+        'salt': decoded.salt,
+        'owf': decoded.owf,
+        'iterationCount': decoded.iterationCount,
+        'mac': decoded.mac,
+    }[key]
+    decoded.owf.__getitem__.side_effect = lambda key: decoded.owf.algorithm
+    decoded.mac.__getitem__.side_effect = lambda key: decoded.mac.algorithm
+    message = _cmp_pbm_message(Mock(), protection.finalize())
+    message['header']['protectionAlg'].__getitem__.side_effect = lambda key: decoded if key == 'parameters' else Mock()
+    with (
+        patch('request.authentication.cmp.decoder.decode', return_value=(decoded, b'')),
+        patch('request.authentication.cmp.encoder.encode', return_value=protected_part),
+        patch('request.authentication.cmp.rfc4210.ProtectedPart', return_value=MagicMock()),
+    ):
+        result = CmpSharedSecretAuthentication._verify_protection_shared_secret(message, 'secret')
+    assert result is not None
+
+
+def test_cmp_shared_secret_verifies_pbm_with_multiple_iterations_and_sha512_hmac() -> None:
+    salt = b'branch-salt'
+    hmac_key = b'secret' + salt
+    for _ in range(2):
+        digest = hashes.Hash(hashes.SHA384())
+        digest.update(hmac_key)
+        hmac_key = digest.finalize()
+
+    protection = hmac.HMAC(hmac_key, hashes.SHA512())
+    protection.update(b'protected-part')
+    decoded = MagicMock(
+        salt=Mock(asOctets=Mock(return_value=salt)),
+        owf=MagicMock(algorithm=Mock(prettyPrint=Mock(return_value='2.16.840.1.101.3.4.2.2'))),
+        iterationCount=2,
+        mac=MagicMock(algorithm=Mock(prettyPrint=Mock(return_value='1.3.6.1.5.5.8.1.7'))),
+    )
+    decoded.__getitem__.side_effect = lambda key: {
+        'salt': decoded.salt, 'owf': decoded.owf,
+        'iterationCount': decoded.iterationCount, 'mac': decoded.mac,
+    }[key]
+    decoded.owf.__getitem__.side_effect = lambda key: decoded.owf.algorithm
+    decoded.mac.__getitem__.side_effect = lambda key: decoded.mac.algorithm
+    message = _cmp_pbm_message(decoded, protection.finalize())
+    with (
+        patch('request.authentication.cmp.decoder.decode', return_value=(decoded, b'')),
+        patch('request.authentication.cmp.encoder.encode', return_value=b'protected-part'),
+        patch('request.authentication.cmp.rfc4210.ProtectedPart', return_value=MagicMock()),
+    ):
+        assert CmpSharedSecretAuthentication._verify_protection_shared_secret(message, 'secret')
+
+
+def test_cmp_shared_secret_rejects_invalid_hmac_and_owf() -> None:
+    decoded = MagicMock(
+        salt=Mock(asOctets=Mock(return_value=b'salt')),
+        owf=MagicMock(algorithm=Mock(prettyPrint=Mock(return_value='unsupported'))),
+    )
+    decoded.__getitem__.side_effect = lambda key: {
+        'salt': decoded.salt,
+        'owf': decoded.owf,
+        'iterationCount': decoded.iterationCount,
+        'mac': decoded.mac,
+    }[key]
+    decoded.owf.__getitem__.side_effect = lambda key: decoded.owf.algorithm
+    with patch('request.authentication.cmp.decoder.decode', return_value=(decoded, b'')):
+        with pytest.raises(ValueError, match='owf algorithm not supported'):
+            CmpSharedSecretAuthentication._verify_protection_shared_secret(_cmp_pbm_message(Mock(), b'bad'), 'secret')
+
+    decoded.owf.algorithm.prettyPrint.return_value = '2.16.840.1.101.3.4.2.1'
+    decoded.iterationCount = 1
+    decoded.mac = MagicMock(algorithm=Mock(prettyPrint=Mock(return_value='1.3.6.1.5.5.8.1.5')))
+    decoded.mac.__getitem__.side_effect = lambda key: decoded.mac.algorithm
+    message = _cmp_pbm_message(decoded, b'bad')
+    with (
+        patch('request.authentication.cmp.decoder.decode', return_value=(decoded, b'')),
+        patch('request.authentication.cmp.encoder.encode', return_value=b'protected-part'),
+        patch('request.authentication.cmp.rfc4210.ProtectedPart', return_value=MagicMock()),
+    ):
+        with pytest.raises(ValueError, match='hmac verification failed'):
+            CmpSharedSecretAuthentication._verify_protection_shared_secret(message, 'secret')
+
+
+def test_cmp_signature_initialization_rejects_wrong_protocol() -> None:
+    with pytest.raises(ValueError):
+        CmpSignatureBasedInitializationAuthentication()._should_authenticate(
+            Mock(protocol='est', operation='initialization')
+        )
+
+
+def test_cmp_signature_certification_skips_wrong_protocol() -> None:
+    assert (
+        CmpSignatureBasedCertificationAuthentication()._should_authenticate(
+            Mock(protocol='est', operation='certification')
+        )
+        is False
+    )
+
+
+def test_cmp_signature_initialization_wraps_authenticator_error() -> None:
+    auth = CmpSignatureBasedInitializationAuthentication()
+    with pytest.raises(ValueError, match='signature-based initialization'):
+        auth._authenticate_and_verify_device(Mock(), Mock(), [])
+
+
+def test_cmp_signature_certification_rejects_unknown_device() -> None:
+    auth = CmpSignatureBasedCertificationAuthentication()
+    with patch.object(DeviceModel.objects, 'get', side_effect=DeviceModel.DoesNotExist):
+        with pytest.raises(ValueError, match='Device not found'):
+            auth._lookup_device({'device_id': 3})
+
+
+def test_cmp_signature_poll_domain_credential_is_accepted() -> None:
+    auth = CmpSignatureBasedPollAuthentication()
+    device = Mock()
+    context = Mock()
+    with (
+        patch.object(auth, '_authenticate_with_domain_credential', return_value=device),
+        patch.object(auth, '_extract_extra_certs', return_value=(Mock(), [])),
+        patch.object(auth, '_should_authenticate', return_value=True),
+        patch.object(auth, '_verify_protection_and_finalize'),
+    ):
+        auth.authenticate(context)
+
+
+def test_cmp_signature_poll_rejects_failed_idevid_authentication() -> None:
+    auth = CmpSignatureBasedPollAuthentication()
+    with patch(
+        'request.authentication.cmp.IDevIDAuthenticator.authenticate_idevid_from_x509', side_effect=ValueError('bad')
+    ):
+        assert auth._authenticate_with_idevid(Mock(), Mock(), []) is None
+    context = CmpPollRequestContext(protocol='cmp', cmp_body_type='pollReq', parsed_message=Mock())
+    with (
+        patch.object(auth, '_should_authenticate', return_value=True),
+        patch.object(auth, '_extract_extra_certs', return_value=(Mock(), [])),
+        patch.object(auth, '_authenticate_with_domain_credential', return_value=None),
+        patch.object(auth, '_authenticate_with_idevid', return_value=None),
+    ):
+        with pytest.raises(ValueError, match='pollReq authentication failed'):
+            auth.authenticate(context)
+
+
+@pytest.mark.parametrize(
+    'auth_class, context_class, fields',
+    [
+        (UsernamePasswordAuthentication, EstBaseRequestContext, {'est_username': 1, 'est_password': 'x'}),
+        (RestUsernamePasswordAuthentication, RestBaseRequestContext, {'rest_username': 1, 'rest_password': 'x'}),
+    ],
+)
+def test_username_password_rejects_unknown_or_wrong_type(
+    auth_class: type, context_class: type, fields: dict[str, object]
+) -> None:
+    auth = auth_class()
+    with pytest.raises(ValueError, match='Invalid username or password'):
+        auth.authenticate(context_class(**fields))
+    with pytest.raises(TypeError):
+        auth.authenticate(BaseRequestContext())
+
+
+def test_rest_username_password_invalid_config_and_lookup_error() -> None:
+    auth = RestUsernamePasswordAuthentication()
+    context = RestBaseRequestContext(rest_username='device', rest_password='secret')
+    with patch('request.authentication.rest.DeviceModel.objects') as objects:
+        objects.select_related.return_value.filter.return_value.first.return_value = Mock(
+            onboarding_config=None, no_onboarding_config=None
+        )
+        with pytest.raises(ValueError, match='Invalid username or password'):
+            auth.authenticate(context)
+    with patch('request.authentication.rest.DeviceModel.objects') as objects:
+        objects.select_related.side_effect = RuntimeError('db')
+        with pytest.raises(ValueError, match='Invalid username or password'):
+            auth.authenticate(context)
+
+
+def test_cmp_shared_secret_rejects_unsupported_hmac_algorithm() -> None:
+    decoded = MagicMock(
+        salt=Mock(asOctets=Mock(return_value=b'salt')),
+        owf=MagicMock(algorithm=Mock(prettyPrint=Mock(return_value='2.16.840.1.101.3.4.2.1'))),
+        iterationCount=1,
+        mac=MagicMock(algorithm=Mock(prettyPrint=Mock(return_value='unsupported'))),
+    )
+    decoded.__getitem__.side_effect = lambda key: {
+        'salt': decoded.salt, 'owf': decoded.owf,
+        'iterationCount': decoded.iterationCount, 'mac': decoded.mac,
+    }[key]
+    decoded.owf.__getitem__.side_effect = lambda key: decoded.owf.algorithm
+    decoded.mac.__getitem__.side_effect = lambda key: decoded.mac.algorithm
+
+    with patch('request.authentication.cmp.decoder.decode', return_value=(decoded, b'')):
+        with pytest.raises(ValueError, match='hmac algorithm not supported'):
+            CmpSharedSecretAuthentication._verify_protection_shared_secret(
+                _cmp_pbm_message(decoded, b'bad'), 'secret'
+            )
+
+
+def test_cmp_signature_base_rejects_missing_or_empty_extra_certs() -> None:
+    auth = CmpSignatureBasedInitializationAuthentication()
+    with pytest.raises(ValueError, match='Missing parsed message'):
+        auth._extract_extra_certs(CmpBaseRequestContext())
+
+    message = MagicMock(spec=rfc4210.PKIMessage)
+    message.__getitem__.return_value = []
+    with pytest.raises(ValueError, match='No extra certificates'):
+        auth._extract_extra_certs(CmpBaseRequestContext(parsed_message=message))
+
+
+def test_cmp_signature_initialization_success_sets_device_and_certificate() -> None:
+    auth = CmpSignatureBasedInitializationAuthentication()
+    signer = Mock()
+    device = Mock(common_name='device')
+    context = CmpCertificateRequestContext(protocol='cmp', operation='initialization')
+    with (
+        patch.object(auth, '_should_authenticate', return_value=True),
+        patch.object(auth, '_extract_extra_certs', return_value=(signer, [])),
+        patch.object(auth, '_authenticate_and_verify_device', return_value=device),
+    ):
+        auth.authenticate(context)
+
+    assert context.client_certificate is signer
+    assert context.device is device
+
+
+def test_cmp_signature_initialization_rejects_missing_domain_and_config() -> None:
+    auth = CmpSignatureBasedInitializationAuthentication()
+    device = Mock(domain=None)
+    with patch('request.authentication.cmp.IDevIDAuthenticator.authenticate_idevid_from_x509', return_value=device):
+        with pytest.raises(ValueError, match='Device domain is not set'):
+            auth._authenticate_device(CmpCertificateRequestContext(), Mock(), [])
+
+    with pytest.raises(ValueError, match='not configured'):
+        auth._verify_device_configuration(Mock(domain=Mock(), onboarding_config=None))
+
+
+def test_cmp_signature_initialization_passes_aoki_parameters() -> None:
+    auth = CmpSignatureBasedInitializationAuthentication()
+    device = Mock(domain=Mock())
+    context = CmpCertificateRequestContext(
+        protocol='cmp', operation='initialization', domain_str='.aoki',
+        raw_message=Mock(path='/p/.aoki/initialization'),
+    )
+    with patch(
+        'request.authentication.cmp.IDevIDAuthenticator.authenticate_idevid_from_x509', return_value=device
+    ) as authenticate:
+        assert auth._authenticate_device(context, Mock(), []) is device
+    assert authenticate.call_args.kwargs['domain'] is None
+    assert authenticate.call_args.kwargs['onboarding_protocol'].name == 'AOKI'
+
+
+def test_cmp_signature_initialization_rejects_wrong_onboarding_protocol_and_pki() -> None:
+    auth = CmpSignatureBasedInitializationAuthentication()
+    device = Mock(domain=Mock(), onboarding_config=Mock(onboarding_protocol='wrong'))
+    with pytest.raises(ValueError, match='Wrong onboarding protocol'):
+        auth._verify_device_configuration(device)
+    device.onboarding_config.onboarding_protocol = OnboardingProtocol.CMP_IDEVID
+    device.onboarding_config.has_pki_protocol.return_value = False
+    with pytest.raises(ValueError, match='PKI protocol CMP expected'):
+        auth._verify_device_configuration(device)
+
+
+def test_cmp_signature_certification_falls_back_to_fingerprint_lookup() -> None:
+    auth = CmpSignatureBasedCertificationAuthentication()
+    certificate, _ = _certificate_and_csr()
+    context = CmpCertificateRequestContext(client_certificate=certificate)
+    device = Mock()
+    with patch.object(ClientCertificateAuthentication, 'authenticate', side_effect=lambda ctx: setattr(ctx, 'device', device)):
+        assert auth._authenticate_device(context) is device
+
+
+def test_cmp_signature_certification_wraps_protection_failure() -> None:
+    auth = CmpSignatureBasedCertificationAuthentication()
+    context = CmpCertificateRequestContext(protocol='cmp', operation='certification')
+    with (
+        patch.object(auth, '_should_authenticate', return_value=True),
+        patch.object(auth, '_extract_extra_certs', return_value=(Mock(), [])),
+        patch.object(auth, '_authenticate_device', return_value=Mock()),
+        patch.object(auth, '_verify_protection_and_finalize', side_effect=TypeError('bad signature')),
+    ):
+        with pytest.raises(ValueError, match='bad signature'):
+            auth.authenticate(context)
+
+
+def test_cmp_signature_certification_requires_profile_and_signer() -> None:
+    auth = CmpSignatureBasedCertificationAuthentication()
+    context = CmpCertificateRequestContext(
+        protocol='cmp', operation='certification', parsed_message=MagicMock(spec=rfc4210.PKIMessage),
+        cert_profile_str=None,
+    )
+    with patch('request.authentication.cmp.AlgorithmIdentifier.from_dotted_string', return_value=Mock()):
+        with pytest.raises(ValueError, match='Missing application certificate template'):
+            auth._should_authenticate(context)
+
+    context.client_certificate = None
+    with pytest.raises(ValueError, match='signer certificate is missing'):
+        auth._authenticate_device(context)
+
+
+def test_cmp_signature_certification_rejects_domain_and_wrong_config() -> None:
+    auth = CmpSignatureBasedCertificationAuthentication()
+    device_info = {'serial_number': None, 'domain_name': None, 'device_id': None, 'common_name': None}
+    with pytest.raises(ValueError, match='not part of any domain'):
+        auth._validate_device(Mock(domain=None), device_info, Mock())
+
+    no_config = Mock(domain=Mock(unique_name='domain'), onboarding_config=None)
+    with pytest.raises(ValueError, match='not configured'):
+        auth._validate_device(no_config, device_info, Mock())
+
+
+def test_cmp_signature_poll_falls_back_after_domain_credential_error() -> None:
+    auth = CmpSignatureBasedPollAuthentication()
+    context = CmpPollRequestContext()
+    with patch.object(ClientCertificateAuthentication, 'authenticate', side_effect=ValueError('unknown')):
+        assert auth._authenticate_with_domain_credential(context) is None
+    assert context.device is None
+
+    with patch(
+        'request.authentication.cmp.IDevIDAuthenticator.authenticate_idevid_from_x509',
+        return_value=Mock(domain=None),
+    ):
+        with pytest.raises(ValueError, match='Device domain is not set'):
+            auth._authenticate_with_idevid(context, Mock(), [])
+
+
+def test_cmp_signature_poll_checks_protocol_body_and_signature_protection() -> None:
+    auth = CmpSignatureBasedPollAuthentication()
+    assert not auth._should_authenticate(CmpPollRequestContext(protocol='est', cmp_body_type='pollReq'))
+    assert not auth._should_authenticate(CmpPollRequestContext(protocol='cmp', cmp_body_type='certRep'))
+    context = CmpPollRequestContext(
+        protocol='cmp', cmp_body_type='pollReq', parsed_message=MagicMock(spec=rfc4210.PKIMessage)
+    )
+    with patch('request.authentication.cmp.AlgorithmIdentifier.from_dotted_string', return_value=HashAlgorithm.SHA256):
+        assert auth._should_authenticate(context)
+
+
+def test_cmp_signature_poll_wraps_certificate_extraction_error() -> None:
+    auth = CmpSignatureBasedPollAuthentication()
+    context = CmpPollRequestContext(protocol='cmp', cmp_body_type='pollReq')
+    with (
+        patch.object(auth, '_should_authenticate', return_value=True),
+        patch.object(auth, '_extract_extra_certs', side_effect=ValueError('no signer')),
+    ):
+        with pytest.raises(ValueError, match='pollReq authentication failed: no signer'):
+            auth.authenticate(context)
+
+
+def test_cmp_certconf_hash_resolution_and_missing_credential() -> None:
+    auth = CmpCertConfAuthentication()
+    assert isinstance(auth._resolve_certconf_hash_algorithm(CmpCertConfRequestContext()), hashes.SHA256)
+
+    unsupported = CmpCertConfRequestContext(cert_hash_algorithm_oid='1.2.3')
+    with pytest.raises(ValueError, match='unsupported'):
+        auth._resolve_certconf_hash_algorithm(unsupported)
+
+    context = CmpCertConfRequestContext(operation='certconf', cert_hash=b'unknown')
+    queryset = Mock()
+    queryset.select_related.return_value.first.return_value = None
+    with patch.object(IssuedCredentialModel.objects, 'filter', return_value=queryset):
+        with pytest.raises(ValueError, match='no issued credential'):
+            auth.authenticate(context)
+
+
+def test_cmp_certconf_resolves_allowed_hash_and_der_certificate() -> None:
+    auth = CmpCertConfAuthentication()
+    certificate, _ = _certificate_and_csr()
+    digest = hashes.Hash(hashes.SHA384())
+    digest.update(certificate.public_bytes(Encoding.DER))
+    issued = Mock(credential=Mock(get_certificate=Mock(return_value=certificate)))
+    queryset = Mock()
+    queryset.iterator.return_value = iter([issued])
+    context = CmpCertConfRequestContext(cert_hash=digest.finalize(), cert_hash_algorithm_oid='2.16.840.1.101.3.4.2.2')
+    with patch.object(IssuedCredentialModel.objects, 'select_related', return_value=queryset):
+        assert auth._resolve_issued_credential_by_cert_hash(context=context, hash_algorithm=hashes.SHA384()) is issued
+
+
+def test_cmp_certconf_rejects_disallowed_hash_and_missing_implicit_signature_hash() -> None:
+    auth = CmpCertConfAuthentication()
+    with pytest.raises(TypeError, match='not permitted'):
+        auth._resolve_certconf_hash_algorithm(CmpCertConfRequestContext(cert_hash_algorithm_oid='1.2.840.113549.2.5'))
+    certificate, _ = _certificate_and_csr()
+    digest = hashes.Hash(hashes.SHA256())
+    digest.update(certificate.public_bytes(Encoding.DER))
+    issued = Mock(credential=Mock(get_certificate=Mock(return_value=certificate)))
+    queryset = Mock()
+    queryset.select_related.return_value.first.return_value = issued
+    context = CmpCertConfRequestContext(cert_hash=digest.finalize())
+    with (
+        patch.object(IssuedCredentialModel.objects, 'filter', return_value=queryset),
+        patch('request.authentication.cmp.SignatureSuite.from_certificate', return_value=Mock(
+            algorithm_identifier=Mock(hash_algorithm=None)
+        )),
+    ):
+        with pytest.raises(ValueError, match='hashAlg is required'):
+            auth._resolve_issued_credential_by_cert_hash(context=context, hash_algorithm=hashes.SHA256())
+
+
+def test_est_username_password_skips_missing_credentials_and_accepts_valid_device() -> None:
+    auth = UsernamePasswordAuthentication()
+    assert auth.authenticate(EstBaseRequestContext(est_username='user')) is None
+
+    device = Mock(spec=DeviceModel)
+    device.onboarding_config = Mock(est_password='secret')
+    queryset = Mock()
+    queryset.filter.return_value.first.return_value = device
+    context = EstBaseRequestContext(est_username='user', est_password='secret')
+    with patch.object(DeviceModel.objects, 'select_related', return_value=queryset):
+        auth.authenticate(context)
+    assert context.device is device

--- a/trustpoint/request/tests/test_authentication_branches.py
+++ b/trustpoint/request/tests/test_authentication_branches.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 The Trustpoint Project Authors
+# SPDX-License-Identifier: MIT
+
 """Focused branch tests for request authentication components."""
 
 from __future__ import annotations

--- a/trustpoint/request/tests/test_authentication_extended.py
+++ b/trustpoint/request/tests/test_authentication_extended.py
@@ -3,18 +3,26 @@
 
 """Extended tests for request/authentication.py to increase coverage."""
 
+from datetime import datetime, timedelta, timezone
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.x509.oid import NameOID
+from pyasn1.codec.der import decoder, encoder
+from pyasn1.type import univ
+from pyasn1_modules import rfc4210, rfc5280
 
 from devices.models import (
     DeviceModel,
     NoOnboardingConfigModel,
     NoOnboardingPkiProtocol,
     OnboardingConfigModel,
+    OnboardingProtocol,
 )
 from pki.util.keys import KeyGenerator
 from request.authentication import (
@@ -22,14 +30,141 @@ from request.authentication import (
     IDevIDAuthentication,
 )
 from pki.models import IssuedCredentialModel
-from request.authentication.cmp import CmpSharedSecretAuthentication
-from request.authentication.est import UsernamePasswordAuthentication
-from request.request_context import BaseRequestContext, EstBaseRequestContext, CmpBaseRequestContext, HttpBaseRequestContext
+from request.authentication.cmp import (
+    CmpCertConfAuthentication,
+    CmpSharedSecretAuthentication,
+    CmpSignatureBasedCertificationAuthentication,
+    CmpSignatureBasedInitializationAuthentication,
+    CmpSignatureBasedPollAuthentication,
+    CmpSignatureBasedRevocationAuthentication,
+)
+from request.authentication.est import (
+    EstAuthentication,
+    ReenrollmentAuthentication,
+    UsernamePasswordAuthentication,
+)
+from request.request_context import (
+    BaseRequestContext,
+    BaseCertificateRequestContext,
+    CmpBaseRequestContext,
+    CmpCertificateRequestContext,
+    CmpPollRequestContext,
+    EstBaseRequestContext,
+    EstCertificateRequestContext,
+    HttpBaseRequestContext,
+)
+
+
+def _certificate_and_csr() -> tuple[x509.Certificate, x509.CertificateSigningRequest]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'device')])
+    san = x509.SubjectAlternativeName([x509.DNSName('device.example')])
+    csr = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(subject)
+        .add_extension(san, critical=False)
+        .sign(key, hashes.SHA256())
+    )
+    now = datetime.now(timezone.utc)
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=1))
+        .add_extension(san, critical=False)
+        .sign(key, hashes.SHA256())
+    )
+    return certificate, csr
+
+
+def _typed_cmp_message(algorithm: str = '1.2.3') -> rfc4210.PKIMessage:
+    message = rfc4210.PKIMessage()
+    message['header']['protectionAlg']['algorithm'] = algorithm
+    message['body']['pkiconf'] = ''
+    return message
+
+
+def _cmp_message_with_certificate(certificate: x509.Certificate) -> rfc4210.PKIMessage:
+    message = _typed_cmp_message()
+    cert_asn1, _ = decoder.decode(
+        certificate.public_bytes(Encoding.DER), asn1Spec=rfc5280.Certificate()
+    )
+    message['extraCerts'][0] = cert_asn1
+    return message
 
 
 @pytest.mark.django_db
 class TestUsernamePasswordAuthenticationExtended:
     """Extended tests for UsernamePasswordAuthentication."""
+
+    def test_authenticate_rejects_non_base_est_context(self) -> None:
+        """Test authentication requires the EST base context contract."""
+        with pytest.raises(TypeError, match='requires an EstBaseRequestContext'):
+            UsernamePasswordAuthentication().authenticate(BaseRequestContext())
+
+    def test_authenticate_skips_missing_credentials(self) -> None:
+        """Test authentication does not run when either credential is absent."""
+        context = EstBaseRequestContext(est_username='device', est_password=None)
+
+        assert UsernamePasswordAuthentication().authenticate(context) is None
+        assert context.device is None
+
+    def test_authenticate_onboarding_device(self, est_device_with_onboarding: dict[str, Any]) -> None:
+        """Test a real device configured for EST onboarding authenticates successfully."""
+        device = est_device_with_onboarding['device']
+        context = EstBaseRequestContext(
+            est_username=device.common_name,
+            est_password=device.onboarding_config.est_password,
+        )
+
+        UsernamePasswordAuthentication().authenticate(context)
+
+        assert context.device.pk == device.pk
+
+    def test_authenticate_no_onboarding_device(self, est_device_without_onboarding: dict[str, Any]) -> None:
+        """Test a real device configured for EST without onboarding authenticates successfully."""
+        device = est_device_without_onboarding['device']
+        context = EstBaseRequestContext(
+            est_username=device.common_name,
+            est_password=device.no_onboarding_config.est_password,
+        )
+
+        UsernamePasswordAuthentication().authenticate(context)
+
+        assert context.device.pk == device.pk
+
+    def test_authenticate_unknown_user(self) -> None:
+        """Test unknown usernames receive the standardized authentication error."""
+        context = EstBaseRequestContext(est_username='unknown-user', est_password='secret')
+
+        with pytest.raises(ValueError, match='Authentication failed: Invalid username or password'):
+            UsernamePasswordAuthentication().authenticate(context)
+        assert context.device is None
+
+    def test_authenticate_invalid_password(self, est_device_without_onboarding: dict[str, Any]) -> None:
+        """Test an incorrect password does not populate the security context."""
+        device = est_device_without_onboarding['device']
+        context = EstBaseRequestContext(est_username=device.common_name, est_password='wrong-password')
+
+        with pytest.raises(ValueError, match='Authentication failed: Invalid username or password'):
+            UsernamePasswordAuthentication().authenticate(context)
+        assert context.device is None
+
+    def test_authenticate_rejects_malformed_device_model(self) -> None:
+        """Test a lookup result that is not a DeviceModel is rejected."""
+        context = EstBaseRequestContext(est_username='device', est_password='secret')
+        queryset = Mock()
+        queryset.filter.return_value.first.return_value = Mock(
+            onboarding_config=Mock(est_password='secret'), no_onboarding_config=None
+        )
+
+        with patch.object(DeviceModel.objects, 'select_related', return_value=queryset):
+            with pytest.raises(ValueError, match='Authentication failed: Invalid username or password'):
+                UsernamePasswordAuthentication().authenticate(context)
+        assert context.device is None
     
     def test_authenticate_device_without_est_password(
         self,
@@ -91,6 +226,81 @@ class TestUsernamePasswordAuthenticationExtended:
             
             with pytest.raises(ValueError, match="Authentication failed: Invalid username or password"):
                 auth.authenticate(context)
+
+
+@pytest.mark.django_db
+class TestEstAuthenticationSpecificComponents:
+    """Tests for EST-specific authentication component wiring and guards."""
+
+    def test_est_authentication_contains_components_in_security_order(self) -> None:
+        """Test EST tries certificate reenrollment before password authentication."""
+        authenticator = EstAuthentication()
+
+        assert [type(component) for component in authenticator.components] == [
+            ReenrollmentAuthentication,
+            UsernamePasswordAuthentication,
+            ClientCertificateAuthentication,
+            IDevIDAuthentication,
+        ]
+
+    def test_est_authentication_populates_context_from_password(
+        self, est_device_without_onboarding: dict[str, Any]
+    ) -> None:
+        """Test the EST composite preserves the authenticated device in its context."""
+        device = est_device_without_onboarding['device']
+        context = EstBaseRequestContext(
+            est_username=device.common_name,
+            est_password=device.no_onboarding_config.est_password,
+        )
+
+        EstAuthentication().authenticate(context)
+
+        assert context.device.pk == device.pk
+        assert context.domain is None
+
+    def test_reenrollment_rejects_non_est_certificate_context(self) -> None:
+        """Test EST reenrollment enforces its certificate request context."""
+        with pytest.raises(TypeError, match='requires an EstCertificateRequestContext'):
+            ReenrollmentAuthentication().authenticate(BaseRequestContext())
+
+    def test_reenrollment_returns_when_client_certificate_is_absent(self) -> None:
+        context = EstCertificateRequestContext(cert_requested=Mock())
+
+        assert ReenrollmentAuthentication().authenticate(context) is None
+        assert context.device is None
+
+    def test_reenrollment_rejects_invalid_credential(self) -> None:
+        certificate, csr = _certificate_and_csr()
+        credential_certificate = Mock()
+        credential = Mock(certificate_or_error=credential_certificate)
+        credential.is_valid_issued_credential.return_value = (False, 'revoked')
+        issued = Mock(credential=credential)
+        context = EstCertificateRequestContext(client_certificate=certificate, cert_requested=csr)
+
+        with patch.object(IssuedCredentialModel, 'get_credential_for_certificate', return_value=issued):
+            with pytest.raises(ValueError, match='Invalid client certificate for reenrollment: revoked'):
+                ReenrollmentAuthentication().authenticate(context)
+
+    def test_reenrollment_rejects_invalid_csr_type(self) -> None:
+        certificate, _ = _certificate_and_csr()
+        context = EstCertificateRequestContext(client_certificate=certificate, cert_requested=Mock())
+        issued = Mock(credential=Mock())
+
+        with patch.object(IssuedCredentialModel, 'get_credential_for_certificate', return_value=issued):
+            with pytest.raises(ValueError, match='Invalid credential model for reenrollment'):
+                ReenrollmentAuthentication().authenticate(context)
+
+    def test_reenrollment_rejects_extension_mismatch(self) -> None:
+        certificate, _ = _certificate_and_csr()
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        csr = (
+            x509.CertificateSigningRequestBuilder()
+            .subject_name(certificate.subject)
+            .sign(key, hashes.SHA256())
+        )
+
+        with pytest.raises(ValueError, match='CSR/client SAN does not match'):
+            ReenrollmentAuthentication()._validate_certificate_extensions(certificate, certificate, csr)
 
 
 @pytest.mark.django_db
@@ -205,6 +415,62 @@ class TestCmpSharedSecretAuthentication:
         
         with pytest.raises(TypeError, match="CMP shared secret authentication requires a PKIMessage"):
             auth.authenticate(context)
+
+    def test_non_pbm_message_is_skipped(self) -> None:
+        auth = CmpSharedSecretAuthentication()
+        message = MagicMock(spec=rfc4210.PKIMessage)
+        message.__bool__.return_value = True
+        message.__getitem__.return_value = MagicMock()
+        message['header']['protectionAlg']['algorithm'].prettyPrint.return_value = '1.2.3'
+        context = CmpBaseRequestContext(protocol='cmp', parsed_message=message)
+        with patch('request.authentication.cmp.AlgorithmIdentifier.from_dotted_string', return_value='signature'):
+            assert auth._validate_context(context) is False
+
+    def test_missing_sender_kid_is_rejected(self) -> None:
+        auth = CmpSharedSecretAuthentication()
+        message = MagicMock(spec=rfc4210.PKIMessage)
+        message['header']['senderKID'].prettyPrint.side_effect = ValueError('missing')
+        context = CmpBaseRequestContext(parsed_message=message)
+
+        with pytest.raises(ValueError, match='Invalid or missing senderKID'):
+            auth._extract_sender_kid(context)
+
+    def test_device_lookup_and_configuration_failures_are_rejected(self) -> None:
+        auth = CmpSharedSecretAuthentication()
+        with patch.object(auth, '_validate_context', return_value=True), \
+                patch.object(auth, '_extract_sender_kid', return_value=7), \
+                patch.object(auth, '_get_device', side_effect=ValueError('device lookup failed')):
+            with pytest.raises(ValueError, match='device lookup failed'):
+                auth.authenticate(CmpBaseRequestContext(protocol='cmp', parsed_message=Mock()))
+
+        device = Mock(common_name='device', onboarding_config=None, no_onboarding_config=None)
+        with pytest.raises(ValueError, match='no shared secret configured'):
+            auth._validate_device_configuration(device, sender_kid=7)
+
+    def test_successful_shared_secret_authentication_populates_context(self) -> None:
+        auth = CmpSharedSecretAuthentication()
+        context = CmpBaseRequestContext(protocol='cmp', parsed_message=Mock())
+        device = Mock(common_name='device', domain=Mock())
+        config = Mock(cmp_shared_secret='secret')
+        with patch.object(auth, '_validate_context', return_value=True), \
+                patch.object(auth, '_extract_sender_kid', return_value=7), \
+                patch.object(auth, '_get_device', return_value=device), \
+                patch.object(auth, '_validate_device_configuration', return_value=config), \
+                patch.object(auth, '_verify_hmac_protection') as verify:
+            auth.authenticate(context)
+
+        verify.assert_called_once_with(context, 'secret')
+        assert context.device is device
+        assert context.domain is device.domain
+
+
+def test_signature_authentication_skips_wrong_context_and_operation() -> None:
+    init_auth = CmpSignatureBasedInitializationAuthentication()
+    cert_auth = CmpSignatureBasedCertificationAuthentication()
+    assert init_auth.authenticate(BaseRequestContext(protocol='cmp')) is None
+    assert cert_auth.authenticate(BaseRequestContext(protocol='cmp')) is None
+    assert init_auth._should_authenticate(CmpCertificateRequestContext(protocol='cmp', operation='certification')) is False
+    assert cert_auth._should_authenticate(CmpCertificateRequestContext(protocol='cmp', operation='initialization')) is False
 
 
 @pytest.mark.django_db
@@ -347,6 +613,31 @@ class TestCompositeAuthentication:
             onboarding_config = device.onboarding_config
             # Only set password if protocol supports it
             from onboarding.models import OnboardingProtocol
+
+
+            def _certificate_and_csr() -> tuple[x509.Certificate, x509.CertificateSigningRequest]:
+                key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+                subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'device')])
+                san = x509.SubjectAlternativeName([x509.DNSName('device.example')])
+                csr = (
+                    x509.CertificateSigningRequestBuilder()
+                    .subject_name(subject)
+                    .add_extension(san, critical=False)
+                    .sign(key, hashes.SHA256())
+                )
+                now = datetime.now(timezone.utc)
+                certificate = (
+                    x509.CertificateBuilder()
+                    .subject_name(subject)
+                    .issuer_name(subject)
+                    .public_key(key.public_key())
+                    .serial_number(x509.random_serial_number())
+                    .not_valid_before(now)
+                    .not_valid_after(now + timedelta(days=1))
+                    .add_extension(san, critical=False)
+                    .sign(key, hashes.SHA256())
+                )
+                return certificate, csr
             if onboarding_config.onboarding_protocol == OnboardingProtocol.EST_USERNAME_PASSWORD:
                 onboarding_config.est_password = 'onboarding-password-123'
                 onboarding_config.save()
@@ -439,3 +730,162 @@ class TestAuthenticationEdgeCases:
         
         with pytest.raises(ValueError, match="Authentication failed: Invalid username or password"):
             auth.authenticate(context)
+
+
+class TestRemainingEstAuthenticationBranches:
+    """Cover EST validation branches with concrete certificates and contexts."""
+
+    def test_reenrollment_context_validation_errors(self) -> None:
+        certificate, csr = _certificate_and_csr()
+        auth = ReenrollmentAuthentication()
+
+        with pytest.raises(ValueError, match='Invalid client certificate type'):
+            auth._validate_context(EstCertificateRequestContext(client_certificate=Mock(), cert_requested=csr))
+        with pytest.raises(ValueError, match='CSR is missing'):
+            auth._validate_context(EstCertificateRequestContext(client_certificate=certificate))
+
+    def test_reenrollment_missing_issued_credential(self) -> None:
+        certificate, csr = _certificate_and_csr()
+        context = EstCertificateRequestContext(client_certificate=certificate, cert_requested=csr)
+        with patch.object(IssuedCredentialModel, 'get_credential_for_certificate',
+                          side_effect=IssuedCredentialModel.DoesNotExist):
+            with pytest.raises(ValueError, match='Issued credential not found'):
+                ReenrollmentAuthentication().authenticate(context)
+
+    def test_reenrollment_subject_and_extension_success(self) -> None:
+        certificate, csr = _certificate_and_csr()
+        credential = Mock()
+        credential.is_valid_issued_credential.return_value = (True, '')
+        credential.certificate_or_error = Mock()
+        credential.certificate_or_error.subjects_match.return_value = True
+        credential.certificate_or_error.get_certificate_serializer.return_value.as_crypto.return_value = certificate
+        issued = Mock(credential=credential, device=Mock())
+        context = EstCertificateRequestContext(client_certificate=certificate, cert_requested=csr)
+
+        with patch.object(IssuedCredentialModel, 'get_credential_for_certificate', return_value=issued):
+            ReenrollmentAuthentication().authenticate(context)
+        assert context.device is issued.device
+
+        credential.certificate_or_error.subjects_match.side_effect = [False, True]
+        with pytest.raises(ValueError, match='subject does not match'):
+            ReenrollmentAuthentication()._validate_credential(credential, csr, certificate)
+
+    def test_reenrollment_extension_serializer_failure(self) -> None:
+        certificate, csr = _certificate_and_csr()
+        credential = Mock()
+        credential.certificate_or_error.get_certificate_serializer.side_effect = ValueError('bad serializer')
+        with pytest.raises(ValueError, match='Certificate extension validation failed'):
+            ReenrollmentAuthentication()._validate_certificate_extensions_safe(credential, certificate, csr)
+
+
+class TestRemainingCmpAuthenticationBranches:
+    """Cover CMP protocol guards, certificate paths, and configuration errors."""
+
+    def test_base_helpers_and_extra_certificate_extraction(self) -> None:
+        certificate, _ = _certificate_and_csr()
+        auth = CmpSignatureBasedInitializationAuthentication()
+        context = CmpBaseRequestContext(domain_str='.aoki')
+        context.raw_message = Mock(path='/p/.aoki/initialization')
+        assert auth._is_aoki_request(context) is True
+        context.raw_message = None
+        assert auth._is_aoki_request(context) is False
+
+        message = _cmp_message_with_certificate(certificate)
+        signer, intermediates = auth._extract_extra_certs(
+            CmpBaseRequestContext(parsed_message=message)
+        )
+        assert signer.subject == certificate.subject
+        assert intermediates == []
+        with pytest.raises(ValueError, match='No extra certificates'):
+            auth._extract_extra_certs(CmpBaseRequestContext(parsed_message=_typed_cmp_message()))
+
+    def test_signature_verification_rsa_and_ec(self) -> None:
+        message = _typed_cmp_message()
+        message['protection'] = message['protection'].clone(
+            value=univ.BitString.fromOctetString(b'signature')
+        )
+        with patch('request.authentication.cmp.encoder.encode', return_value=b'encoded'), \
+            patch('request.authentication.cmp.SignatureSuite.from_certificate') as suite_factory:
+            suite_factory.return_value.algorithm_identifier.hash_algorithm = Mock(
+                hash_algorithm=lambda: hashes.SHA256()
+            )
+            rsa_key = Mock(spec=rsa.RSAPublicKey)
+            certificate = Mock(spec=x509.Certificate)
+            certificate.public_key.return_value = rsa_key
+            CmpSignatureBasedInitializationAuthentication()._verify_protection_signature(message, certificate)
+            rsa_key.verify.assert_called_once()
+
+            ec_key = Mock(spec=ec.EllipticCurvePublicKey)
+            certificate.public_key.return_value = ec_key
+            CmpSignatureBasedInitializationAuthentication()._verify_protection_signature(message, certificate)
+            ec_key.verify.assert_called_once()
+
+    @pytest.mark.parametrize(
+        ('protocol', 'operation', 'parsed_message', 'error'),
+        [
+            ('est', 'initialization', _typed_cmp_message(), 'requires CMP protocol'),
+            ('cmp', 'initialization', None, 'requires a parsed message'),
+            ('cmp', 'initialization', object(), 'requires a PKIMessage'),
+        ],
+    )
+    def test_initialization_guards(self, protocol: str, operation: str, parsed_message: Any, error: str) -> None:
+        context = CmpCertificateRequestContext(
+            protocol=protocol, operation=operation, parsed_message=parsed_message
+        )
+        with pytest.raises(ValueError, match=error):
+            CmpSignatureBasedInitializationAuthentication()._should_authenticate(context)
+
+    def test_initialization_success_and_configuration_errors(self) -> None:
+        certificate, _ = _certificate_and_csr()
+        context = CmpCertificateRequestContext(
+            protocol='cmp', operation='initialization', parsed_message=_typed_cmp_message()
+        )
+        device = Mock(domain=Mock(), onboarding_config=Mock())
+        device.onboarding_config.onboarding_protocol = 'wrong'
+        with pytest.raises(ValueError, match='Wrong onboarding protocol'):
+            CmpSignatureBasedInitializationAuthentication()._verify_device_configuration(device)
+        device.onboarding_config.onboarding_protocol = OnboardingProtocol.CMP_IDEVID
+        device.onboarding_config.has_pki_protocol.return_value = False
+        with pytest.raises(ValueError, match='PKI protocol CMP expected'):
+            CmpSignatureBasedInitializationAuthentication()._verify_device_configuration(device)
+
+        auth = CmpSignatureBasedInitializationAuthentication()
+        with patch.object(auth, '_extract_extra_certs', return_value=(certificate, [])), \
+                patch.object(auth, '_authenticate_and_verify_device', return_value=device), \
+                patch.object(auth, '_should_authenticate', return_value=True):
+            auth.authenticate(context)
+        assert context.client_certificate is certificate
+        assert context.device is device
+
+    def test_certification_and_revocation_guards(self) -> None:
+        certificate, _ = _certificate_and_csr()
+        cert_auth = CmpSignatureBasedCertificationAuthentication()
+        context = CmpCertificateRequestContext(protocol='cmp', operation='certification',
+                                                parsed_message=_typed_cmp_message(), cert_profile_str=None)
+        with patch('request.authentication.cmp.AlgorithmIdentifier.from_dotted_string', return_value='signature'):
+            with pytest.raises(ValueError, match='Missing application certificate template'):
+                cert_auth._should_authenticate(context)
+        with pytest.raises(ValueError, match='signer certificate is missing'):
+            cert_auth._authenticate_device(context)
+
+        rev_auth = CmpSignatureBasedRevocationAuthentication()
+        rev_context = CmpBaseRequestContext(protocol='cmp', operation='revocation',
+                                            parsed_message=_typed_cmp_message())
+        with pytest.raises(ValueError, match='requires a PKIMessage'):
+            rev_context.parsed_message = object()
+            rev_auth._should_authenticate(rev_context)
+
+    def test_poll_fallback_and_idevid_errors(self) -> None:
+        certificate, _ = _certificate_and_csr()
+        auth = CmpSignatureBasedPollAuthentication()
+        context = CmpPollRequestContext(protocol='cmp', cmp_body_type='pollReq',
+                        parsed_message=_typed_cmp_message())
+        with patch.object(auth, '_extract_extra_certs', return_value=(certificate, [])), \
+                patch.object(auth, '_authenticate_with_domain_credential', return_value=None), \
+            patch.object(auth, '_authenticate_with_idevid', return_value=None), \
+            patch('request.authentication.cmp.AlgorithmIdentifier.from_dotted_string', return_value='signature'):
+            with pytest.raises(ValueError, match='Device authentication failed'):
+                auth.authenticate(context)
+        with patch('request.authentication.cmp.IDevIDAuthenticator.authenticate_idevid_from_x509',
+                   side_effect=ValueError('invalid')):
+            assert auth._authenticate_with_idevid(context, certificate, []) is None

--- a/trustpoint/request/tests/test_authorization.py
+++ b/trustpoint/request/tests/test_authorization.py
@@ -2,10 +2,15 @@
 # SPDX-License-Identifier: MIT
 
 """Tests for authorization components."""
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.x509.oid import NameOID
 from devices.models import DeviceModel
+from management.models.security import SecurityConfig
 from pki.models.domain import DomainModel
 
 from request.authorization.base import (
@@ -13,10 +18,31 @@ from request.authorization.base import (
     CertificateProfileAuthorization,
     CompositeAuthorization,
     DomainScopeValidation,
+    DevOwnerIDAuthorization,
+    OnboardingDomainCredentialAuthorization,
     ProtocolAuthorization,
+    SecurityConfigAuthorization,
 )
 from request.authorization.est import EstAuthorization, EstOperationAuthorization
-from request.request_context import BaseRequestContext, BaseCertificateRequestContext, EstBaseRequestContext, EstCertificateRequestContext
+from request.authorization.manual import ManualAuthorization
+from request.authorization.rest import RestAuthorization, RestOperationAuthorization
+from request.request_context import (
+    BaseRequestContext,
+    BaseCertificateRequestContext,
+    CmpBaseRequestContext,
+    EstBaseRequestContext,
+    EstCertificateRequestContext,
+    HttpBaseRequestContext,
+    RestBaseRequestContext,
+)
+
+
+def _csr(private_key: rsa.RSAPrivateKey | ec.EllipticCurvePrivateKey, *, ca: bool = False) -> x509.CertificateSigningRequest:
+    builder = x509.CertificateSigningRequestBuilder().subject_name(
+        x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'authorization-test')])
+    )
+    builder = builder.add_extension(x509.BasicConstraints(ca=ca, path_length=None), critical=True)
+    return builder.sign(private_key, hashes.SHA256())
 
 
 class TestProtocolAuthorization:
@@ -225,6 +251,33 @@ class TestCertificateProfileAuthorization:
         # Should not raise an exception
         auth.authorize(context)
 
+    def test_cert_profile_requires_domain_and_device(self) -> None:
+        auth = CertificateProfileAuthorization()
+        context = MagicMock(spec=BaseCertificateRequestContext)
+        context.domain = None
+        with pytest.raises(ValueError, match='Domain information is missing'):
+            auth.authorize(context)
+
+        context.domain = Mock()
+        context.device = None
+        with pytest.raises(ValueError, match='Device information is missing'):
+            auth.authorize(context)
+
+    def test_aoki_profile_defaults_to_domain_credential(self) -> None:
+        auth = CertificateProfileAuthorization()
+        context = MagicMock(spec=BaseCertificateRequestContext)
+        context.domain_str = '.aoki'
+        context.cert_profile_str = None
+        context.domain = Mock()
+        context.domain.get_domain_credential_profile_name.return_value = 'domain_credential'
+        context.device = Mock(onboarding_config=Mock())
+        context.domain.get_allowed_cert_profile.return_value = Mock(
+            credential_type='certificate'
+        )
+        with patch('request.authorization.base.ProfileValidator.validate'):
+            auth.authorize(context)
+        assert context.cert_profile_str == 'domain_credential'
+
 
 class TestDomainScopeValidation:
     """Test cases for DomainScopeValidation."""
@@ -309,6 +362,114 @@ class TestDomainScopeValidation:
 
         assert f"Unauthorized requested domain: '{domain}'" in str(exc_info.value)
         assert "Device domain: 'None'" in str(exc_info.value)
+
+
+class TestOnboardingAndOwnerAuthorization:
+    def test_onboarding_domain_profile_is_allowed_without_existing_credential(self) -> None:
+        context = MagicMock(spec=BaseCertificateRequestContext)
+        context.device = Mock(onboarding_config=Mock(), common_name='device')
+        context.certificate_profile_model = Mock(unique_name='domain_credential')
+        OnboardingDomainCredentialAuthorization().authorize(context)
+
+    def test_onboarding_requires_a_valid_domain_credential(self) -> None:
+        context = MagicMock(spec=BaseCertificateRequestContext)
+        context.device = Mock(onboarding_config=Mock(), common_name='device')
+        context.certificate_profile_model = Mock(unique_name='tls_server')
+        context.domain = None
+        with patch('request.authorization.base.IssuedCredentialModel.objects.filter') as filter_mock:
+            filter_mock.return_value.select_related.return_value = [
+                Mock(is_valid_domain_credential=Mock(return_value=(False, 'expired')))
+            ]
+            with pytest.raises(ValueError, match='no valid domain credential'):
+                OnboardingDomainCredentialAuthorization().authorize(context)
+        assert context.http_response_status == 403
+
+    def test_dev_owner_id_skips_non_aoki_and_sets_owner_credential(self) -> None:
+        component = DevOwnerIDAuthorization()
+        component.authorize(BaseRequestContext(protocol='rest', domain_str='.aoki'))
+        context = CmpBaseRequestContext(protocol='cmp', domain_str='.aoki', client_certificate=Mock())
+        owner = Mock()
+        with patch('request.authorization.base.AokiServiceMixin.get_owner_credential', return_value=owner):
+            component.authorize(context)
+        assert context.owner_credential is owner
+
+    def test_dev_owner_id_rejects_missing_certificate_and_missing_owner(self) -> None:
+        context = CmpBaseRequestContext(protocol='cmp', domain_str='.aoki')
+        with pytest.raises(ValueError, match='Client certificate is missing'):
+            DevOwnerIDAuthorization().authorize(context)
+        context.client_certificate = Mock()
+        with patch('request.authorization.base.AokiServiceMixin.get_owner_credential', return_value=None), \
+             patch('request.authorization.base.AokiServiceMixin.get_domain_based_owner_credential', return_value=None):
+            with pytest.raises(ValueError, match='No DevOwnerID credential'):
+                DevOwnerIDAuthorization().authorize(context)
+        assert context.http_response_status == 403
+
+
+class TestSecurityConfigAuthorization:
+    def test_rsa_key_size_is_allowed_and_rejected(self) -> None:
+        csr = _csr(rsa.generate_private_key(public_exponent=65537, key_size=2048))
+        component = SecurityConfigAuthorization()
+        component._check_key_constraints(csr, Mock(rsa_minimum_key_size=2048))
+        with pytest.raises(ValueError, match='below the minimum'):
+            component._check_key_constraints(csr, Mock(rsa_minimum_key_size=4096))
+        with pytest.raises(ValueError, match='not permitted'):
+            component._check_key_constraints(csr, Mock(rsa_minimum_key_size=None))
+
+    def test_curve_and_signature_restrictions_are_enforced(self) -> None:
+        csr = _csr(ec.generate_private_key(ec.SECP256R1()))
+        component = SecurityConfigAuthorization()
+        curve_oid = component._ec_curve_oid(csr.public_key())
+        assert curve_oid is not None
+        with pytest.raises(ValueError, match='ECC curve'):
+            component._check_key_constraints(csr, Mock(not_permitted_ecc_curve_oids=[curve_oid]))
+        hash_oid = component._hash_oid('sha256')
+        assert hash_oid is not None
+        with pytest.raises(ValueError, match='Signature hash algorithm'):
+            component._check_signature_algorithm(csr, Mock(not_permitted_signature_algorithm_oids=[hash_oid]))
+
+    def test_ca_policy_and_missing_security_config_paths(self) -> None:
+        csr = _csr(rsa.generate_private_key(public_exponent=65537, key_size=2048), ca=True)
+        with pytest.raises(ValueError, match='CA certificate issuance'):
+            SecurityConfigAuthorization()._check_ca_issuance(csr, Mock(allow_ca_issuance=False))
+        context = MagicMock(spec=BaseCertificateRequestContext)
+        context.cert_requested = csr
+        context.cert_requested_profile_validated = None
+        with patch.object(SecurityConfig.objects, 'get', side_effect=SecurityConfig.DoesNotExist):
+            SecurityConfigAuthorization().authorize(context)
+
+
+class TestManualAndRestAuthorization:
+    def test_manual_authorization_contains_manual_protocol(self) -> None:
+        protocols = next(component for component in ManualAuthorization().components if isinstance(component, ProtocolAuthorization))
+        assert protocols.allowed_protocols == ['manual']
+
+    def test_rest_operation_authorization_success_and_failures(self) -> None:
+        component = RestOperationAuthorization(['enroll'])
+        component.authorize(RestBaseRequestContext(operation='enroll'))
+        with pytest.raises(TypeError, match='RestBaseRequestContext'):
+            component.authorize(HttpBaseRequestContext())
+        with pytest.raises(ValueError, match='Operation information is missing'):
+            component.authorize(RestBaseRequestContext())
+        with pytest.raises(ValueError, match="Unauthorized operation: 'reenroll'"):
+            component.authorize(RestBaseRequestContext(operation='reenroll'))
+
+    def test_rest_authorization_forwards_custom_operations(self) -> None:
+        auth = RestAuthorization(['issue'])
+        operation = next(component for component in auth.components if isinstance(component, RestOperationAuthorization))
+        assert operation.allowed_operations == ['issue']
+
+    def test_rest_authorization_default_components_and_operations(self) -> None:
+        auth = RestAuthorization()
+        assert [type(component).__name__ for component in auth.components] == [
+            'DomainScopeValidation',
+            'CertificateProfileAuthorization',
+            'OnboardingDomainCredentialAuthorization',
+            'ProtocolAuthorization',
+            'RestOperationAuthorization',
+            'SecurityConfigAuthorization',
+        ]
+        operation = next(component for component in auth.components if isinstance(component, RestOperationAuthorization))
+        assert operation.allowed_operations == ['enroll', 'reenroll']
 
 
 class TestCompositeAuthorization:

--- a/trustpoint/request/tests/test_certificate_request_processors.py
+++ b/trustpoint/request/tests/test_certificate_request_processors.py
@@ -7,12 +7,13 @@ from __future__ import annotations
 
 from unittest.mock import Mock, patch
 
+import pytest
 from cryptography import x509
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 from request.operation_processor.issue_cert import LocalCaCertificateIssueProcessor
 from request.operation_processor.issue_cred import CredentialIssueProcessor
-from request.request_context import CmpCertificateRequestContext, ManualCredentialRequestContext
+from request.request_context import BaseRequestContext, CmpCertificateRequestContext, ManualCredentialRequestContext
 from workflows2.models import Workflow2Run
 from workflows2.services.dispatch import DispatchOutcome
 
@@ -61,3 +62,28 @@ def test_local_ca_certificate_issue_processor_tolerates_request_without_meta() -
         url = LocalCaCertificateIssueProcessor()._get_crl_distribution_point_url(context, ca_id=7)  # noqa: SLF001
 
     assert url.endswith('/crl/7')
+
+
+def test_credential_issue_processor_validates_context_and_request() -> None:
+    """Reject contexts without the required credential issuance inputs."""
+    processor = CredentialIssueProcessor()
+    with pytest.raises(TypeError, match='subclass of BaseCredentialRequestContext'):
+        processor.process_operation(BaseRequestContext())
+    with pytest.raises(ValueError, match='certificate request'):
+        processor.process_operation(ManualCredentialRequestContext(domain=Mock()))
+    with pytest.raises(ValueError, match='domain'):
+        processor.process_operation(ManualCredentialRequestContext(cert_requested=x509.CertificateBuilder()))
+
+
+def test_credential_issue_processor_preserves_existing_key_and_propagates_issue_errors() -> None:
+    """Reuse an existing key and expose errors from certificate issuance."""
+    context = ManualCredentialRequestContext(
+        cert_requested=x509.CertificateBuilder(), domain=Mock(), private_key=Mock(),
+    )
+    with patch(
+        'request.operation_processor.issue_cred.CertificateIssueProcessor.process_operation',
+        side_effect=RuntimeError('issue failed'),
+    ) as issue:
+        with pytest.raises(RuntimeError, match='issue failed'):
+            CredentialIssueProcessor().process_operation(context)
+    issue.assert_called_once_with(context)

--- a/trustpoint/request/tests/test_cmp_authorization.py
+++ b/trustpoint/request/tests/test_cmp_authorization.py
@@ -94,6 +94,56 @@ class TestCmpRevocationAuthorization:
             with pytest.raises(ValueError, match='Signer certificate is not associated'):
                 CmpRevocationAuthorization().authorize(ctx)
 
+    def test_self_revocation_authorizes_matching_signer_certificate(self) -> None:
+        ctx = CmpRevocationRequestContext(
+            operation='revocation', cert_serial_number='1234',
+            client_certificate=Mock(), domain=Mock()
+        )
+        issued = Mock(credential=Mock(certificate_or_error=Mock(serial_number='1234')))
+        with patch.object(IssuedCredentialModel, 'get_credential_for_certificate', return_value=issued):
+            CmpRevocationAuthorization().authorize(ctx)
+        assert ctx.credential_to_revoke is issued
+
+    def test_domain_credential_revocation_rejects_other_device(self) -> None:
+        target_device = Mock()
+        ctx = CmpRevocationRequestContext(
+            operation='revocation', cert_serial_number='1234',
+            client_certificate=Mock(), domain=Mock(), device=target_device
+        )
+        issued = Mock(
+            credential=Mock(certificate_or_error=Mock(serial_number='5678')),
+            device=Mock(), is_valid_domain_credential=Mock(return_value=(True, None)),
+        )
+        with patch.object(IssuedCredentialModel, 'get_credential_for_certificate', return_value=issued):
+            with pytest.raises(ValueError, match='Signer device does not match'):
+                CmpRevocationAuthorization().authorize(ctx)
+        assert ctx.http_response_status == 403
+
+        def test_self_revocation_authorizes_matching_signer_certificate(self) -> None:
+            ctx = CmpRevocationRequestContext(
+                operation='revocation', cert_serial_number='1234', client_certificate=Mock(), domain=Mock()
+            )
+            issued = Mock(credential=Mock(certificate_or_error=Mock(serial_number='1234')), common_name='device-cert')
+            with patch.object(IssuedCredentialModel, 'get_credential_for_certificate', return_value=issued):
+                CmpRevocationAuthorization().authorize(ctx)
+            assert ctx.credential_to_revoke is issued
+
+        def test_domain_credential_revocation_rejects_other_device(self) -> None:
+            target_device = Mock()
+            ctx = CmpRevocationRequestContext(
+                operation='revocation', cert_serial_number='1234', client_certificate=Mock(),
+                domain=Mock(), device=target_device,
+            )
+            issued = Mock(
+                credential=Mock(certificate_or_error=Mock(serial_number='5678')),
+                device=Mock(),
+                is_valid_domain_credential=Mock(return_value=(True, None)),
+            )
+            with patch.object(IssuedCredentialModel, 'get_credential_for_certificate', return_value=issued):
+                with pytest.raises(ValueError, match='Signer device does not match'):
+                    CmpRevocationAuthorization().authorize(ctx)
+            assert ctx.http_response_status == 403
+
 
 # ---------------------------------------------------------------------------
 # CmpCertConfAuthorization
@@ -235,6 +285,51 @@ class TestCmpPollAuthorization:
             with pytest.raises(ValueError, match='No CMP transaction found'):
                 CmpPollAuthorization().authorize(ctx)
 
+    def test_poll_request_operation_mismatch_is_rejected(self) -> None:
+        from request.cmp_transaction_state import CmpTransactionState
+
+        ctx = CmpPollRequestContext(
+            cmp_body_type='pollReq', cmp_transaction_id='tx',
+            poll_cert_req_id=0, operation='certification'
+        )
+        transaction = Mock(operation='initialization', cert_req_id=0, device_id=None, domain_id=None)
+        with patch.object(CmpTransactionState, 'get_by_transaction_id', return_value=transaction):
+            with pytest.raises(ValueError, match='operation mismatch'):
+                CmpPollAuthorization().authorize(ctx)
+        assert ctx.http_response_status == 403
+
+        @pytest.mark.parametrize(
+            ('field', 'value', 'message'),
+            [
+                ('operation', 'certification', 'operation mismatch'),
+                ('poll_cert_req_id', 9, 'certReqId mismatch'),
+            ],
+        )
+        def test_poll_request_mismatches_transaction_are_rejected(
+            self, field: str, value: object, message: str
+        ) -> None:
+            ctx = CmpPollRequestContext(
+                cmp_body_type='pollReq', cmp_transaction_id='tx', poll_cert_req_id=0,
+                operation='initialization',
+            )
+            setattr(ctx, field, value)
+            transaction = Mock(operation='initialization', cert_req_id=0, device_id=None, domain_id=None)
+            with patch('request.authorization.cmp.CmpTransactionState.get_by_transaction_id', return_value=transaction):
+                with pytest.raises(ValueError, match=message):
+                    CmpPollAuthorization().authorize(ctx)
+            assert ctx.http_response_status == 403
+
+        def test_poll_request_device_and_domain_mismatches_are_rejected(self) -> None:
+            ctx = CmpPollRequestContext(
+                cmp_body_type='pollReq', cmp_transaction_id='tx', poll_cert_req_id=0,
+                device=Mock(id=1), domain=Mock(id=2),
+            )
+            transaction = Mock(operation='initialization', cert_req_id=0, device_id=3, domain_id=4)
+            with patch('request.authorization.cmp.CmpTransactionState.get_by_transaction_id', return_value=transaction):
+                with pytest.raises(ValueError, match='device does not match'):
+                    CmpPollAuthorization().authorize(ctx)
+            assert ctx.http_response_status == 403
+
     @pytest.mark.django_db
     def test_valid_poll_request_hydrates_context(self) -> None:
         """A valid pollReq loads the stored transaction into the context."""
@@ -338,6 +433,16 @@ class TestCmpOperationAuthorization:
         ctx = CmpBaseRequestContext(operation='certification')
         ctx.parsed_message = msg
         CmpOperationAuthorization(['certification']).authorize(ctx)  # must not raise
+
+        def test_certconf_and_pollreq_bodies_are_allowed_for_enrollment_operations(self) -> None:
+            from pyasn1_modules.rfc4210 import PKIMessage
+
+            for operation, body_type in (('certification', 'certConf'), ('initialization', 'pollReq')):
+                msg = MagicMock()
+                msg.__class__ = PKIMessage
+                msg['body'].getName.return_value = body_type
+                ctx = CmpBaseRequestContext(operation=operation, parsed_message=msg)
+                CmpOperationAuthorization([operation]).authorize(ctx)
 
 
 # ---------------------------------------------------------------------------

--- a/trustpoint/request/tests/test_cmp_client.py
+++ b/trustpoint/request/tests/test_cmp_client.py
@@ -12,6 +12,33 @@ from request.clients.cmp_client import CmpClient, CmpClientError
 from request.request_context import CmpBaseRequestContext
 
 
+def _der(tag: int, value: bytes) -> bytes:
+    """Build a DER TLV for the raw extraction tests."""
+    length = len(value)
+    if length < 128:
+        encoded_length = bytes([length])
+    else:
+        length_bytes = length.to_bytes((length.bit_length() + 7) // 8, 'big')
+        encoded_length = bytes([0x80 | len(length_bytes)]) + length_bytes
+    return bytes([tag]) + encoded_length + value
+
+
+def _raw_cmp_response(*, ca_pubs: bytes = b'', extra_certs: bytes = b'') -> bytes:
+    """Build the CertRepMessage shape traversed by CmpClient."""
+    issued_cert = _der(0x30, b'issued')
+    certified_key_pair = _der(0x30, _der(0xA0, issued_cert))
+    cert_response = _der(
+        0x30,
+        _der(0x02, b'\x00') + _der(0x30, _der(0x02, b'\x00')) + certified_key_pair,
+    )
+    responses = _der(0x30, cert_response)
+    cert_rep_message = _der(0x30, ca_pubs + responses)
+    body = _der(0x30, cert_rep_message)
+    header = _der(0x30, b'')
+    body_and_extra = header + body + extra_certs
+    return _der(0x30, body_and_extra)
+
+
 class TestCmpClient:
     """Test cases for the CmpClient class."""
 
@@ -221,6 +248,122 @@ class TestCmpClient:
         with pytest.raises(ValueError, match='DER parse error: offset 5 beyond data length 4'):
             client._parse_der_tlv(data, 5)
 
+    @pytest.mark.parametrize(
+        ('data', 'offset', 'message'),
+        [
+            (b'', 0, 'DER parse error: offset 0 beyond data length 0'),
+            (b'\x30', 0, 'index out of range'),
+        ],
+    )
+    def test_parse_der_tlv_malformed_or_truncated(
+        self,
+        valid_context: CmpBaseRequestContext,
+        data: bytes,
+        offset: int,
+        message: str,
+    ) -> None:
+        """Test malformed and truncated DER length fields."""
+        client = CmpClient(valid_context)
+
+        with pytest.raises((ValueError, IndexError), match=message):
+            client._parse_der_tlv(data, offset)
+
+    def test_parse_der_tlv_preserves_declared_length_for_truncated_value(
+        self, valid_context: CmpBaseRequestContext
+    ) -> None:
+        """Test the parser's declared-length result for an incomplete value."""
+        client = CmpClient(valid_context)
+
+        _, header_length, value_length, total_length = client._parse_der_tlv(b'\x30\x02\x00', 0)
+
+        assert (header_length, value_length, total_length) == (2, 2, 4)
+
+    def test_extract_certs_from_raw_response_navigates_real_der(self, valid_context: CmpBaseRequestContext) -> None:
+        """Test extraction through the complete raw CertRepMessage structure."""
+        client = CmpClient(valid_context)
+        extra_one = _der(0x30, b'chain-one')
+        extra_two = _der(0x30, b'chain-two')
+        raw_response = _raw_cmp_response(
+            ca_pubs=_der(0xA1, _der(0x30, b'ca-pub')),
+            extra_certs=_der(0xA1, _der(0x30, extra_one + extra_two)),
+        )
+
+        issued_cert, extra_certs = client._extract_certs_from_raw_response(raw_response)
+
+        assert issued_cert == _der(0x30, b'issued')
+        assert extra_certs == [extra_one, extra_two]
+
+    def test_extract_certs_from_raw_response_without_optional_fields(
+        self, valid_context: CmpBaseRequestContext
+    ) -> None:
+        """Test extraction when caPubs and extraCerts are absent."""
+        client = CmpClient(valid_context)
+
+        issued_cert, extra_certs = client._extract_certs_from_raw_response(_raw_cmp_response())
+
+        assert issued_cert == _der(0x30, b'issued')
+        assert extra_certs == []
+
+    def test_extract_certs_from_raw_response_raw_certificate_choice(
+        self, valid_context: CmpBaseRequestContext
+    ) -> None:
+        """Test the fallback for an unexpected CertOrEncCert tag."""
+        client = CmpClient(valid_context)
+        raw_response = _raw_cmp_response()
+        issued_cert = _der(0x30, b'issued')
+        raw_response = raw_response.replace(_der(0xA0, issued_cert), issued_cert, 1)
+
+        extracted_cert, extra_certs = client._extract_certs_from_raw_response(raw_response)
+
+        assert extracted_cert == issued_cert
+        assert extra_certs == []
+
+    def test_extract_extra_certs_handles_non_sequence_wrapper(
+        self, valid_context: CmpBaseRequestContext
+    ) -> None:
+        """Test extraction of an extra certificate from a non-SEQUENCE wrapper."""
+        client = CmpClient(valid_context)
+        extra_cert = _der(0xA0, b'extra')
+        wrapped_extra_cert = _der(0xA1, extra_cert)
+
+        extracted = client._extract_extra_certs(wrapped_extra_cert, 0, len(wrapped_extra_cert))
+
+        assert extracted == [extra_cert]
+
+    def test_extract_extra_certs_ignores_other_trailing_tlv(
+        self, valid_context: CmpBaseRequestContext
+    ) -> None:
+        """Test that unrelated fields after the body are ignored."""
+        client = CmpClient(valid_context)
+        ignored_tlv = _der(0x30, b'ignored')
+
+        extracted = client._extract_extra_certs(ignored_tlv, 0, len(ignored_tlv))
+
+        assert extracted == []
+
+    def test_skip_cert_req_id_and_status_requires_certified_key_pair(
+        self, valid_context: CmpBaseRequestContext
+    ) -> None:
+        """Test the exact error for a CertResponse without a key pair."""
+        client = CmpClient(valid_context)
+        raw_cert_response = _der(0x02, b'\x00') + _der(0x30, b'')
+
+        with pytest.raises(CmpClientError, match=r'^No certifiedKeyPair found in CertResponse$'):
+            client._skip_cert_req_id_and_status(raw_cert_response, 0, len(raw_cert_response))
+
+    @pytest.mark.parametrize(
+        'raw_data',
+        [b'', b'\x30', b'\x30\x02\x30'],
+    )
+    def test_extract_certs_from_raw_response_rejects_malformed_der(
+        self, valid_context: CmpBaseRequestContext, raw_data: bytes
+    ) -> None:
+        """Test exact client errors for malformed raw CMP responses."""
+        client = CmpClient(valid_context)
+
+        with pytest.raises(CmpClientError, match=r'^Failed to extract certificates from raw CMP response DER:'):
+            client._extract_certs_from_raw_response(raw_data)
+
     @patch('request.clients.cmp_client.requests.post')
     @patch('request.clients.cmp_client.encoder.encode')
     def test_send_pki_message_success(self, mock_encode, mock_post, valid_context: CmpBaseRequestContext) -> None:
@@ -248,6 +391,42 @@ class TestCmpClient:
 
     @patch('request.clients.cmp_client.requests.post')
     @patch('request.clients.cmp_client.encoder.encode')
+    def test_send_pki_message_adds_shared_secret_protection(
+        self, mock_encode, mock_post, valid_context: CmpBaseRequestContext
+    ) -> None:
+        """Test protected requests use the protected message for encoding."""
+        client = CmpClient(valid_context)
+        pki_message = Mock()
+        protected_message = Mock()
+        mock_encode.return_value = b'request_data'
+        mock_response = Mock(status_code=200, content=b'response_data')
+        mock_post.return_value = mock_response
+
+        with patch.object(client, '_add_protection_shared_secret', return_value=protected_message) as add_protection:
+            with patch.object(client, '_parse_response', return_value=Mock()):
+                client.send_pki_message(pki_message, add_shared_secret_protection=True)
+
+        add_protection.assert_called_once_with(pki_message)
+        mock_encode.assert_called_once_with(protected_message)
+
+    @patch('request.clients.cmp_client.requests.post')
+    @patch('request.clients.cmp_client.encoder.encode')
+    def test_send_pki_message_protection_error_is_preserved(
+        self, mock_encode, mock_post, valid_context: CmpBaseRequestContext
+    ) -> None:
+        """Test protection failures retain their exact client error."""
+        client = CmpClient(valid_context)
+        protection_error = CmpClientError('CMP shared secret is not set')
+
+        with patch.object(client, '_add_protection_shared_secret', side_effect=protection_error):
+            with pytest.raises(CmpClientError, match=r'^CMP shared secret is not set$'):
+                client.send_pki_message(Mock(), add_shared_secret_protection=True)
+
+        mock_encode.assert_not_called()
+        mock_post.assert_not_called()
+
+    @patch('request.clients.cmp_client.requests.post')
+    @patch('request.clients.cmp_client.encoder.encode')
     def test_send_pki_message_http_error(self, mock_encode, mock_post, valid_context: CmpBaseRequestContext) -> None:
         """Test sending PKI message fails with HTTP error."""
         client = CmpClient(valid_context)
@@ -259,7 +438,7 @@ class TestCmpClient:
 
         mock_pki_message = Mock()
 
-        with pytest.raises(CmpClientError, match='CMP server returned error status 500'):
+        with pytest.raises(CmpClientError, match=r'^CMP server returned error status 500: Internal Server Error$'):
             client.send_pki_message(mock_pki_message)
 
     @patch('request.clients.cmp_client.requests.post')
@@ -273,7 +452,10 @@ class TestCmpClient:
 
         mock_pki_message = Mock()
 
-        with pytest.raises(CmpClientError, match='Failed to communicate with CMP server'):
+        with pytest.raises(
+            CmpClientError,
+            match=r'^Failed to communicate with CMP server: Connection timed out$',
+        ):
             client.send_pki_message(mock_pki_message)
 
     @patch.object(CmpClient, 'send_pki_message')
@@ -406,3 +588,31 @@ class TestCmpClient:
 
         with pytest.raises(CmpClientError, match='No certificate responses in CMP message'):
             client._extract_issued_certificate(mock_message, b'raw_data')
+
+    def test_extract_issued_certificate_wraps_certificate_load_error(
+        self, valid_context: CmpBaseRequestContext
+    ) -> None:
+        """Test invalid extracted certificate bytes produce the client error."""
+        client = CmpClient(valid_context)
+        mock_cert_response = Mock()
+        mock_status = Mock()
+        mock_status.__getitem__ = Mock(return_value=0)
+        mock_cert_response.__getitem__ = Mock(return_value=mock_status)
+        mock_body = Mock()
+        mock_body.getName.return_value = 'cp'
+        mock_cert_rep_message = Mock()
+        mock_cert_rep_message.__getitem__ = Mock(return_value=[mock_cert_response])
+        mock_body.__getitem__ = Mock(return_value=mock_cert_rep_message)
+        mock_message = Mock()
+        mock_message.__getitem__ = Mock(return_value=mock_body)
+
+        with patch.object(client, '_extract_certs_from_raw_response', return_value=(b'bad', [])):
+            with patch(
+                'request.clients.cmp_client.x509.load_der_x509_certificate',
+                side_effect=ValueError('invalid certificate'),
+            ):
+                with pytest.raises(
+                    CmpClientError,
+                    match=r'^Failed to extract certificate from response: invalid certificate$',
+                ):
+                    client._extract_issued_certificate(mock_message, b'raw_data')

--- a/trustpoint/request/tests/test_cmp_remaining_branches.py
+++ b/trustpoint/request/tests/test_cmp_remaining_branches.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 The Trustpoint Project Authors
+# SPDX-License-Identifier: MIT
+
 """Focused coverage for defensive CMP request branches."""
 
 from unittest.mock import Mock, patch

--- a/trustpoint/request/tests/test_cmp_remaining_branches.py
+++ b/trustpoint/request/tests/test_cmp_remaining_branches.py
@@ -1,0 +1,358 @@
+"""Focused coverage for defensive CMP request branches."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding
+from pyasn1.codec.der import decoder as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.type import tag
+from pyasn1_modules import rfc2459, rfc4210, rfc5280
+from trustpoint_core.oid import HashAlgorithm, HmacAlgorithm
+
+from cmp.models import CmpTransactionModel
+from pki.models import IssuedCredentialModel
+from pki.models.ca_rollover import CaRolloverState
+from request.authorization.base import (
+    CertificateProfileAuthorization,
+    OnboardingDomainCredentialAuthorization,
+    SecurityConfigAuthorization,
+)
+from request.authorization.cmp import (
+    CmpCertConfAuthorization,
+    CmpOperationAuthorization,
+    CmpPollAuthorization,
+    CmpRevocationAuthorization,
+)
+from request.message_parser.cmp import (
+    CmpBodyValidation,
+    CmpCertConfBodyValidation,
+    CmpCertificateBodyValidation,
+    CmpHeaderValidation,
+    CmpPkiMessageParsing,
+    CmpRevocationBodyValidation,
+)
+from request.message_parser.rfc9480 import PKIBody, PKIMessage
+from request.message_responder.cmp import (
+    CmpErrorMessageResponder,
+    CmpMessageResponder,
+    CmpTransactionResponder,
+)
+from request.request_context import (
+    BaseCertificateRequestContext,
+    CmpBaseRequestContext,
+    CmpCertConfRequestContext,
+    CmpPollRequestContext,
+    CmpRevocationRequestContext,
+)
+
+
+def _message(body_type: str = 'ir') -> rfc4210.PKIMessage:
+    message = rfc4210.PKIMessage()
+    message['header']['pvno'] = 2
+    message['header']['transactionID'] = b't' * 16
+    message['header']['senderNonce'] = b'n' * 16
+    message['body'][body_type].setComponentByPosition(0)
+    return message
+
+
+class TestCmpAuthorizationRemainingBranches:
+    def test_revocation_rejects_invalid_domain_credential(self) -> None:
+        context = CmpRevocationRequestContext(
+            operation='revocation', cert_serial_number='1234', client_certificate=Mock(), domain=Mock(),
+        )
+        credential = Mock(
+            credential=Mock(certificate_or_error=Mock(serial_number='5678')),
+            is_valid_domain_credential=Mock(return_value=(False, 'expired')),
+        )
+        with patch.object(IssuedCredentialModel, 'get_credential_for_certificate', return_value=credential):
+            with pytest.raises(ValueError, match='Signer certificate does not match'):
+                CmpRevocationAuthorization().authorize(context)
+
+    def test_revocation_authorizes_matching_domain_credential(self) -> None:
+        device = Mock()
+        context = CmpRevocationRequestContext(
+            operation='revocation', cert_serial_number='1234', client_certificate=Mock(),
+            domain=Mock(), device=device,
+        )
+        signer = Mock(
+            credential=Mock(certificate_or_error=Mock(serial_number='5678')),
+            device=device, is_valid_domain_credential=Mock(return_value=(True, None)),
+        )
+        target = Mock(common_name='target')
+        with (
+            patch.object(IssuedCredentialModel, 'get_credential_for_certificate', return_value=signer),
+            patch.object(IssuedCredentialModel, 'get_credential_for_serial_number', return_value=target),
+        ):
+            CmpRevocationAuthorization().authorize(context)
+        assert context.credential_to_revoke is target
+
+    def test_certconf_rejects_unsupported_declared_hash(self) -> None:
+        context = CmpCertConfRequestContext(
+            operation='certconf', cert_conf_status=2, cert_hash=b'hash',
+            cert_hash_algorithm_oid='1.2.3.4',
+        )
+        with pytest.raises(ValueError, match='unsupported'):
+            CmpCertConfAuthorization().authorize(context)
+        assert context.http_response_status == 403
+
+    def test_certconf_rejects_disallowed_hash(self) -> None:
+        context = CmpCertConfRequestContext(
+            operation='certconf', cert_conf_status=2, cert_hash=b'hash',
+            cert_hash_algorithm_oid=HashAlgorithm.MD5.dotted_string,
+        )
+        with pytest.raises(ValueError, match='not permitted'):
+            CmpCertConfAuthorization().authorize(context)
+
+    def test_poll_rejects_cert_id_and_domain_mismatches(self) -> None:
+        context = CmpPollRequestContext(
+            cmp_body_type='pollReq', cmp_transaction_id='tx', poll_cert_req_id=9,
+            device=Mock(id=1), domain=Mock(id=2),
+        )
+        transaction = Mock(operation='initialization', cert_req_id=0, device_id=1, domain_id=3)
+        with patch('request.authorization.cmp.CmpTransactionState.get_by_transaction_id', return_value=transaction):
+            with pytest.raises(ValueError, match='certReqId mismatch'):
+                CmpPollAuthorization().authorize(context)
+
+        context.poll_cert_req_id = 0
+        with patch('request.authorization.cmp.CmpTransactionState.get_by_transaction_id', return_value=transaction):
+            with pytest.raises(ValueError, match='domain does not match'):
+                CmpPollAuthorization().authorize(context)
+
+    def test_operation_authorizes_revocation_certconf_and_poll(self) -> None:
+        operations = (('revocation', 'rr'), ('certification', 'certConf'), ('initialization', 'pollReq'))
+        for operation, body_type in operations:
+            context = CmpBaseRequestContext(operation=operation, parsed_message=_message(body_type))
+            with (
+                patch('request.authorization.cmp.CmpRevocationAuthorization.authorize'),
+                patch('request.authorization.cmp.CmpCertConfAuthorization.authorize'),
+            ):
+                CmpOperationAuthorization([operation]).authorize(context)
+
+
+class TestAuthorizationPolicyBranches:
+    def test_profile_rejects_no_onboarding_domain_profile(self) -> None:
+        context = Mock(spec=BaseCertificateRequestContext)
+        context.cert_profile_str = 'domain_credential'
+        context.domain = Mock()
+        context.device = Mock(onboarding_config=None, common_name='device')
+        context.domain.get_allowed_cert_profile.return_value = Mock(credential_type='domain')
+        with patch('request.authorization.base.ProfileValidator.validate'):
+            with pytest.raises(ValueError, match='No-Onboarding Device'):
+                CertificateProfileAuthorization().authorize(context)
+
+    def test_onboarding_accepts_any_valid_domain_credential(self) -> None:
+        context = Mock(spec=BaseCertificateRequestContext)
+        context.device = Mock(onboarding_config=Mock())
+        context.domain = None
+        context.certificate_profile_model = Mock(unique_name='tls_server')
+        queryset = Mock()
+        queryset.select_related.return_value = [Mock(is_valid_domain_credential=Mock(return_value=(True, None)))]
+        with patch('request.authorization.base.IssuedCredentialModel.objects.filter', return_value=queryset):
+            OnboardingDomainCredentialAuthorization().authorize(context)
+
+    def test_security_config_helpers_cover_empty_and_unknown_policies(self) -> None:
+        component = SecurityConfigAuthorization()
+        csr = x509.CertificateSigningRequestBuilder().subject_name(x509.Name([])).sign(
+            rsa.generate_private_key(public_exponent=65537, key_size=2048), hashes.SHA256(),
+        )
+        component._check_key_constraints(csr, Mock(rsa_minimum_key_size=0))
+        component._check_signature_algorithm(csr, Mock(not_permitted_signature_algorithm_oids=['1.2.3']))
+        component._check_ca_issuance(csr, Mock(allow_ca_issuance=True))
+        assert component._hash_oid('SHA-256') == HashAlgorithm.SHA256.dotted_string
+
+
+class TestCmpResponderRemainingBranches:
+    def test_header_and_implicit_confirm_are_encoded(self) -> None:
+        message = _message()
+        sender_kid = rfc2459.KeyIdentifier(b'ski').subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2)
+        )
+        header = CmpMessageResponder._build_response_message_header(message, sender_kid, None)
+        assert header['recipient'] == message['header']['sender']
+        response = rfc4210.PKIMessage()
+        response['header'] = header
+        CmpMessageResponder._grant_implicit_confirm(response)
+        assert len(response['header']['generalInfo']) == 1
+
+    def test_transaction_detail_fallbacks_and_credential_resolution(self) -> None:
+        for status, expected in (
+            (CmpTransactionModel.Status.PROCESSING, 3),
+            (CmpTransactionModel.Status.REJECTED, 2),
+            (CmpTransactionModel.Status.CANCELLED, 2),
+            (CmpTransactionModel.Status.FAILED, 2),
+        ):
+            result, detail = CmpTransactionResponder._detail_for_transaction_status(Mock(status=status, detail=None))
+            assert result == expected
+            assert detail
+
+        credential = Mock()
+        context = Mock(issuer_credential=credential)
+        assert CmpTransactionResponder._resolve_issuer_credential(context) is credential
+        context.issuer_credential = None
+        context.cmp_transaction = Mock(issuer_credential=credential)
+        assert CmpTransactionResponder._resolve_issuer_credential(context) is credential
+
+    def test_error_message_uses_empty_sender_kid_without_ca(self) -> None:
+        context = CmpBaseRequestContext(parsed_message=_message(), error_details='bad')
+        with (
+            patch.object(
+                CmpErrorMessageResponder, '_sign_pki_message', side_effect=lambda pki_message, **_: pki_message,
+            ),
+            patch('request.message_responder.cmp.encoder.encode', return_value=b'error'),
+        ):
+            CmpErrorMessageResponder._build_response(context)
+        assert context.http_response_content == b'error'
+
+    def test_rollover_chain_is_appended_in_preparation(self, device_instance) -> None:
+        issuer = Mock()
+        issuer.get_certificate.return_value = device_instance['cert']
+        issuer.get_certificate_chain.return_value = []
+        new_issuer = Mock()
+        new_issuer.credential = Mock()
+        new_issuer.credential.get_certificate.return_value = device_instance['cert']
+        new_issuer.credential.get_certificate_chain.return_value = []
+        rollover = Mock(
+            state=CaRolloverState.PREPARATION,
+            new_issuing_ca=new_issuer,
+        )
+        context = Mock(domain=Mock(issuing_ca=Mock()))
+        with patch('request.message_responder.cmp.CaRolloverService.get_active_rollover', return_value=rollover):
+            chain = CmpMessageResponder.build_certificate_chain_with_rollover(issuer, context)
+        assert chain == [device_instance['cert'], device_instance['cert']]
+
+    def test_transaction_credential_falls_back_to_domain_issuing_ca(self) -> None:
+        credential = Mock()
+        context = Mock(issuer_credential=None, cmp_transaction=None)
+        context.domain = Mock(issuing_ca=Mock())
+        context.domain.issuing_ca.get_credential.return_value = credential
+        assert CmpTransactionResponder._resolve_issuer_credential(context) is credential
+
+    def test_error_response_handles_missing_domain_credential(self) -> None:
+        context = CmpBaseRequestContext(parsed_message=_message(), error_details='bad', domain=Mock())
+        context.domain.get_issuing_ca_or_value_error.side_effect = ValueError('missing')
+        with (
+            patch.object(
+                CmpErrorMessageResponder, '_sign_pki_message', side_effect=lambda pki_message, **_: pki_message,
+            ),
+            patch('request.message_responder.cmp.encoder.encode', return_value=b'error'),
+        ):
+            CmpErrorMessageResponder._build_response(context)
+        assert context.http_response_content == b'error'
+
+    def test_rollover_chain_ignores_non_preparation_rollover(self) -> None:
+        issuer = Mock()
+        issuer.get_certificate_chain.return_value = []
+        rollover = Mock(state=CaRolloverState.COMPLETED, new_issuing_ca=Mock())
+        context = Mock(domain=Mock(issuing_ca=Mock()))
+        with patch('request.message_responder.cmp.CaRolloverService.get_active_rollover', return_value=rollover):
+            chain = CmpMessageResponder.build_certificate_chain_with_rollover(issuer, context)
+        assert chain == [issuer.get_certificate.return_value]
+
+    def test_shared_secret_protection_rejects_unknown_algorithms(self) -> None:
+        message = rfc4210.PKIMessage()
+        context = Mock(cmp_shared_secret='secret', parsed_message=_message())
+        pbm = rfc4210.PBMParameter()
+        pbm['salt'] = b'salt'
+        pbm['owf']['algorithm'] = '1.2.3.4'
+        pbm['iterationCount'] = 1
+        pbm['mac']['algorithm'] = HmacAlgorithm.HMAC_SHA256.dotted_string
+        context.parsed_message['header']['protectionAlg']['parameters'] = der_encode(pbm)
+        with pytest.raises(ValueError, match='owf algorithm not supported'):
+            CmpMessageResponder._add_protection_shared_secret(message, context)
+
+
+class TestCmpTypedMalformedBodies:
+    def test_certconf_requires_hash_and_cert_req_id(self) -> None:
+        body = PKIBody()
+        body['certConf'].setComponentByPosition(0)
+        status = body['certConf'][0]
+        with pytest.raises(ValueError, match='certHash is REQUIRED'):
+            CmpCertConfBodyValidation().parse_certconf_body(Mock(), body)
+        status['certHash'] = b'hash'
+        with pytest.raises(ValueError, match='certReqId is REQUIRED'):
+            CmpCertConfBodyValidation().parse_certconf_body(Mock(), body)
+
+    def test_certconf_rejects_invalid_status_and_hash_algorithm(self) -> None:
+        body = PKIBody()
+        body['certConf'].setComponentByPosition(0)
+        status = body['certConf'][0]
+        status['certHash'] = b'hash'
+        status['certReqId'] = 0
+        status['statusInfo']['status'] = 1
+        with pytest.raises(ValueError, match='accepted'):
+            CmpCertConfBodyValidation().parse_certconf_body(Mock(), body)
+        status['statusInfo'].clear()
+        status['hashAlg']['algorithm'] = '1.2.3.4'
+        with pytest.raises(ValueError, match='Unsupported certConf hashAlg'):
+            CmpCertConfBodyValidation().parse_certconf_body(Mock(), body)
+
+    def test_revocation_and_cert_request_cardinality_errors(self) -> None:
+        body = rfc4210.PKIBody()
+        body['rr'].setComponentByPosition(0)
+        body['rr'].setComponentByPosition(1)
+        with pytest.raises(ValueError, match='Multiple RevReqMessages'):
+            CmpRevocationBodyValidation().parse_rr_body(Mock(), body)
+
+        validator = CmpCertificateBodyValidation()
+        with pytest.raises(ValueError, match='No CertReqMessages'):
+            validator._validate_cert_req_messages([])
+        with pytest.raises(ValueError, match='Multiple CertReqMessages'):
+            validator._validate_cert_req_messages([Mock(), Mock()])
+
+    def test_header_absent_implicit_confirm_and_body_operation_edges(self) -> None:
+        message = _message()
+        context = Mock(operation='initialization')
+        CmpHeaderValidation()._check_implicit_confirm(context, message)
+        assert context.implicit_confirm is False
+        with pytest.raises(ValueError, match='Unsupported CMP operation'):
+            CmpBodyValidation()._validate_operation_body_match('unknown', 'ir')
+        with pytest.raises(ValueError, match='initialization or certification'):
+            CmpBodyValidation()._validate_pollreq_operation('revocation')
+
+    def test_rr_decodes_crl_reason_and_defaults_unknown_reason(self) -> None:
+        body = rfc4210.PKIBody()
+        body['rr'].setComponentByPosition(0)
+        request = body['rr'][0]
+        request['certDetails']['serialNumber'] = 0x10
+        reason_extension = rfc2459.Extension()
+        reason_extension['extnID'] = '2.5.29.21'
+        reason_extension['extnValue'] = der_encode(rfc5280.CRLReason('keyCompromise'))
+        request['crlEntryDetails'].append(reason_extension)
+        context = Mock()
+        CmpRevocationBodyValidation().parse_rr_body(context, body)
+        assert context.revocation_reason is x509.ReasonFlags.unspecified
+
+        reason_extension['extnID'] = '1.2.3.4'
+        CmpRevocationBodyValidation().parse_rr_body(context, body)
+        assert context.revocation_reason is x509.ReasonFlags.unspecified
+
+    def test_pki_parser_rejects_malformed_intermediate_certificate(self, device_instance) -> None:
+        parsed_message = _message()
+        valid_cert, _ = der_decoder.decode(
+            device_instance['cert'].public_bytes(Encoding.DER),
+            asn1Spec=rfc4210.CMPCertificate(),
+        )
+        parsed_message['extraCerts'].append(valid_cert)
+        parsed_message['extraCerts'].append(rfc4210.CMPCertificate())
+        context = CmpBaseRequestContext(parsed_message=parsed_message)
+        with pytest.raises(ValueError, match='Failed to extract CMP signer certificate'):
+            CmpPkiMessageParsing()._extract_signer_certificate(context)
+
+    def test_body_validation_dispatches_real_certconf_and_infers_operation(self) -> None:
+        message = PKIMessage()
+        message['header']['pvno'] = 2
+        message['header']['transactionID'] = b't' * 16
+        message['header']['senderNonce'] = b'n' * 16
+        message['body']['certConf'].setComponentByPosition(0)
+        status = message['body']['certConf'][0]
+        status['certHash'] = b'hash'
+        status['certReqId'] = 0
+        context = CmpBaseRequestContext(parsed_message=message, operation=None)
+        parsed_context = CmpBodyValidation().parse(context)
+        assert isinstance(parsed_context, CmpCertConfRequestContext)
+        assert parsed_context.operation == 'certconf'
+        assert parsed_context.cert_conf_status == 0

--- a/trustpoint/request/tests/test_cmp_transaction_pipeline.py
+++ b/trustpoint/request/tests/test_cmp_transaction_pipeline.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -14,10 +14,13 @@ from devices.models import DeviceModel
 from request.authorization.cmp import CmpPollAuthorization
 from request.cmp_transaction_state import CmpTransactionState
 from request.operation_processor.cmp_certificate_request import CmpCertificateRequestProcessor
+from request.operation_processor.cmp_poll import CmpPollProcessor
 from request.request_context import CmpCertificateRequestContext, CmpPollRequestContext
 from workflows2.events.request_events import Events
 from workflows2.models import Workflow2Approval, Workflow2Definition, Workflow2Instance, Workflow2Run
 from workflows2.services.dispatch import DispatchOutcome
+from request.workflow2_issuance import Workflow2IssuanceDecision
+from workflows2.services.request_decision import Workflow2RequestDecision
 
 
 @pytest.mark.django_db
@@ -53,6 +56,126 @@ def test_cmp_poll_authorization_infers_operation_from_transaction() -> None:
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    ('decision', 'status'),
+    [
+        (Workflow2IssuanceDecision.REJECT, CmpTransactionModel.Status.REJECTED),
+        (Workflow2IssuanceDecision.FAIL, CmpTransactionModel.Status.FAILED),
+    ],
+)
+def test_cmp_certificate_request_processor_persists_terminal_workflow_outcomes(decision, status) -> None:
+    context = CmpCertificateRequestContext(
+        raw_message=Mock(body=b'cmp-ir-request'), protocol='cmp', operation='initialization',
+        domain_str='test-domain', cmp_body_type='ir', cmp_transaction_id='terminal-id',
+    )
+    run = Mock(id='run-terminal', status=Workflow2Run.STATUS_FINISHED)
+    context.workflow2_outcome = DispatchOutcome(status='terminal', run=run, instances=[])
+
+    with patch('request.operation_processor.cmp_certificate_request.get_workflow2_issuance_decision', return_value=decision):
+        CmpCertificateRequestProcessor().process_operation(context)
+
+    assert context.cmp_transaction.status == status
+
+
+@pytest.mark.django_db
+def test_cmp_certificate_request_processor_rejects_missing_transaction_or_body() -> None:
+    processor = CmpCertificateRequestProcessor()
+    with pytest.raises(TypeError, match='requires a CmpCertificateRequestContext'):
+        processor.process_operation(Mock())
+    with pytest.raises(ValueError, match='missing transactionID'):
+        processor.process_operation(CmpCertificateRequestContext(protocol='cmp', cmp_body_type='ir'))
+    context = CmpCertificateRequestContext(
+        protocol='cmp', cmp_body_type='ir', cmp_transaction_id='missing-body', raw_message=Mock(body=b''),
+    )
+    with pytest.raises(ValueError, match='body is empty'):
+        processor.process_operation(context)
+
+
+def test_cmp_certificate_request_processor_rejects_missing_waiting_outcome() -> None:
+    """A waiting decision must carry the workflow run needed for polling."""
+    context = CmpCertificateRequestContext(
+        raw_message=Mock(body=bytearray(b'cmp-ir-request')), protocol='cmp', operation='initialization',
+        cmp_body_type='ir', cmp_transaction_id='missing-outcome',
+    )
+
+    with patch(
+        'request.operation_processor.cmp_certificate_request.get_workflow2_issuance_decision',
+        return_value=Workflow2IssuanceDecision.WAIT,
+    ), pytest.raises(ValueError, match='requires a Workflow 2 outcome'):
+        CmpCertificateRequestProcessor().process_operation(context)
+
+
+def test_cmp_request_helpers_normalize_supported_body_values() -> None:
+    """Normalize bytearray and text HTTP bodies and reject unsupported values."""
+    processor = CmpCertificateRequestProcessor()
+    context = CmpCertificateRequestContext(raw_message=Mock(body=bytearray(b'bytes')))
+    assert processor._request_body_bytes(context) == b'bytes'  # noqa: SLF001
+    context.raw_message.body = 'text'
+    assert processor._request_body_bytes(context) == b'text'  # noqa: SLF001
+    context.raw_message.body = object()
+    with pytest.raises(TypeError, match='must be bytes-like'):
+        processor._request_body_bytes(context)  # noqa: SLF001
+
+
+def test_cmp_request_helpers_reject_missing_http_message_and_empty_transaction_id() -> None:
+    processor = CmpCertificateRequestProcessor()
+    with pytest.raises(ValueError, match='missing its raw HTTP message'):
+        processor._request_body_bytes(CmpCertificateRequestContext())  # noqa: SLF001
+    with pytest.raises(ValueError, match='body is empty'):
+        processor._require_request_der(CmpCertificateRequestContext(raw_message=Mock(body=b'')))  # noqa: SLF001
+    with pytest.raises(ValueError, match='missing transactionID'):
+        processor._require_transaction_id(CmpCertificateRequestContext(cmp_transaction_id='  '))  # noqa: SLF001
+
+
+def test_cmp_pending_detail_distinguishes_awaiting_and_processing_runs() -> None:
+    processor = CmpCertificateRequestProcessor()
+    assert 'approval' in processor.detail_for_pending_run(Workflow2Run.STATUS_AWAITING)
+    assert 'processing' in processor.detail_for_pending_run(Workflow2Run.STATUS_RUNNING)
+
+
+@pytest.mark.django_db
+def test_cmp_certificate_request_processor_rejects_transaction_reuse() -> None:
+    CmpTransactionModel.objects.create(
+        transaction_id='reused', operation='initialization', request_body_type='ir', request_der=b'original',
+        status=CmpTransactionModel.Status.WAITING,
+    )
+    context = CmpCertificateRequestContext(
+        raw_message=Mock(body=b'different'), protocol='cmp', operation='initialization',
+        cmp_body_type='ir', cmp_transaction_id='REUSED',
+    )
+
+    with pytest.raises(ValueError, match='already in use'):
+        CmpCertificateRequestProcessor().process_operation(context)
+
+
+@pytest.mark.django_db
+def test_cmp_certificate_request_processor_hydrates_existing_issued_transaction() -> None:
+    transaction_record = CmpTransactionModel.objects.create(
+        transaction_id='issued-replay', operation='initialization', request_body_type='ir',
+        request_der=b'issued-request', status=CmpTransactionModel.Status.ISSUED,
+        implicit_confirm=True, cert_profile='domain_credential',
+    )
+    context = CmpCertificateRequestContext(
+        raw_message=Mock(body=b'issued-request'), protocol='cmp', operation='initialization',
+        cmp_body_type='ir', cmp_transaction_id='issued-replay',
+    )
+
+    with patch.object(CmpCertificateRequestProcessor, 'populate_success_context') as populate:
+        CmpCertificateRequestProcessor().process_operation(context)
+
+    assert context.cmp_transaction == transaction_record
+    populate.assert_called_once_with(context, transaction_record)
+
+
+def test_cmp_certificate_request_processor_delegates_wrong_context_protocol_and_operation() -> None:
+    processor = CmpCertificateRequestProcessor()
+    with patch('request.operation_processor.cmp_certificate_request.CertificateIssueProcessor.process_operation') as issue:
+        processor.process_operation(CmpCertificateRequestContext(protocol='est'))
+        processor.process_operation(CmpCertificateRequestContext(protocol='cmp', cmp_body_type='pollReq'))
+    assert issue.call_count == 2
+
+
+@pytest.mark.django_db
 def test_cmp_certificate_request_processor_persists_waiting_transaction_for_pending_workflow() -> None:
     """CMP certificate requests should persist a waiting transaction when workflows2 delays issuance."""
     raw_message = Mock()
@@ -84,6 +207,29 @@ def test_cmp_certificate_request_processor_persists_waiting_transaction_for_pend
     assert transaction_record.request_body_type == 'ir'
     assert transaction_record.operation == 'initialization'
     assert context.cmp_transaction == transaction_record
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('issue_side_effect', [RuntimeError('issue failed'), None])
+def test_cmp_certificate_request_processor_persists_failed_issuance_outcome(issue_side_effect: Exception | None) -> None:
+    context = CmpCertificateRequestContext(
+        raw_message=Mock(body=b'cmp-ir-request'), protocol='cmp', operation='initialization',
+        domain_str='test-domain', cmp_body_type='ir', cmp_transaction_id=f'issue-{issue_side_effect is None}',
+    )
+    with patch(
+        'request.operation_processor.cmp_certificate_request.CertificateIssueProcessor.process_operation',
+        side_effect=issue_side_effect,
+    ) as issue:
+        if issue_side_effect is not None:
+            with pytest.raises(RuntimeError, match='issue failed'):
+                CmpCertificateRequestProcessor().process_operation(context)
+        else:
+            CmpCertificateRequestProcessor().process_operation(context)
+
+    transaction_record = CmpTransactionModel.objects.get(transaction_id=context.cmp_transaction.transaction_id)
+    assert transaction_record.status == CmpTransactionModel.Status.FAILED
+    assert 'failed while issuing' in transaction_record.detail or 'without issuing' in transaction_record.detail
+    issue.assert_called_once_with(context)
 
 
 @pytest.mark.django_db
@@ -167,3 +313,144 @@ def test_cmp_transaction_state_syncs_rejected_approval_even_when_run_status_is_f
 
     transaction_record.refresh_from_db()
     assert transaction_record.status == CmpTransactionModel.Status.REJECTED
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ('decision', 'run_status', 'expected_status', 'detail'),
+    [
+        (Workflow2RequestDecision.CONTINUE, Workflow2Run.STATUS_RUNNING, CmpTransactionModel.Status.PROCESSING,
+         'CMP poll finalization in progress.'),
+        (Workflow2RequestDecision.WAIT, Workflow2Run.STATUS_AWAITING, CmpTransactionModel.Status.WAITING,
+         'Enrollment request pending workflow approval.'),
+    ],
+)
+def test_cmp_transaction_state_syncs_pending_workflow_decisions(
+    decision: Workflow2RequestDecision,
+    run_status: str,
+    expected_status: str,
+    detail: str,
+) -> None:
+    """Synchronize waiting transactions to processing or waiting state."""
+    run = Workflow2Run.objects.create(
+        trigger_on='cmp.initialization', event_json={}, source_json={}, status=run_status,
+    )
+    transaction_record = CmpTransactionModel.objects.create(
+        transaction_id=f'sync-{decision.value}', operation='initialization', request_body_type='ir',
+        request_der=b'cmp-request', status=CmpTransactionModel.Status.WAITING,
+        backend=CmpTransactionModel.Backend.WORKFLOW2, backend_reference=str(run.pk), check_after_seconds=9,
+    )
+
+    with patch('request.cmp_transaction_state.resolve_request_decision', return_value=decision):
+        CmpTransactionState.sync_from_workflow2_run(run=run)
+
+    transaction_record.refresh_from_db()
+    assert transaction_record.status == expected_status
+    assert transaction_record.detail == detail
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ('decision', 'run_status', 'expected_status'),
+    [
+        (Workflow2RequestDecision.WAIT, Workflow2Run.STATUS_AWAITING, CmpTransactionModel.Status.WAITING),
+        (Workflow2RequestDecision.CONTINUE, Workflow2Run.STATUS_RUNNING, CmpTransactionModel.Status.PROCESSING),
+        (Workflow2RequestDecision.REJECT, Workflow2Run.STATUS_FINISHED, CmpTransactionModel.Status.REJECTED),
+        (Workflow2RequestDecision.FAIL, Workflow2Run.STATUS_ERROR, CmpTransactionModel.Status.FAILED),
+    ],
+)
+def test_cmp_poll_refreshes_waiting_transaction_for_each_workflow_decision(
+    decision: Workflow2RequestDecision,
+    run_status: str,
+    expected_status: str,
+) -> None:
+    """Refresh a waiting transaction for each workflow request decision."""
+    run = Workflow2Run.objects.create(
+        trigger_on='cmp.initialization', event_json={}, source_json={}, status=run_status,
+    )
+    transaction_record = CmpTransactionModel.objects.create(
+        transaction_id=f'poll-{decision.value}', operation='initialization', request_body_type='ir',
+        request_der=b'cmp-request', status=CmpTransactionModel.Status.WAITING,
+        backend=CmpTransactionModel.Backend.WORKFLOW2, backend_reference=str(run.pk),
+        check_after_seconds=12,
+    )
+    context = CmpPollRequestContext(cmp_transaction=transaction_record)
+
+    finalize_patch = (
+        patch.object(CmpPollProcessor, '_finalize_transaction')
+        if decision == Workflow2RequestDecision.CONTINUE
+        else patch.object(CmpPollProcessor, '_finalize_transaction', autospec=True)
+    )
+    with patch('request.operation_processor.cmp_poll.resolve_request_decision', return_value=decision), finalize_patch:
+        CmpPollProcessor().process_operation(context)
+
+    transaction_record.refresh_from_db()
+    assert transaction_record.status == expected_status
+    assert context.cmp_transaction == transaction_record
+    if decision == Workflow2RequestDecision.WAIT:
+        assert transaction_record.detail == 'Enrollment request pending workflow approval.'
+    elif decision == Workflow2RequestDecision.CONTINUE:
+        assert transaction_record.detail == 'CMP poll finalization in progress.'
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('backend_reference', ['', '00000000-0000-0000-0000-000000000001'])
+def test_cmp_poll_marks_missing_workflow_reference_failed(backend_reference: str) -> None:
+    """Persist a failure when a waiting transaction cannot find its backend run."""
+    transaction_record = CmpTransactionModel.objects.create(
+        transaction_id=f'missing-{backend_reference or "empty"}', operation='initialization', request_body_type='ir',
+        request_der=b'cmp-request', status=CmpTransactionModel.Status.WAITING,
+        backend=CmpTransactionModel.Backend.WORKFLOW2, backend_reference=backend_reference,
+    )
+    context = CmpPollRequestContext(cmp_transaction=transaction_record)
+
+    CmpPollProcessor().process_operation(context)
+
+    transaction_record.refresh_from_db()
+    assert transaction_record.status == CmpTransactionModel.Status.FAILED
+    assert transaction_record.finalized_at is not None
+    assert 'run reference' in transaction_record.detail or 'no longer exists' in transaction_record.detail
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('issue_result', ['exception', 'no-certificate'])
+def test_cmp_poll_finalization_failures_are_persisted(issue_result: str) -> None:
+    """Persist poll finalization exceptions and missing certificate results."""
+    transaction_record = CmpTransactionModel.objects.create(
+        transaction_id=f'finalize-{issue_result}', operation='initialization', request_body_type='ir',
+        request_der=b'cmp-request', status=CmpTransactionModel.Status.PROCESSING,
+    )
+    context = CmpPollRequestContext(cmp_transaction=transaction_record)
+    replay_context = Mock(issued_certificate=None)
+    issue_patch = patch(
+        'request.operation_processor.cmp_poll.CertificateIssueProcessor.process_operation',
+        side_effect=RuntimeError('issuer failed') if issue_result == 'exception' else None,
+    )
+    with patch.object(CmpCertificateRequestProcessor, 'build_replay_context', return_value=replay_context), issue_patch:
+        CmpPollProcessor().process_operation(context)
+
+    transaction_record.refresh_from_db()
+    assert transaction_record.status == CmpTransactionModel.Status.FAILED
+    assert transaction_record.finalized_at is not None
+    assert 'without issuing' in transaction_record.detail or 'failed while issuing' in transaction_record.detail
+
+
+@pytest.mark.django_db
+def test_cmp_poll_finalization_hydrates_successful_issuance() -> None:
+    """Hydrate the poll context after the issuance boundary succeeds."""
+    transaction_record = CmpTransactionModel.objects.create(
+        transaction_id='finalize-success', operation='initialization', request_body_type='ir',
+        request_der=b'cmp-request', status=CmpTransactionModel.Status.PROCESSING,
+    )
+    context = CmpPollRequestContext(cmp_transaction=transaction_record)
+    replay_context = Mock(issued_certificate=Mock())
+    issued_transaction = Mock(status=CmpTransactionModel.Status.ISSUED)
+
+    with patch.object(CmpCertificateRequestProcessor, 'build_replay_context', return_value=replay_context), \
+        patch('request.operation_processor.cmp_poll.CertificateIssueProcessor.process_operation'), \
+        patch.object(CmpCertificateRequestProcessor, 'mark_transaction_issued', return_value=issued_transaction), \
+        patch.object(CmpCertificateRequestProcessor, 'populate_success_context') as populate:
+        CmpPollProcessor().process_operation(context)
+
+    assert context.cmp_transaction is issued_transaction
+    populate.assert_called_once_with(context, issued_transaction)

--- a/trustpoint/request/tests/test_est_client.py
+++ b/trustpoint/request/tests/test_est_client.py
@@ -1,0 +1,168 @@
+"""Behavioral tests for the EST client at its HTTP boundary."""
+
+import base64
+import datetime
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import pkcs7
+
+from request.clients.est_client import EstClient, EstClientError
+from request.request_context import EstBaseRequestContext
+
+
+def certificate_and_csr() -> tuple[rsa.RSAPrivateKey, x509.Certificate, x509.CertificateSigningRequest]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, 'est-test')])
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.now(datetime.UTC))
+        .not_valid_after(datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1))
+        .sign(key, hashes.SHA256())
+    )
+    csr = x509.CertificateSigningRequestBuilder().subject_name(subject).sign(key, hashes.SHA256())
+    return key, certificate, csr
+
+
+def truststore() -> Mock:
+    store = Mock()
+    store.get_certificate_collection_serializer.return_value.as_pem.return_value = (
+        b'-----BEGIN CERTIFICATE-----\nZmFrZQ==\n-----END CERTIFICATE-----\n'
+    )
+    return store
+
+
+def client_context(**kwargs: object) -> EstBaseRequestContext:
+    values: dict[str, object] = {
+        'est_server_host': 'est.example.test',
+        'est_server_truststore': truststore(),
+        'est_server_path': '/.well-known/est/simpleenroll',
+        **kwargs,
+    }
+    return EstBaseRequestContext(**values)
+
+
+class TestEstClient:
+    def test_constructor_requires_host_and_truststore(self) -> None:
+        with pytest.raises(EstClientError, match='est_server_host is required'):
+            EstClient(EstBaseRequestContext(est_server_truststore=truststore()))
+        with pytest.raises(EstClientError, match='est_server_truststore is required'):
+            EstClient(EstBaseRequestContext(est_server_host='est.example.test'))
+
+    def test_url_uses_default_and_custom_ports(self) -> None:
+        assert EstClient(client_context())._build_url() == 'https://est.example.test/.well-known/est/simpleenroll'
+        custom = EstClient(client_context(est_server_port=8443, est_server_path='/enroll'))
+        assert custom._build_url() == 'https://est.example.test:8443/enroll'
+        assert custom._build_url('/.well-known/est/cacerts') == 'https://est.example.test:8443/.well-known/est/cacerts'
+
+    def test_prepare_csr_data_returns_base64_der(self) -> None:
+        _, _, csr = certificate_and_csr()
+        encoded, content_type = EstClient(client_context())._prepare_csr_data(csr)
+        assert content_type == 'application/pkcs10'
+        assert base64.b64decode(encoded) == csr.public_bytes(serialization.Encoding.DER)
+
+    def test_parse_response_rejects_content_type_and_empty_pkcs7(self) -> None:
+        client = EstClient(client_context())
+        with pytest.raises(EstClientError, match='Unexpected content type'):
+            client._parse_response(b'', 'text/plain')
+        with patch('request.clients.est_client.pkcs7.load_der_pkcs7_certificates', return_value=[]):
+            with pytest.raises(EstClientError, match='No certificates found'):
+                client._parse_response(base64.b64encode(b'valid-pkcs7'), 'application/pkcs7-mime')
+
+    def test_parse_response_returns_first_certificate(self) -> None:
+        key, certificate, _ = certificate_and_csr()
+        data = pkcs7.PKCS7SignatureBuilder().set_data(b'issued').add_signer(
+            certificate, key, hashes.SHA256()
+        ).sign(serialization.Encoding.DER, [])
+        result = EstClient(client_context())._parse_response(base64.b64encode(data), 'application/pkcs7-mime')
+        assert result.subject == certificate.subject
+
+    def test_prepare_auth_prefers_mtls_then_basic_then_none(self) -> None:
+        mtls = EstClient(client_context(est_client_cert_pem='CERT', est_client_key_pem='KEY'))
+        with patch.object(mtls, '_write_temp_pem', side_effect=['cert.pem', 'key.pem']):
+            basic, cert, files = mtls._prepare_auth()
+        assert basic is None and cert == ('cert.pem', 'key.pem') and files == ['cert.pem', 'key.pem']
+
+        basic_client = EstClient(client_context(est_username='alice', est_password='synthetic-password'))
+        assert basic_client._prepare_auth() == (('alice', 'synthetic-password'), None, [])
+        assert EstClient(client_context())._prepare_auth() == (None, None, [])
+
+    def test_write_temp_pem_writes_text_and_bytes(self) -> None:
+        client = EstClient(client_context())
+        text_path = client._write_temp_pem('CERT')
+        bytes_path = client._write_temp_pem(b'KEY')
+        try:
+            assert Path(text_path).read_text() == 'CERT'
+            assert Path(bytes_path).read_text() == 'KEY'
+        finally:
+            Path(text_path).unlink()
+            Path(bytes_path).unlink()
+
+    def test_prepare_ca_bundle_requires_truststore(self) -> None:
+        client = EstClient(client_context())
+        path = client._prepare_ca_bundle()
+        try:
+            assert Path(path).read_bytes().startswith(b'-----BEGIN CERTIFICATE-----')
+        finally:
+            Path(path).unlink()
+        client.context.est_server_truststore = None
+        with pytest.raises(EstClientError, match='truststore is not configured'):
+            client._prepare_ca_bundle()
+
+    @patch('request.clients.est_client.requests.post')
+    def test_simple_enroll_success_and_cleanup(self, post: Mock) -> None:
+        key, certificate, csr = certificate_and_csr()
+        response_data = pkcs7.PKCS7SignatureBuilder().set_data(b'issued').add_signer(
+            certificate, key, hashes.SHA256()
+        ).sign(serialization.Encoding.DER, [])
+        response = Mock(status_code=200, content=base64.b64encode(response_data), headers={'Content-Type': 'application/pkcs7-mime'})
+        post.return_value = response
+        ca_path = tempfile.NamedTemporaryFile(delete=False).name
+        auth_path = tempfile.NamedTemporaryFile(delete=False).name
+        context = client_context(est_username='alice', est_password='synthetic-password')
+        client = EstClient(context, timeout=7)
+        with patch.object(client, '_prepare_ca_bundle', return_value=ca_path), patch.object(
+            client, '_prepare_auth', return_value=(('alice', 'synthetic-password'), None, [auth_path])
+        ):
+            result = client.simple_enroll(csr)
+        assert result.subject == certificate.subject
+        post.assert_called_once()
+        assert post.call_args.kwargs['timeout'] == 7
+        assert not Path(ca_path).exists() and not Path(auth_path).exists()
+
+    @patch('request.clients.est_client.requests.post')
+    def test_simple_enroll_translates_http_and_network_errors(self, post: Mock) -> None:
+        _, _, csr = certificate_and_csr()
+        for response in [Mock(status_code=500, text='server failure')]:
+            post.return_value = response
+            client = EstClient(client_context())
+            with patch.object(client, '_prepare_ca_bundle', side_effect=lambda: tempfile.NamedTemporaryFile(delete=False).name):
+                with pytest.raises(EstClientError, match='returned error status 500'):
+                    client.simple_enroll(csr)
+        post.side_effect = __import__('requests').exceptions.Timeout('timed out')
+        client = EstClient(client_context())
+        with patch.object(client, '_prepare_ca_bundle', side_effect=lambda: tempfile.NamedTemporaryFile(delete=False).name):
+            with pytest.raises(EstClientError, match='Failed to communicate'):
+                client.simple_enroll(csr)
+
+    @patch('request.clients.est_client.requests.get')
+    def test_get_ca_certs_success_and_http_error(self, get: Mock) -> None:
+        key, certificate, _ = certificate_and_csr()
+        response_data = pkcs7.PKCS7SignatureBuilder().set_data(b'cas').add_signer(
+            certificate, key, hashes.SHA256()
+        ).sign(serialization.Encoding.DER, [])
+        get.return_value = Mock(status_code=200, content=base64.b64encode(response_data), text='')
+        result = EstClient(client_context()).get_ca_certs()
+        assert len(result) == 1 and result[0].subject == certificate.subject
+        get.return_value = Mock(status_code=503, content=b'', text='unavailable')
+        with pytest.raises(EstClientError, match='returned error status 503'):
+            EstClient(client_context()).get_ca_certs()

--- a/trustpoint/request/tests/test_est_client.py
+++ b/trustpoint/request/tests/test_est_client.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 The Trustpoint Project Authors
+# SPDX-License-Identifier: MIT
+
 """Behavioral tests for the EST client at its HTTP boundary."""
 
 import base64

--- a/trustpoint/request/tests/test_gds_push_service.py
+++ b/trustpoint/request/tests/test_gds_push_service.py
@@ -5,12 +5,13 @@
 
 import datetime
 from typing import Any
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 import pytest
 from asyncua import ua
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import ObjectIdentifier
 
@@ -148,6 +149,14 @@ class TestGdsPushService:
         assert service.server_url == 'opc.tcp://192.168.1.100:4840'
         assert service.domain_credential is None
         assert service.server_truststore is None
+
+    def test_get_server_truststore_rejects_missing_onboarding_config(self, mock_opc_device):
+        mock_opc_device.onboarding_config = None
+        service = GdsPushService.__new__(GdsPushService)
+        service.device = mock_opc_device
+
+        with pytest.raises(GdsPushError, match='has no onboarding config'):
+            service._get_server_truststore()
 
     def test_init_secure_mode(self, mock_opc_device, mock_domain_credential, mock_truststore):
         """Test initialization in secure mode."""
@@ -826,6 +835,17 @@ class TestGdsPushService:
         with pytest.raises(GdsPushError, match='No server truststore configured'):
             await service._update_truststore_with_new_certificate(b'cert_data', [b'issuer_cert'])
 
+    @pytest.mark.asyncio
+    async def test_build_trustlist_rejects_malformed_crl(self, mock_opc_device, mock_ca_with_crl):
+        """Reject a CA trustlist when its CRL cannot be parsed."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        with patch.object(
+            type(mock_ca_with_crl), 'crl_pem', new_callable=PropertyMock,
+            return_value='not-a-certificate',
+        ), patch.object(service, '_build_ca_chain', new=AsyncMock(return_value=[mock_ca_with_crl])):
+            with pytest.raises(GdsPushError, match='Failed to load CRL'):
+                await service._build_trustlist_for_server()
+
     # ========================================================================
     # Error Handling Tests
     # ========================================================================
@@ -1119,3 +1139,416 @@ class TestGdsPushServiceAdditionalCoverage:
 
         with pytest.raises(GdsPushError, match='has no onboarding config'):
             service._get_server_truststore()
+
+    @pytest.mark.asyncio
+    async def test_build_ca_chain_without_issuing_ca(self, mock_opc_device):
+        """Reject a domain that cannot provide an issuing CA."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        service.device.domain.issuing_ca = None
+
+        with pytest.raises(GdsPushError, match='has no issuing CA configured'):
+            await service._build_ca_chain()
+
+    @pytest.mark.asyncio
+    async def test_build_trustlist_rejects_missing_crl(self, mock_opc_device):
+        """Reject a trustlist when any CA is missing its mandatory CRL."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        ca = Mock()
+        ca.unique_name = 'missing-crl'
+        ca.ca_certificate_model = Mock()
+        ca.ca_certificate_model.get_certificate_serializer.return_value.as_crypto.return_value = Mock(
+            public_bytes=Mock(return_value=b'ca-cert')
+        )
+        ca.crl_pem = None
+
+        with patch.object(service, '_build_ca_chain', return_value=[ca]):
+            with pytest.raises(GdsPushError, match='has no CRL configured'):
+                await service._build_trustlist_for_server()
+
+    @pytest.mark.asyncio
+    async def test_get_client_credentials_rejects_invalid_credential(
+        self, mock_opc_device, mock_domain_credential
+    ):
+        """Reject an invalid domain credential before reading its key."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        service.domain_credential = mock_domain_credential
+
+        with patch.object(
+            mock_domain_credential,
+            'is_valid_domain_credential',
+            return_value=(False, 'revoked'),
+        ), patch.object(service, '_validate_client_certificate') as validate:
+            with pytest.raises(GdsPushError, match='Invalid domain credential: revoked'):
+                await service._get_client_credentials()
+
+        validate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_server_certificate_missing_order_zero(self, mock_opc_device):
+        """Convert a missing order-zero truststore entry to GdsPushError."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        truststore = Mock()
+        truststore.unique_name = 'server-store'
+        truststore.truststoreordermodel_set.get.side_effect = TruststoreOrderModel.DoesNotExist
+        service.server_truststore = truststore
+
+        with pytest.raises(GdsPushError, match='has no certificate at order 0'):
+            await service._get_server_certificate()
+
+    @pytest.mark.asyncio
+    async def test_create_secure_client_wraps_credential_failure(self, mock_opc_device):
+        """Wrap failures during secure client setup with GdsPushError."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+
+        with patch.object(
+            service,
+            '_get_client_credentials',
+            side_effect=GdsPushError('credential unavailable'),
+        ):
+            with pytest.raises(GdsPushError, match='Failed to create secure client: credential unavailable'):
+                await service._create_secure_client()
+
+    @pytest.mark.asyncio
+    async def test_gather_server_info_reads_list_server_name(self, mock_opc_device):
+        """Normalize a list-valued ServerName property."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        endpoint = Mock(
+            EndpointUrl='opc.tcp://server:4840',
+            SecurityPolicyUri='None',
+            SecurityMode=ua.MessageSecurityMode.None_,
+            ServerCertificate=b'',
+        )
+        server_name_node = Mock()
+        server_name_node.read_value = AsyncMock(return_value=['Server A', 'ignored'])
+        client = Mock()
+        client.get_endpoints = AsyncMock(return_value=[endpoint])
+        client.get_node.return_value = server_name_node
+
+        info = await service._gather_server_info(client)
+
+        assert info['server_name'] == 'Server A'
+        assert info['endpoints'][0]['has_server_cert'] is False
+
+    @pytest.mark.asyncio
+    async def test_update_trustlist_returns_no_nodes(self, mock_opc_device):
+        """Report a connected server that exposes no TrustList nodes."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        client = AsyncMock()
+
+        with patch.object(service, '_build_trustlist_for_server', return_value=Mock()), \
+             patch.object(service, '_create_secure_client', return_value=client), \
+             patch.object(service, '_discover_trustlist_nodes', return_value=[]):
+            success, message = await service.update_trustlist()
+
+        assert success is False
+        assert message == 'No TrustList nodes found on server'
+        client.__aenter__.assert_awaited_once()
+        client.__aexit__.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_update_single_trustlist_writes_chunks_and_applies_changes(self, mock_opc_device):
+        """Write serialized trustlist data in bounded chunks and apply changes."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        node = Mock()
+        open_method, write_method, close_method, apply_method = (Mock() for _ in range(4))
+        node.get_child = AsyncMock(side_effect=[open_method, write_method, close_method])
+        node.call_method = AsyncMock(side_effect=[7, None, None, None, True])
+        group_node = Mock()
+        groups_node = Mock()
+        config_node = Mock()
+        node.get_parent = AsyncMock(return_value=group_node)
+        group_node.get_parent = AsyncMock(return_value=groups_node)
+        groups_node.get_parent = AsyncMock(return_value=config_node)
+        config_node.get_child = AsyncMock(return_value=apply_method)
+        config_node.call_method = AsyncMock()
+
+        with patch('request.gds_push.gds_push_service.struct_to_binary', return_value=b'abcdef'):
+            assert await service._update_single_trustlist(node, Mock(), max_chunk_size=2) is True
+
+        assert node.call_method.await_args_list[1].args[2] == b'ab'
+        assert node.call_method.await_args_list[2].args[2] == b'cd'
+        assert node.call_method.await_args_list[3].args[2] == b'ef'
+        config_node.call_method.assert_awaited_once_with(apply_method)
+
+    @pytest.mark.asyncio
+    async def test_update_server_certificate_skips_user_token_and_reports_failures(self, mock_opc_device):
+        """Skip UserToken groups and preserve failed application-group results."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        client = AsyncMock()
+        groups = [
+            {'name': 'UserTokenGroup', 'node_id': ua.NodeId(1, 1)},
+            {'name': 'ApplicationGroup', 'node_id': ua.NodeId(1, 2)},
+        ]
+
+        with patch.object(service, '_create_secure_client', return_value=client), \
+             patch.object(service, '_discover_certificate_groups', return_value=groups), \
+             patch.object(service, '_update_single_certificate', return_value=(False, None, None)) as update:
+            success, message, cert_data = await service.update_server_certificate()
+
+        assert (success, cert_data) == (False, None)
+        assert 'Failed to update any certificate' in message
+        update.assert_awaited_once_with(client=client, certificate_group_id=groups[1]['node_id'])
+
+    @pytest.mark.asyncio
+    async def test_update_single_certificate_returns_false_on_server_error(self, mock_opc_device):
+        """Return a failed result when the server rejects CSR creation."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        client = Mock()
+        client.get_node.side_effect = RuntimeError('CSR unavailable')
+
+        result = await service._update_single_certificate(client, ua.NodeId(1, 2))
+
+        assert result == (False, None, None)
+
+    @pytest.mark.asyncio
+    async def test_sign_csr_rejects_invalid_der(self, mock_opc_device):
+        """Wrap malformed server CSR data as a GdsPushError."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+
+        with pytest.raises(GdsPushError, match='Failed to sign CSR'):
+            await service._sign_csr(b'not-a-csr')
+
+    @pytest.mark.asyncio
+    async def test_update_truststore_rejects_unknown_server_certificate(self, mock_opc_device):
+        """Fail before creating truststore orders when the new certificate is unknown."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        service.server_truststore = Mock(unique_name='server-store')
+        service.server_truststore.truststoreordermodel_set.get.side_effect = TruststoreOrderModel.DoesNotExist
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        cert = x509.CertificateBuilder().subject_name(
+            x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, 'new-server')])
+        ).issuer_name(
+            x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, 'new-server')])
+        ).public_key(key.public_key()).serial_number(1).not_valid_before(
+            datetime.datetime.now(datetime.UTC)
+        ).not_valid_after(
+            datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1)
+        ).sign(key, hashes.SHA256())
+
+        with patch('request.gds_push.gds_push_service.CertificateModel.get_cert_by_sha256_fingerprint', return_value=None):
+            with pytest.raises(GdsPushError, match='Server certificate not found in database'):
+                await service._update_truststore_with_new_certificate(
+                    cert.public_bytes(serialization.Encoding.DER), []
+                )
+
+    @pytest.mark.asyncio
+    async def test_update_trustlist_reports_mixed_group_results(self, mock_opc_device):
+        """Report both successful and failed TrustList group updates."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        client = AsyncMock()
+        nodes = [
+            {'group_name': 'Application', 'trustlist_node': Mock()},
+            {'group_name': 'Https', 'trustlist_node': Mock()},
+        ]
+
+        with patch.object(service, '_build_trustlist_for_server', new_callable=AsyncMock), \
+             patch.object(service, '_create_secure_client', new_callable=AsyncMock, return_value=client), \
+             patch.object(service, '_discover_trustlist_nodes', new_callable=AsyncMock, return_value=nodes), \
+             patch.object(service, '_update_single_trustlist', new_callable=AsyncMock,
+                          side_effect=[True, False]) as update:
+            success, message = await service.update_trustlist()
+
+        assert success is True
+        assert message == 'Successfully updated 1/2 trustlist(s): ✓ Application, ✗ Https'
+        assert update.await_args_list[0].args[0] is nodes[0]['trustlist_node']
+        assert update.await_args_list[1].args[0] is nodes[1]['trustlist_node']
+
+    @pytest.mark.asyncio
+    async def test_discover_trustlist_nodes_skips_group_that_cannot_be_read(self, mock_opc_device):
+        """Continue discovery when one certificate group has no TrustList."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        server_node = Mock()
+        config_node = Mock()
+        groups_node = Mock()
+        good_group = Mock()
+        bad_group = Mock()
+        good_name = Mock(Name='Application')
+        good_trustlist = Mock()
+        good_group.read_browse_name = AsyncMock(return_value=good_name)
+        good_group.get_child = AsyncMock(return_value=good_trustlist)
+        bad_group.read_browse_name = AsyncMock(side_effect=RuntimeError('browse failed'))
+        server_node.get_child = AsyncMock(return_value=config_node)
+        config_node.get_child = AsyncMock(return_value=groups_node)
+        groups_node.get_children = AsyncMock(return_value=[bad_group, good_group])
+        service_client = Mock()
+        service_client.get_node.return_value = server_node
+
+        nodes = await service._discover_trustlist_nodes(service_client)
+
+        assert nodes == [{
+            'group_name': 'Application',
+            'group_node': good_group,
+            'trustlist_node': good_trustlist,
+        }]
+
+    @pytest.mark.asyncio
+    async def test_create_secure_client_sets_credentials_and_security_payload(self, mock_opc_device):
+        """Configure the client with the certificate chain, key, URI, and user."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        service.device.onboarding_config.opc_user = 'opc-user'
+        service.device.onboarding_config.opc_password = 'opc-password'
+        client = Mock()
+        client.set_security = AsyncMock()
+        certificate = Mock()
+
+        with patch('request.gds_push.gds_push_service.Client', return_value=client), \
+             patch.object(service, '_get_client_credentials', new_callable=AsyncMock,
+                          return_value=(certificate, b'private-key')), \
+             patch.object(service, '_get_server_certificate', new_callable=AsyncMock,
+                          return_value=b'server-cert'), \
+             patch.object(service, '_extract_application_uri', return_value='urn:test:app'), \
+             patch.object(service, '_build_client_certificate_chain', new_callable=AsyncMock,
+                          return_value=b'client-chain'):
+            result = await service._create_secure_client()
+
+        assert result is client
+        assert client.application_uri == 'urn:test:app'
+        client.set_user.assert_called_once_with('opc-user')
+        client.set_password.assert_called_once_with('opc-password')
+        client.set_security.assert_awaited_once()
+        security_args = client.set_security.await_args.kwargs
+        assert security_args['mode'] == ua.MessageSecurityMode.SignAndEncrypt
+        assert security_args['server_certificate'].endswith('.der')
+
+    @pytest.mark.asyncio
+    async def test_update_server_certificate_logs_certificate_mismatch(self, mock_opc_device):
+        """Collect mismatch diagnostics when the secure session cannot open."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        client = AsyncMock()
+        client.__aenter__.side_effect = Exception('certificate mismatch')
+        log_details = AsyncMock()
+
+        with patch.object(service, '_create_secure_client', new_callable=AsyncMock, return_value=client), \
+             patch.object(service, '_log_certificate_mismatch_details', log_details):
+            success, message, certificate = await service.update_server_certificate()
+
+        assert (success, certificate) == (False, None)
+        assert 'certificate mismatch' in message
+        log_details.assert_awaited_once_with(client)
+        client.__aexit__.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sign_csr_rejects_missing_certificate_profile(self, mock_opc_device):
+        """Turn a domain without the OPC UA profile into a GDS error."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        csr = x509.CertificateSigningRequestBuilder().subject_name(
+            x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, 'server')])
+        ).sign(key, hashes.SHA256())
+        context = Mock(domain=mock_opc_device.domain)
+        mock_opc_device.domain.get_allowed_cert_profile = Mock(return_value=None)
+
+        with patch('request.gds_push.gds_push_service.BaseCertificateRequestContext', return_value=context):
+            with pytest.raises(GdsPushError, match='Certificate profile "opc_ua" not found'):
+                await service._sign_csr(csr.public_bytes(serialization.Encoding.DER))
+
+    @pytest.mark.asyncio
+    async def test_update_truststore_replaces_old_order_and_chain(self, mock_opc_device):
+        """Revoke the old server certificate and create ordered replacement entries."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        truststore = Mock(unique_name='server-store')
+        old_order = Mock(certificate=Mock(common_name='old-server'))
+        truststore.truststoreordermodel_set.get.return_value = old_order
+        truststore.truststoreordermodel_set.all.return_value.delete.return_value = (2, {})
+        service.server_truststore = truststore
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        cert = x509.CertificateBuilder().subject_name(
+            x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, 'new-server')])
+        ).issuer_name(
+            x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, 'new-server')])
+        ).public_key(key.public_key()).serial_number(2).not_valid_before(
+            datetime.datetime.now(datetime.UTC)
+        ).not_valid_after(
+            datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1)
+        ).sign(key, hashes.SHA256())
+        cert_der = cert.public_bytes(serialization.Encoding.DER)
+        ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        ca_cert = x509.CertificateBuilder().subject_name(
+            x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, 'ca')])
+        ).issuer_name(
+            x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, 'ca')])
+        ).public_key(ca_key.public_key()).serial_number(3).not_valid_before(
+            datetime.datetime.now(datetime.UTC)
+        ).not_valid_after(datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1)).sign(
+            ca_key, hashes.SHA256()
+        )
+        ca_der = ca_cert.public_bytes(serialization.Encoding.DER)
+
+        with patch('request.gds_push.gds_push_service.RevokedCertificateModel.objects.create') as revoke, \
+             patch('request.gds_push.gds_push_service.CertificateModel.get_cert_by_sha256_fingerprint',
+                   side_effect=[Mock(), Mock()]), \
+             patch('request.gds_push.gds_push_service.TruststoreOrderModel.objects.create') as create_order:
+            await service._update_truststore_with_new_certificate(cert_der, [ca_der])
+
+        revoke.assert_called_once()
+        truststore.truststoreordermodel_set.all.return_value.delete.assert_called_once_with()
+        assert [call.kwargs['order'] for call in create_order.call_args_list] == [0, 1]
+
+    @pytest.mark.asyncio
+    async def test_get_server_certificate_reports_missing_order_zero_entry(self, mock_opc_device):
+        """Reject a truststore that has no server certificate at order zero."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        service.server_truststore = mock_opc_device.onboarding_config.opc_trust_store
+
+        with pytest.raises(GdsPushError, match='has no certificate at order 0'):
+            await service._get_server_certificate()
+
+    @pytest.mark.asyncio
+    async def test_build_trustlist_rejects_ca_without_crl(self, mock_opc_device, mock_ca_with_crl):
+        """Reject a trustlist when a CA has no configured CRL."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+
+        with patch.object(service, '_build_ca_chain', new_callable=AsyncMock, return_value=[mock_ca_with_crl]):
+            with pytest.raises(GdsPushError, match='has no CRL configured'):
+                await service._build_trustlist_for_server()
+
+    @pytest.mark.asyncio
+    async def test_get_client_credentials_wraps_private_key_failure(self, mock_opc_device, mock_domain_credential):
+        """Convert private-key retrieval failures into a GDS Push error."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        service.domain_credential = mock_domain_credential
+        credential = mock_domain_credential.credential
+
+        with (
+            patch.object(mock_domain_credential, 'is_valid_domain_credential', return_value=(True, '')),
+            patch.object(credential, 'get_private_key', side_effect=RuntimeError('key unavailable')),
+            patch.object(service, '_validate_client_certificate'),
+        ):
+            with pytest.raises(GdsPushError, match='Failed to get private key: key unavailable'):
+                await service._get_client_credentials()
+
+    @pytest.mark.asyncio
+    async def test_log_certificate_mismatch_details_logs_expected_and_actual(self, mock_opc_device, mock_server_certificate,
+                                                                               caplog):
+        """Log both certificates when the OPC UA client exposes the presented certificate."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        service.server_truststore = mock_opc_device.onboarding_config.opc_trust_store
+        client = Mock()
+        client.uaclient.security_policy.server_certificate = mock_server_certificate.public_bytes(
+            serialization.Encoding.DER
+        )
+
+        with patch.object(service, '_get_server_certificate', return_value=client.uaclient.security_policy.server_certificate):
+            with caplog.at_level('ERROR'):
+                await service._log_certificate_mismatch_details(client)
+
+        assert 'Server certificate mismatch detected' in caplog.text
+        assert 'Actual certificate presented by server' in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_update_server_certificate_updates_truststore_after_success(self, mock_opc_device):
+        """Persist the first successful certificate and issuer chain returned by the server."""
+        service = GdsPushService(mock_opc_device, insecure=True)
+        client = AsyncMock()
+        groups = [{'name': 'ApplicationGroup', 'node_id': ua.NodeId(1, 2)}]
+
+        with patch.object(service, '_create_secure_client', new_callable=AsyncMock, return_value=client), \
+             patch.object(service, '_discover_certificate_groups', new_callable=AsyncMock, return_value=groups), \
+             patch.object(service, '_update_single_certificate', new_callable=AsyncMock,
+                          return_value=(True, b'new-cert', [b'issuer'])), \
+             patch.object(service, '_update_truststore_with_new_certificate', new_callable=AsyncMock) as update:
+            success, message, certificate = await service.update_server_certificate()
+
+        assert (success, certificate) == (True, b'new-cert')
+        assert 'Successfully updated 1/1' in message
+        update.assert_awaited_once_with(b'new-cert', [b'issuer'])

--- a/trustpoint/request/tests/test_gds_push_service.py
+++ b/trustpoint/request/tests/test_gds_push_service.py
@@ -1498,7 +1498,10 @@ class TestGdsPushServiceAdditionalCoverage:
         """Reject a trustlist when a CA has no configured CRL."""
         service = GdsPushService(mock_opc_device, insecure=True)
 
-        with patch.object(service, '_build_ca_chain', new_callable=AsyncMock, return_value=[mock_ca_with_crl]):
+        with (
+            patch.object(service, '_build_ca_chain', new_callable=AsyncMock, return_value=[mock_ca_with_crl]),
+            patch.object(CaModel, 'crl_pem', new_callable=PropertyMock, return_value=''),
+        ):
             with pytest.raises(GdsPushError, match='has no CRL configured'):
                 await service._build_trustlist_for_server()
 

--- a/trustpoint/request/tests/test_issue_cert_processor.py
+++ b/trustpoint/request/tests/test_issue_cert_processor.py
@@ -1,0 +1,297 @@
+# Copyright (c) 2026 The Trustpoint Project Authors
+# SPDX-License-Identifier: MIT
+
+"""Focused tests for certificate issuance operation processors."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock, patch
+
+import pytest
+from cryptography import x509
+
+from pki.models import CaModel, IssuedCredentialModel
+from pki.models.cert_profile import CertificateProfileModel
+from request.operation_processor.issue_cert import (
+    CertificateIssueProcessor,
+    LocalCaCertificateIssueProcessor,
+    RemoteCaCertificateIssueProcessor,
+)
+from request.request_context import BaseRequestContext, CmpCertificateRequestContext
+from request.tests.test_est_client import certificate_and_csr
+
+
+def _validated_builder() -> x509.CertificateBuilder:
+    """Build the minimum profile-validated certificate template for local issuance."""
+    return (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, 'issued-device')]))
+        .not_valid_before(datetime.now(UTC))
+        .not_valid_after(datetime.now(UTC) + timedelta(days=30))
+    )
+
+
+def test_certificate_issue_dispatch_requires_certificate_context() -> None:
+    """Reject contexts that cannot represent certificate requests."""
+    with pytest.raises(TypeError, match='BaseCertificateRequestContext'):
+        CertificateIssueProcessor().process_operation(BaseRequestContext())
+
+
+def test_certificate_issue_dispatch_requires_domain_and_issuing_ca() -> None:
+    """Reject requests without a domain or configured issuing CA."""
+    context = CmpCertificateRequestContext()
+    with pytest.raises(ValueError, match='No suitable operation processor'):
+        CertificateIssueProcessor().process_operation(context)
+
+    context.domain = Mock(issuing_ca=None)
+    with pytest.raises(ValueError, match='No suitable operation processor'):
+        CertificateIssueProcessor().process_operation(context)
+
+
+def test_certificate_issue_dispatch_routes_remote_ca_types(domain_instance: dict[str, object]) -> None:
+    """Route each configured remote CA type to its intended processor."""
+    domain = domain_instance['domain']
+    context = CmpCertificateRequestContext(domain=domain)  # type: ignore[arg-type]
+    ca = domain.issuing_ca  # type: ignore[union-attr]
+
+    for ca_type, processor_type in (
+        (CaModel.CaTypeChoice.REMOTE_ISSUING_EST, LocalCaCertificateIssueProcessor),
+        (CaModel.CaTypeChoice.REMOTE_ISSUING_CMP, LocalCaCertificateIssueProcessor),
+        (CaModel.CaTypeChoice.REMOTE_EST_RA, RemoteCaCertificateIssueProcessor),
+        (CaModel.CaTypeChoice.REMOTE_CMP_RA, RemoteCaCertificateIssueProcessor),
+    ):
+        ca.ca_type = ca_type
+        with patch.object(processor_type, 'process_operation') as process:
+            CertificateIssueProcessor().process_operation(context)
+        process.assert_called_once_with(context)
+
+
+def test_certificate_issue_dispatch_uses_local_processor_for_other_ca_types(
+    domain_instance: dict[str, object],
+) -> None:
+    """Route local CA types to the local certificate processor."""
+    context = CmpCertificateRequestContext(domain=domain_instance['domain'])  # type: ignore[arg-type]
+    context.domain.issuing_ca.ca_type = CaModel.CaTypeChoice.LOCAL_PKCS11  # type: ignore[union-attr]
+    with patch.object(LocalCaCertificateIssueProcessor, 'process_operation') as process:
+        CertificateIssueProcessor().process_operation(context)
+    process.assert_called_once_with(context)
+
+
+def test_get_credential_type_for_template_distinguishes_domain_and_application(
+    domain_instance: dict[str, object],
+) -> None:
+    """Classify domain and application certificate profiles correctly."""
+    domain = domain_instance['domain']
+    domain_profile, _ = CertificateProfileModel.objects.get_or_create(
+        unique_name='domain_credential',
+        defaults={
+            'profile_json': '{"type": "cert_profile", "subj": {"allow":"*"}, "ext": {}, "validity": {"days": 30}}'
+        },
+    )
+    tls_profile, _ = CertificateProfileModel.objects.get_or_create(
+        unique_name='tls_server',
+        defaults={
+            'profile_json': '{"type": "cert_profile", "subj": {"allow":"*"}, "ext": {}, "validity": {"days": 10}}'
+        },
+    )
+
+    context = CmpCertificateRequestContext(domain=domain, certificate_profile_model=domain_profile)  # type: ignore[arg-type]
+    credential_type, display_name = CertificateIssueProcessor._get_credential_type_for_template(context)  # noqa: SLF001
+    assert credential_type == IssuedCredentialModel.IssuedCredentialType.DOMAIN_CREDENTIAL
+    assert display_name == (domain_profile.display_name or domain_profile.unique_name)
+
+    context.certificate_profile_model = tls_profile
+    credential_type, display_name = CertificateIssueProcessor._get_credential_type_for_template(context)  # noqa: SLF001
+    assert credential_type == IssuedCredentialModel.IssuedCredentialType.APPLICATION_CREDENTIAL
+    assert display_name == (tls_profile.display_name or tls_profile.unique_name)
+
+    context.certificate_profile_model = None
+    with pytest.raises(ValueError, match='Certificate profile model is required'):
+        CertificateIssueProcessor._get_credential_type_for_template(context)  # noqa: SLF001
+
+
+@pytest.mark.parametrize(
+    ('field', 'message'),
+    [
+        ('device', 'Device must be set'),
+        ('domain', 'Domain must be set'),
+        ('cert_requested', 'Certificate request must be set'),
+    ],
+)
+def test_local_certificate_issue_validates_required_context(
+    field: str,
+    message: str,
+    device_instance: dict[str, object],
+) -> None:
+    """Reject local issuance when a required context value is missing."""
+    _, _, csr = certificate_and_csr()
+    values: dict[str, object] = {
+        'device': device_instance['device'],
+        'domain': device_instance['domain'],
+        'cert_requested': csr,
+    }
+    values[field] = None
+    with pytest.raises(ValueError, match=message):
+        LocalCaCertificateIssueProcessor().process_operation(CmpCertificateRequestContext(**values))
+
+
+def test_local_certificate_issue_saves_issued_credential_and_sets_context(
+    device_instance: dict[str, object],
+) -> None:
+    """Issue a certificate locally and populate the request context."""
+    _, _, csr = certificate_and_csr()
+    profile, _ = CertificateProfileModel.objects.get_or_create(
+        unique_name='domain_credential',
+        defaults={
+            'profile_json': '{"type": "cert_profile", "subj": {"allow":"*"}, "ext": {}, "validity": {"days": 30}}'
+        },
+    )
+    context = CmpCertificateRequestContext(
+        device=device_instance['device'],
+        domain=device_instance['domain'],
+        cert_requested=csr,
+        cert_requested_profile_validated=_validated_builder(),
+        certificate_profile_model=profile,
+    )
+    with patch('request.operation_processor.issue_cert.CredentialSaver') as saver_class, patch(
+        'request.operation_processor.issue_cert.AuditLog.create_entry'
+    ):
+        LocalCaCertificateIssueProcessor().process_operation(context)
+
+    assert context.issued_certificate is not None
+    common_name = context.issued_certificate.subject.get_attributes_for_oid(
+        x509.NameOID.COMMON_NAME
+    )[0].value
+    assert common_name == 'issued-device'
+    assert context.issued_certificate_chain
+    saver_class.return_value.save_keyless_credential.assert_called_once()
+
+
+def test_local_certificate_issue_rejects_unvalidated_request(
+    device_instance: dict[str, object],
+) -> None:
+    """Reject a CSR that has not passed certificate-profile validation."""
+    _, _, csr = certificate_and_csr()
+    context = CmpCertificateRequestContext(
+        device=device_instance['device'], domain=device_instance['domain'], cert_requested=csr
+    )
+    with pytest.raises(ValueError, match='has not been validated'):
+        LocalCaCertificateIssueProcessor().process_operation(context)
+
+
+def test_local_certificate_issue_rejects_disabled_domain(device_instance: dict[str, object]) -> None:
+    """Do not issue certificates while the device domain is disabled."""
+    _, _, csr = certificate_and_csr()
+    domain = device_instance['domain']
+    domain.is_active = False
+    context = CmpCertificateRequestContext(
+        device=device_instance['device'], domain=domain, cert_requested=csr,
+    )
+
+    with pytest.raises(ValueError, match='currently disabled'):
+        LocalCaCertificateIssueProcessor().process_operation(context)
+
+
+@pytest.mark.parametrize(
+    ('attribute', 'message'),
+    [
+        ('remote_host', 'Remote EST host'),
+        ('remote_port', 'Remote EST port'),
+        ('remote_path', 'Remote EST path'),
+        ('chain_truststore', 'Chain truststore'),
+    ],
+)
+def test_remote_est_configuration_is_validated(
+    attribute: str,
+    message: str,
+) -> None:
+    """Reject EST configuration when any required setting is absent."""
+    ca = Mock()
+    ca.get_ca_type_display.return_value = 'Local-PKCS11'
+    ca.ca_type = CaModel.CaTypeChoice.REMOTE_EST_RA
+    ca.remote_host = 'est.example.test'
+    ca.remote_port = 443
+    ca.remote_path = '/.well-known/est/simpleenroll'
+    ca.chain_truststore = Mock()
+    setattr(ca, attribute, None)
+
+    with pytest.raises(ValueError, match=message):
+        RemoteCaCertificateIssueProcessor()._validate_est_enrollment_config(ca)  # noqa: SLF001
+
+
+def test_remote_est_translates_client_errors_and_does_not_save(
+    device_instance: dict[str, object],
+) -> None:
+    """Translate EST client failures and avoid persistence after network errors."""
+    _, _, csr = certificate_and_csr()
+    ca = Mock()
+    ca.ca_type = CaModel.CaTypeChoice.REMOTE_EST_RA
+    ca.remote_host = 'est.example.test'
+    ca.remote_port = 443
+    ca.remote_path = '/.well-known/est/simpleenroll'
+    ca.chain_truststore = Mock()
+    domain = Mock(issuing_ca=ca, unique_name='remote-domain')
+    context = CmpCertificateRequestContext(
+        device=device_instance['device'], domain=domain, cert_requested=csr
+    )
+
+    with patch('request.operation_processor.issue_cert.EstClient') as client_class, patch(
+        'request.operation_processor.issue_cert.CredentialSaver'
+    ) as saver_class:
+        client_class.return_value.simple_enroll.side_effect = RuntimeError('connection refused')
+        with pytest.raises(ValueError, match='EST enrollment failed: connection refused'):
+            RemoteCaCertificateIssueProcessor().process_operation(context)
+
+    saver_class.assert_not_called()
+
+
+def test_remote_cmp_is_explicitly_unimplemented(
+    device_instance: dict[str, object],
+    issuing_ca_instance: dict[str, object],
+) -> None:
+    """Report that remote CMP certificate issuance is not implemented."""
+    _, _, csr = certificate_and_csr()
+    ca = issuing_ca_instance['issuing_ca']
+    ca.ca_type = CaModel.CaTypeChoice.REMOTE_CMP_RA
+    context = CmpCertificateRequestContext(
+        device=device_instance['device'], domain=device_instance['domain'], cert_requested=csr
+    )
+    with pytest.raises(NotImplementedError, match='CMP remote certificate issuance'):
+        RemoteCaCertificateIssueProcessor(ca_type='cmp').process_operation(context)
+
+
+def test_local_certificate_issue_rejects_unsupported_request_key(device_instance: dict[str, object]) -> None:
+    context = CmpCertificateRequestContext(
+        device=device_instance['device'], domain=device_instance['domain'], cert_requested=Mock()
+    )
+    with patch('request.operation_processor.issue_cert.CaRolloverService.get_active_rollover', return_value=None), patch(
+        'request.operation_processor.issue_cert.is_supported_public_key', return_value=False
+    ), pytest.raises(TypeError, match='unsupported type'):
+        LocalCaCertificateIssueProcessor().process_operation(context)
+
+
+def test_local_certificate_issue_rejects_ca_without_credential(device_instance: dict[str, object]) -> None:
+    _, _, csr = certificate_and_csr()
+    ca = Mock()
+    ca.get_credential.return_value = None
+    domain = Mock(is_active=True, get_issuing_ca_or_value_error=Mock(return_value=ca))
+    context = CmpCertificateRequestContext(
+        device=device_instance['device'], domain=domain, cert_requested=csr
+    )
+    with patch('request.operation_processor.issue_cert.CaRolloverService.get_active_rollover', return_value=None), pytest.raises(
+        ValueError, match='does not have a credential'
+    ):
+        LocalCaCertificateIssueProcessor().process_operation(context)
+
+
+def test_remote_est_context_prefers_configured_truststore(device_instance: dict[str, object]) -> None:
+    ca = Mock(
+        no_onboarding_config=Mock(est_password='secret', trust_store=Mock()),
+        chain_truststore=Mock(), remote_host='est.example.test', remote_port=443,
+        remote_path='/enroll', est_username='user',
+    )
+    context = CmpCertificateRequestContext(device=device_instance['device'], cert_profile_str='tls_client')
+
+    result = RemoteCaCertificateIssueProcessor()._build_est_context(context, ca)  # noqa: SLF001
+
+    assert result.est_password == 'secret'
+    assert result.est_server_truststore is ca.no_onboarding_config.trust_store

--- a/trustpoint/request/tests/test_message_responder.py
+++ b/trustpoint/request/tests/test_message_responder.py
@@ -3,15 +3,24 @@
 
 """Tests for request/message_responder.py."""
 
+import base64
 import json
 from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
+from cryptography.hazmat.primitives.serialization import Encoding, pkcs7
 
 from cmp.models import CmpTransactionModel
 from onboarding.models import OnboardingStatus
-from request.message_responder.cmp import CmpInitializationResponder, CmpTransactionResponder
+from request.message_responder.cmp import (
+    CmpErrorMessageResponder,
+    CmpInitializationResponder,
+    CmpMessageResponder,
+    CmpPkiConfResponder,
+    CmpTransactionResponder,
+    _der_tlv,
+)
 from request.message_responder.est import (
     EstCertificateMessageResponder,
     EstErrorMessageResponder,
@@ -24,6 +33,8 @@ from request.message_responder.rest import (
 )
 from request.request_context import (
     BaseRequestContext,
+    CmpBaseRequestContext,
+    CmpCertConfRequestContext,
     CmpCertificateRequestContext,
     CmpPollRequestContext,
     EstBaseRequestContext,
@@ -31,6 +42,7 @@ from request.request_context import (
     RestBaseRequestContext,
     RestCertificateRequestContext,
 )
+from request.workflow2_issuance import Workflow2IssuanceDecision
 from workflows2.models import Workflow2Approval, Workflow2Definition, Workflow2Instance, Workflow2Run
 from workflows2.services.dispatch import DispatchOutcome
 
@@ -184,6 +196,10 @@ class TestEstMessageResponder:
         assert context.http_response_content == 'No suitable responder found for this EST message.'
         assert context.http_response_content_type == 'text/plain'
 
+    def test_build_response_requires_est_context(self) -> None:
+        with pytest.raises(TypeError, match='EstErrorMessageResponder requires an EstBaseRequestContext'):
+            EstErrorMessageResponder.build_response(Mock(spec=BaseRequestContext))
+
 
 @pytest.mark.django_db
 class TestEstCertificateMessageResponder:
@@ -283,6 +299,38 @@ class TestEstCertificateMessageResponder:
         assert context.http_response_content_type == 'application/pkcs7-mime; smime-type=certs-only'
         assert isinstance(context.http_response_content, str)
         assert device.onboarding_config.onboarding_status == OnboardingStatus.ONBOARDED
+
+    def test_build_response_pkcs7_includes_issued_certificate_chain(
+        self,
+        device_instance_onboarding: dict[str, Any],
+    ) -> None:
+        cert = device_instance_onboarding['cert']
+        context = Mock(spec=EstCertificateRequestContext)
+        context.workflow2_outcome = None
+        context.issued_certificate = cert
+        context.issued_certificate_chain = [cert]
+        context.est_encoding = 'pkcs7'
+        context.device = None
+
+        EstCertificateMessageResponder.build_response(context)
+
+        encoded = base64.b64decode(context.http_response_content)
+        assert len(pkcs7.load_der_pkcs7_certificates(encoded)) == 2
+        assert context.http_response_headers == {'Content-Transfer-Encoding': 'base64'}
+
+    def test_prepare_certificate_data_wraps_base64_der(self, device_instance: dict[str, Any]) -> None:
+        context = EstCertificateRequestContext(
+            issued_certificate=device_instance['cert'],
+            est_encoding='base64_der',
+        )
+
+        data, content_type = EstCertificateMessageResponder._prepare_certificate_data(context)
+
+        assert content_type == 'application/pkix-cert'
+        assert isinstance(data, str)
+        assert data.endswith('\n')
+        assert all(len(line) <= 64 for line in data.splitlines())
+        assert base64.b64decode(data) == device_instance['cert'].public_bytes(Encoding.DER)
 
     def test_build_response_without_onboarding_config(
         self,
@@ -398,6 +446,66 @@ class TestRestMessageResponder:
         assert 'certificate' in payload
         assert device.onboarding_config.onboarding_status == OnboardingStatus.ONBOARDED
 
+    def test_build_response_rejects_unsupported_operation(self) -> None:
+        context = RestBaseRequestContext(operation='unsupported')
+
+        RestMessageResponder.build_response(context)
+
+        assert context.http_response_status == 500
+        assert json.loads(context.http_response_content) == {
+            'status': 'error',
+            'detail': 'No suitable responder found for this REST message.',
+        }
+
+    def test_build_response_returns_certificate_chain(self, device_instance: dict[str, Any]) -> None:
+        cert = device_instance['cert']
+        context = RestCertificateRequestContext(
+            operation='enroll',
+            issued_certificate=cert,
+            issued_certificate_chain=[cert],
+        )
+
+        RestCertificateMessageResponder.build_response(context)
+
+        payload = json.loads(context.http_response_content)
+        assert payload['certificate'].startswith('-----BEGIN CERTIFICATE-----')
+        assert payload['certificate_chain'] == [payload['certificate']]
+
+    @pytest.mark.parametrize(
+        ('decision', 'status', 'response_status'),
+        [
+            ('reject', 'rejected', 403),
+            ('fail', 'failed', 500),
+            ('unknown', 'error', 500),
+        ],
+    )
+    def test_workflow_terminal_outcomes_are_json_errors(
+        self, decision: str, status: str, response_status: int
+    ) -> None:
+        context = Mock(spec=RestCertificateRequestContext)
+        context.workflow2_outcome = Mock(run=Mock(status='finished'))
+
+        with (
+            patch(
+                'request.message_responder.rest.get_workflow2_issuance_decision',
+                return_value=(
+                    decision
+                    if decision == 'unknown'
+                    else Workflow2IssuanceDecision(decision)
+                ),
+            ),
+            patch('request.message_responder.rest.get_workflow2_run_detail_path', return_value='/runs/1'),
+        ):
+            RestCertificateMessageResponder.build_response(context)
+
+        payload = json.loads(context.http_response_content)
+        assert context.http_response_status == response_status
+        assert payload['status'] == status
+
+    def test_build_response_requires_rest_context(self) -> None:
+        with pytest.raises(TypeError, match='RestMessageResponder requires a RestBaseRequestContext'):
+            RestMessageResponder.build_response(Mock(spec=BaseRequestContext))
+
 
 @pytest.mark.django_db
 class TestEstErrorMessageResponder:
@@ -442,6 +550,10 @@ class TestEstErrorMessageResponder:
         assert context.http_response_content_type == 'text/plain'
         assert context.http_response_content == 'An error occurred processing the EST request.'
 
+    def test_build_response_requires_est_context(self) -> None:
+        with pytest.raises(TypeError, match='EstErrorMessageResponder requires an EstBaseRequestContext'):
+            EstErrorMessageResponder.build_response(Mock(spec=BaseRequestContext))
+
 
 @pytest.mark.django_db
 class TestRestErrorMessageResponder:
@@ -462,6 +574,20 @@ class TestRestErrorMessageResponder:
             'status': 'error',
             'detail': 'An error occurred processing the REST request.',
         }
+
+    def test_build_response_decodes_byte_detail(self) -> None:
+        context = RestBaseRequestContext(http_response_status=400, http_response_content=b'bad request')
+
+        RestErrorMessageResponder.build_response(context)
+
+        assert json.loads(context.http_response_content) == {
+            'status': 'error',
+            'detail': 'bad request',
+        }
+
+    def test_build_response_requires_rest_context(self) -> None:
+        with pytest.raises(TypeError, match='RestErrorMessageResponder requires a RestBaseRequestContext'):
+            RestErrorMessageResponder.build_response(Mock(spec=BaseRequestContext))
 
 
 class TestCmpTransactionResponder:
@@ -537,3 +663,133 @@ class TestCmpTransactionResponder:
         assert build_pollrep.call_args.kwargs['check_after_seconds'] == 5
         assert context.http_response_status == 200
         assert context.http_response_content == b'cmp-pollrep'
+
+    def test_terminal_poll_states_build_transaction_result(self) -> None:
+        for transaction_status in (
+            CmpTransactionModel.Status.CANCELLED,
+            CmpTransactionModel.Status.FAILED,
+        ):
+            context = Mock(spec=CmpPollRequestContext)
+            context.issued_certificate = None
+            context.cmp_transaction = Mock(status=transaction_status, detail=None)
+            with (
+                patch.object(CmpTransactionResponder, '_build_transaction_result_message', return_value=Mock()) as build,
+                patch.object(CmpTransactionResponder, '_protect_pki_message', side_effect=lambda message, **_: message),
+                patch('request.message_responder.cmp.encoder.encode', return_value=b'terminal'),
+            ):
+                assert CmpTransactionResponder.respond_if_needed(context) is True
+            assert build.call_args.kwargs['status'] == 2
+            assert context.http_response_content == b'terminal'
+
+    def test_poll_with_issued_certificate_returns_result(self) -> None:
+        context = Mock(spec=CmpPollRequestContext)
+        context.issued_certificate = Mock()
+        context.cmp_transaction = Mock(status=CmpTransactionModel.Status.WAITING)
+        with (
+            patch.object(CmpTransactionResponder, '_build_transaction_result_message', return_value=Mock()) as build,
+            patch.object(CmpTransactionResponder, '_protect_pki_message', side_effect=lambda message, **_: message),
+            patch('request.message_responder.cmp.encoder.encode', return_value=b'issued'),
+        ):
+            assert CmpTransactionResponder.respond_if_needed(context) is True
+        assert build.call_args.kwargs['status'] == 0
+        assert build.call_args.kwargs['issued_cert'] is context.issued_certificate
+
+    def test_unknown_operation_does_not_handle_transaction(self) -> None:
+        context = Mock(spec=CmpCertificateRequestContext)
+        context.issued_certificate = None
+        context.operation = 'unknown'
+        context.cmp_transaction = Mock(status=CmpTransactionModel.Status.FAILED, detail='failed')
+        with patch.object(CmpTransactionResponder, '_build_transaction_result_message', return_value=None):
+            assert CmpTransactionResponder.respond_if_needed(context) is False
+
+
+class TestCmpResponderValidation:
+    """Test CMP responder routing and protection preconditions."""
+
+    def test_der_tlv_uses_long_form_for_large_values(self) -> None:
+        encoded = _der_tlv(0x04, b'x' * 128)
+        assert encoded[:3] == b'\x04\x81\x80'
+        assert encoded[3:] == b'x' * 128
+
+    def test_build_response_returns_cmp_error_for_authorization_failure(self) -> None:
+        context = Mock(spec=BaseRequestContext)
+        context.error_details = 'unauthorized'
+        context.http_response_status = 403
+        context.http_response_content = None
+        context.http_response_content_type = None
+
+        with patch.object(CmpErrorMessageResponder, 'build_response') as build_error:
+            CmpMessageResponder.build_response(context)
+
+        build_error.assert_called_once_with(context)
+
+    def test_build_response_sets_error_when_no_responder_matches(self) -> None:
+        context = Mock(spec=BaseRequestContext)
+        context.error_details = None
+        context.http_response_status = None
+        context.issued_certificate = None
+        context.workflow2_outcome = None
+
+        with patch.object(CmpErrorMessageResponder, 'build_response') as build_error:
+            CmpMessageResponder.build_response(context)
+
+        assert context.http_response_status == 500
+        assert context.http_response_content == 'No suitable responder found for this CMP message.'
+        build_error.assert_called_once_with(context)
+
+    def test_shared_secret_protection_requires_secret(self) -> None:
+        context = Mock(spec=CmpBaseRequestContext)
+        context.cmp_shared_secret = None
+        with pytest.raises(ValueError, match='CMP shared secret is not set'):
+            CmpMessageResponder._add_protection_shared_secret(Mock(), context)
+
+    def test_initialization_responder_requires_issuer_credential(self) -> None:
+        context = Mock(spec=CmpCertificateRequestContext)
+        context.issued_certificate = Mock()
+        context.issuer_credential = None
+        with pytest.raises(ValueError, match='Issuer credential is not set'):
+            CmpInitializationResponder.build_response(context)
+
+    def test_protection_helpers_choose_shared_secret_or_signature(self) -> None:
+        context = Mock(spec=CmpCertificateRequestContext)
+        message = Mock()
+        context.cmp_shared_secret = 'shared-secret'
+        with patch.object(CmpMessageResponder, '_add_protection_shared_secret', return_value=message) as shared:
+            assert CmpTransactionResponder._protect_pki_message(message, context=context) is message
+        shared.assert_called_once()
+
+        context.cmp_shared_secret = None
+        with patch.object(CmpMessageResponder, '_sign_pki_message', return_value=message) as signed:
+            assert CmpTransactionResponder._protect_pki_message(message, context=context) is message
+        signed.assert_called_once()
+
+    def test_error_response_type_for_operations(self) -> None:
+        assert CmpErrorMessageResponder._get_response_type_for_operation('initialization') == ('ip', 1)
+        assert CmpErrorMessageResponder._get_response_type_for_operation('certification') == ('cp', 3)
+        assert CmpErrorMessageResponder._get_response_type_for_operation('revocation') == ('rp', 12)
+        assert CmpErrorMessageResponder._get_response_type_for_operation(None) == ('error', 23)
+
+    def test_pki_conf_rejects_missing_issuer_credential(self) -> None:
+        context = Mock(spec=CmpCertConfRequestContext)
+        context.issuer_credential = None
+        context.domain = None
+        with pytest.raises(ValueError, match='Cannot determine issuing CA credential'):
+            CmpPkiConfResponder.build_response(context)
+
+    def test_pki_conf_builds_signed_response(self) -> None:
+        context = Mock(spec=CmpCertConfRequestContext)
+        context.issuer_credential = Mock()
+        context.owner_credential = None
+        context.cmp_shared_secret = None
+        context.cert_conf_status = 0
+        context.device = None
+        context.parsed_message = Mock()
+        with (
+            patch.object(CmpPkiConfResponder, '_build_base_pkiconf_message', return_value=Mock()),
+            patch.object(CmpPkiConfResponder, '_sign_pki_message', side_effect=lambda pki_message, **_: pki_message) as sign,
+            patch('request.message_responder.cmp.x509.SubjectKeyIdentifier.from_public_key', return_value=Mock(digest=b'ski')),
+            patch('request.message_responder.cmp.encoder.encode', return_value=b'pkiconf'),
+        ):
+            CmpPkiConfResponder.build_response(context)
+        sign.assert_called_once()
+        assert context.http_response_content == b'pkiconf'

--- a/trustpoint/request/tests/test_operation_processors_csr.py
+++ b/trustpoint/request/tests/test_operation_processors_csr.py
@@ -11,6 +11,7 @@ import pytest
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from pki.models import CertificateModel
 
 try:
     from cryptography.hazmat.primitives.asymmetric import mldsa
@@ -400,3 +401,42 @@ class TestCertificateRevocationProcessor:
         ctx.domain.get_issuing_ca_or_value_error.return_value.get_credential.return_value = Mock()
         with pytest.raises(ValueError, match='Credential to revoke must be set'):
             CertificateRevocationProcessor().process_operation(ctx)
+
+    def test_local_ca_revocation_sets_issuer_and_revokes_credential(self) -> None:
+        ctx = CmpRevocationRequestContext()
+        ctx.domain = Mock(unique_name='example')
+        ctx.domain.issuing_ca = Mock()
+        ctx.device = Mock(common_name='device')
+        ctx.protocol = 'cmp'
+        credential = Mock()
+        credential.credential.certificate_or_error = Mock(
+            certificate_status=CertificateModel.CertificateStatus.OK,
+        )
+        ctx.credential_to_revoke = credential
+        ca = ctx.domain.get_issuing_ca_or_value_error.return_value
+        ca.get_credential.return_value = Mock()
+
+        with patch('request.operation_processor.revoke_cert.CaRolloverService.get_active_rollover', return_value=None), \
+            patch('request.operation_processor.revoke_cert.AuditLog.create_entry') as audit:
+            CertificateRevocationProcessor().process_operation(ctx)
+
+        assert ctx.issuer_credential is ca.get_credential.return_value
+        credential.revoke.assert_called_once_with()
+        audit.assert_called_once()
+
+    def test_local_ca_revocation_rejects_already_revoked_certificate(self) -> None:
+        ctx = CmpRevocationRequestContext(
+            domain=Mock(issuing_ca=Mock()), device=Mock(common_name='device'),
+            credential_to_revoke=Mock(),
+        )
+        ctx.domain.get_issuing_ca_or_value_error.return_value.get_credential.return_value = Mock()
+        ctx.credential_to_revoke.credential.certificate_or_error = Mock(
+            certificate_status=CertificateModel.CertificateStatus.REVOKED,
+        )
+
+        with patch('request.operation_processor.revoke_cert.CaRolloverService.get_active_rollover', return_value=None):
+            with pytest.raises(ValueError, match='already revoked'):
+                CertificateRevocationProcessor().process_operation(ctx)
+
+        assert ctx.http_response_status == 422
+        ctx.credential_to_revoke.revoke.assert_not_called()

--- a/trustpoint/request/tests/test_pki_message_parser.py
+++ b/trustpoint/request/tests/test_pki_message_parser.py
@@ -9,12 +9,24 @@ import pytest
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import rsa
+from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.type import univ
+from pyasn1_modules import rfc2459, rfc2511, rfc4210, rfc4211, rfc5280
 from pki.models import DomainModel
 
 from request.message_parser import CmpMessageParser, EstMessageParser
 from request.message_parser.base import CertProfileParsing, CompositeParsing, DomainParsing
-from request.message_parser.cmp import CmpPkiMessageParsing
+from request.message_parser.cmp import (
+    CmpBodyValidation,
+    CmpCertificateBodyValidation,
+    CmpCertConfBodyValidation,
+    CmpHeaderValidation,
+    CmpPollReqBodyValidation,
+    CmpRevocationBodyValidation,
+    CmpPkiMessageParsing,
+)
 from request.message_parser.est import EstAuthorizationHeaderParsing, EstCsrSignatureVerification, EstPkiMessageParsing
+from request.message_parser.rfc9480 import CertStatus, PKIBody
 from request.request_context import BaseCertificateRequestContext, BaseRequestContext, BaseRevocationRequestContext, CmpBaseRequestContext, EstBaseRequestContext, EstCertificateRequestContext
 
 
@@ -546,6 +558,203 @@ class TestCmpPkiMessageParsing:
                 assert False, 'Expected ValueError to be raised'
             except ValueError as e:
                 assert 'Failed to parse the CMP message. It seems to be corrupted.' in str(e)
+
+
+class TestCmpTypedBodyValidation:
+    """Exercise CMP body validators with real pyasn1 structures."""
+
+    @staticmethod
+    def _body(name: str):
+        body = PKIBody()
+        body[name].setComponentByPosition(0)
+        return body
+
+    def test_certconf_requires_one_status_and_cert_req_id_zero(self):
+        body = self._body('certConf')
+        body['certConf'].clear()
+        with pytest.raises(ValueError, match='exactly one CertStatus'):
+            CmpCertConfBodyValidation().parse_certconf_body(Mock(), body)
+
+        status = CertStatus()
+        status['certHash'] = b'certificate-hash'
+        status['certReqId'] = 1
+        body['certConf'].clear()
+        body['certConf'].append(status)
+        with pytest.raises(ValueError, match='certReqId in certConf MUST be 0'):
+            CmpCertConfBodyValidation().parse_certconf_body(Mock(), body)
+
+    def test_certconf_rejection_status_and_hash_algorithm_are_parsed(self):
+        body = self._body('certConf')
+        status = CertStatus()
+        status['certHash'] = b'certificate-hash'
+        status['certReqId'] = 0
+        status['statusInfo']['status'] = 2
+        status['statusInfo']['statusString'].append('rejected')
+        status['hashAlg']['algorithm'] = '2.16.840.1.101.3.4.2.1'
+        body['certConf'].clear()
+        body['certConf'].append(status)
+
+        context = Mock()
+        CmpCertConfBodyValidation().parse_certconf_body(context, body)
+
+        assert context.cert_hash == b'certificate-hash'
+        assert context.cert_conf_status == 2
+        assert context.cert_conf_status_string == 'rejected'
+        assert context.cert_hash_algorithm_oid == '2.16.840.1.101.3.4.2.1'
+
+    def test_pollreq_rejects_nonzero_cert_req_id(self):
+        body = self._body('pollReq')
+        body['pollReq'][0]['certReqId'] = 3
+        with pytest.raises(ValueError, match='certReqId MUST be 0'):
+            CmpPollReqBodyValidation().parse_pollreq_body(Mock(), body)
+
+    def test_revocation_body_extracts_serial_and_default_reason(self):
+        body = self._body('rr')
+        body['rr'][0]['certDetails']['serialNumber'] = 0xABCD
+        context = Mock()
+        CmpRevocationBodyValidation().parse_rr_body(context, body)
+        assert context.cert_serial_number == 'ABCD'
+        assert context.revocation_reason.name == 'unspecified'
+
+    def test_header_validation_rejects_wrong_version_and_lengths(self):
+        message = rfc4210.PKIMessage()
+        message['header']['pvno'] = 99
+        with pytest.raises(ValueError, match='pvno fail'):
+            CmpHeaderValidation()._check_header(message)
+
+        message['header']['pvno'] = 2
+        message['header']['transactionID'] = b'short'
+        with pytest.raises(ValueError, match='transactionID fail'):
+            CmpHeaderValidation()._check_header(message)
+
+    def test_body_validation_rejects_unsupported_body(self):
+        context = Mock(spec=CmpBaseRequestContext)
+        context.parsed_message = rfc4210.PKIMessage()
+        context.parsed_message['body']['error'].setComponentByPosition(0)
+        with pytest.raises(ValueError, match='Unsupported CMP body type'):
+            CmpBodyValidation().parse(context)
+
+    def test_cert_request_rejects_invalid_shape_and_template_version(self):
+        validator = CmpCertificateBodyValidation()
+        cert_req = rfc2511.CertReqMsg()
+        cert_request = cert_req['certReq']
+        cert_request['certReqId'] = 0
+        with pytest.raises(ValueError, match='Public key missing'):
+            validator._validate_cert_request(cert_request)
+
+        cert_request['certReqId'] = 1
+        with pytest.raises(ValueError, match='certReqId must be 0'):
+            validator._validate_cert_request(cert_request)
+
+        cert_request['certReqId'] = 0
+        cert_request['certTemplate']['version'] = 3
+        with pytest.raises(ValueError, match='Version must be 2'):
+            validator._validate_cert_request(cert_request)
+
+    def test_cert_template_extensions_parse_typed_values(self):
+        validator = CmpCertificateBodyValidation()
+        extensions = rfc2459.Extensions()
+        san = rfc2459.SubjectAltName()
+        san.append(rfc2459.GeneralName().setComponentByName('dNSName', 'device.example'))
+        san.append(rfc2459.GeneralName().setComponentByName('iPAddress', b'\x7f\x00\x00\x01'))
+        san.append(rfc2459.GeneralName().setComponentByName('uniformResourceIdentifier', 'urn:device'))
+        san.append(rfc2459.GeneralName().setComponentByName('rfc822Name', 'device@example'))
+        basic_constraints = rfc2459.BasicConstraints()
+        basic_constraints['cA'] = True
+        basic_constraints['pathLenConstraint'] = 2
+        key_usage = rfc2459.KeyUsage('111000000')
+        eku = rfc2459.ExtKeyUsageSyntax()
+        eku.append('1.3.6.1.5.5.7.3.2')
+        policies = rfc2459.CertificatePolicies()
+        policies[0]['policyIdentifier'] = '1.2.3.4'
+        values = [
+            ('2.5.29.17', der_encode(san), False),
+            ('2.5.29.19', der_encode(basic_constraints), True),
+            ('2.5.29.15', der_encode(key_usage), True),
+            ('2.5.29.37', der_encode(eku), False),
+            ('2.5.29.14', der_encode(rfc2459.SubjectKeyIdentifier(b'\x01\x02')), False),
+            ('2.5.29.32', der_encode(policies), False),
+        ]
+        for index, (oid, value, critical) in enumerate(values):
+            extension = rfc2459.Extension()
+            extension['extnID'] = oid
+            if critical:
+                extension['critical'] = True
+            extension['extnValue'] = value
+            extensions[index] = extension
+
+        parsed = validator._parse_cert_template_extensions(extensions)
+        assert [extension.oid for extension in parsed] == [x509.ObjectIdentifier(oid) for oid, _, _ in values]
+        assert parsed[0].value.get_values_for_type(x509.DNSName) == ['device.example']
+        assert parsed[1].value.ca is True
+        assert parsed[2].critical is True
+        assert parsed[3].value[0].dotted_string == '1.3.6.1.5.5.7.3.2'
+
+    def test_cert_template_extension_rejects_unsupported_oid_and_policy_qualifier(self):
+        validator = CmpCertificateBodyValidation()
+        unsupported = rfc2459.Extension()
+        unsupported['extnID'] = '1.2.3.4.5'
+        unsupported['extnValue'] = b'ignored'
+        with pytest.raises(NotImplementedError, match='not supported'):
+            validator._parse_cert_template_extensions([unsupported])
+
+        policies = rfc2459.CertificatePolicies()
+        policies[0]['policyIdentifier'] = '1.2.3.4'
+        policies[0]['policyQualifiers'][0]['policyQualifierId'] = '1.3.6.1.5.5.7.2.1'
+        policies[0]['policyQualifiers'][0]['qualifier'] = der_encode(univ.ObjectIdentifier('1.2.3.4'))
+        with pytest.raises(ValueError, match='Policy qualifiers are not supported'):
+            validator._parse_certificate_policies(der_encode(policies), critical=False)
+
+    def test_revocation_body_parses_reason_and_rejects_missing_details(self):
+        body = self._body('rr')
+        request = body['rr'][0]
+        request['certDetails']['serialNumber'] = 0x10
+        reason = rfc5280.CRLReason('keyCompromise')
+        crl_extension = request['crlEntryDetails'].componentType.clone()
+        crl_extension['extnID'] = '2.5.29.21'
+        crl_extension['extnValue'] = der_encode(reason)
+        request['crlEntryDetails'].append(crl_extension)
+        context = Mock()
+        CmpRevocationBodyValidation().parse_rr_body(context, body)
+        assert context.revocation_reason == x509.ReasonFlags.unspecified
+
+        request['certDetails']['serialNumber'] = univ.noValue
+        with pytest.raises(ValueError, match='serialNumber must be present'):
+            CmpRevocationBodyValidation().parse_rr_body(context, body)
+
+    def test_certconf_acceptance_defaults_and_rejects_invalid_status_or_hash(self):
+        body = self._body('certConf')
+        status = CertStatus()
+        status['certHash'] = b'hash'
+        status['certReqId'] = 0
+        body['certConf'].clear()
+        body['certConf'].append(status)
+        context = Mock()
+        CmpCertConfBodyValidation().parse_certconf_body(context, body)
+        assert context.cert_conf_status == 0
+        assert context.cert_hash_algorithm_oid is None
+
+        status['statusInfo']['status'] = 1
+        with pytest.raises(ValueError, match='accepted.*rejection'):
+            CmpCertConfBodyValidation().parse_certconf_body(context, body)
+
+    def test_header_implicit_confirm_and_poll_length_branches(self):
+        message = rfc4210.PKIMessage()
+        message['header']['pvno'] = 2
+        message['header']['transactionID'] = b'x' * 16
+        message['header']['senderNonce'] = b'y' * 16
+        message['body']['ir'].setComponentByPosition(0)
+        entry = message['header']['generalInfo'].componentType.clone()
+        entry['infoType'] = '1.3.6.1.5.5.7.4.13'
+        entry['infoValue'] = univ.OctetString(b'bad')
+        message['header']['generalInfo'].append(entry)
+        with pytest.raises(ValueError, match='implicit confirm entry fail'):
+            CmpHeaderValidation()._check_implicit_confirm(Mock(operation='initialization'), message)
+
+        poll = self._body('pollReq')
+        poll['pollReq'].clear()
+        with pytest.raises(ValueError, match='exactly one'):
+            CmpPollReqBodyValidation().parse_pollreq_body(Mock(), poll)
 
 
 class TestCompositeParsing:

--- a/trustpoint/request/tests/test_request_components_additional.py
+++ b/trustpoint/request/tests/test_request_components_additional.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 The Trustpoint Project Authors
+# SPDX-License-Identifier: MIT
+
 """Additional security and error-path tests for request components."""
 
 from unittest.mock import MagicMock, Mock, patch

--- a/trustpoint/request/tests/test_request_components_additional.py
+++ b/trustpoint/request/tests/test_request_components_additional.py
@@ -1,0 +1,828 @@
+"""Additional security and error-path tests for request components."""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from cryptography import x509
+from cmp.models import CmpTransactionModel
+from cmp.util import PKIFailureInfo, PKI_STATUS_REJECTION
+from django.test import RequestFactory
+from onboarding.models import OnboardingStatus
+from pyasn1_modules import rfc4210
+from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.type import tag, univ
+from pyasn1_modules import rfc2459
+
+from request.authentication.base import CompositeAuthentication
+from request.authorization.base import (
+    CompositeAuthorization,
+    DomainScopeValidation,
+    ProtocolAuthorization,
+)
+from request.cmp_transaction_state import CmpTransactionState
+from request.message_parser.base import CompositeParsing, DomainParsing
+from request.message_parser.cmp import (
+    CmpBodyValidation,
+    CmpCertificateBodyValidation,
+    CmpCertConfBodyValidation,
+    CmpHeaderValidation,
+    CmpPkiMessageParsing,
+    CmpPollReqBodyValidation,
+    CmpRevocationBodyValidation,
+)
+from request.message_responder.cmp import (
+    CmpCertificationResponder,
+    CmpErrorMessageResponder,
+    CmpRevocationResponder,
+    CmpMessageResponder,
+    CmpInitializationResponder,
+    CmpPkiConfResponder,
+    CmpTransactionResponder,
+)
+from request.operation_processor.cert_conf import CertConfProcessor
+from request.operation_processor.general import OperationProcessor
+from request.operation_processor.cmp_poll import CmpPollDisposition, CmpPollProcessor
+from request.request_context import (
+    BaseRequestContext,
+    CmpCertConfRequestContext,
+    CmpCertificateRequestContext,
+    CmpBaseRequestContext,
+    CmpPollRequestContext,
+    CmpRevocationRequestContext,
+    EstCertificateRequestContext,
+    HttpBaseRequestContext,
+)
+from request.tests.test_est_client import certificate_and_csr
+from workflows2.events.request_events import Events
+
+
+class AuthComponent:
+    def __init__(self, result: object = None, error: Exception | None = None) -> None:
+        self.result = result
+        self.error = error
+        self.calls = 0
+
+    def authenticate(self, context: BaseRequestContext) -> None:
+        self.calls += 1
+        if self.error:
+            raise self.error
+        if self.result is not None:
+            context.device = self.result
+
+
+class AuthorizationComponent:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls = 0
+
+    def authorize(self, context: BaseRequestContext) -> None:
+        self.calls += 1
+        if self.error:
+            raise self.error
+
+
+class ParsingComponent:
+    def __init__(self, result: BaseRequestContext | None = None, error: Exception | None = None) -> None:
+        self.result = result
+        self.error = error
+        self.calls = 0
+
+    def parse(self, context: BaseRequestContext) -> BaseRequestContext | None:
+        self.calls += 1
+        if self.error:
+            raise self.error
+        return self.result
+
+
+def test_composite_authentication_short_circuits_and_removes_components() -> None:
+    device = Mock(common_name='device', ip_address=None)
+    first = AuthComponent(error=ValueError('bad credentials'))
+    second = AuthComponent(result=device)
+    composite = CompositeAuthentication()
+    composite.add(first)
+    composite.add(second)
+    request = RequestFactory().post('/')
+    request.META['REMOTE_ADDR'] = '192.0.2.4'
+    context = HttpBaseRequestContext(raw_message=request)
+
+    composite.authenticate(context)
+
+    assert context.device is device
+    assert first.calls == 1 and second.calls == 1
+    assert device.ip_address == '192.0.2.4'
+    composite.remove(first)
+    assert first not in composite.components
+    with pytest.raises(ValueError, match='Authentication failed'):
+        composite.remove(second)
+        composite.authenticate(HttpBaseRequestContext())
+
+
+def test_composite_authentication_reports_failure_and_sets_http_state() -> None:
+    composite = CompositeAuthentication()
+    composite.add(AuthComponent(error=RuntimeError('backend unavailable')))
+    context = HttpBaseRequestContext()
+    with pytest.raises(ValueError, match='All authentication methods'):
+        composite.authenticate(context)
+    assert context.http_response_status == 403
+    assert context.http_response_content == 'Authentication failed.'
+
+
+def test_composite_authorization_order_and_remove_errors() -> None:
+    first = AuthorizationComponent()
+    second = AuthorizationComponent()
+    composite = CompositeAuthorization()
+    composite.add(first)
+    composite.add(second)
+    context = BaseRequestContext(protocol='rest')
+    composite.authorize(context)
+    assert first.calls == 1 and second.calls == 1
+    composite.remove(first)
+    with pytest.raises(ValueError, match='non-existent'):
+        composite.remove(first)
+
+
+def test_composite_authorization_wraps_component_errors() -> None:
+    composite = CompositeAuthorization()
+    composite.add(AuthorizationComponent(error=ValueError('denied')))
+    with pytest.raises(ValueError, match='AuthorizationComponent: denied'):
+        composite.authorize(BaseRequestContext())
+
+
+@pytest.mark.parametrize(
+    ('protocol', 'expected'),
+    [('est', None), (None, 'missing'), ('cmp', 'Unauthorized')],
+)
+def test_protocol_authorization_accepts_and_rejects(protocol: str | None, expected: str | None) -> None:
+    component = ProtocolAuthorization(['est'])
+    if expected is None:
+        component.authorize(BaseRequestContext(protocol=protocol))
+    else:
+        with pytest.raises(ValueError, match=expected):
+            component.authorize(BaseRequestContext(protocol=protocol))
+
+
+def test_domain_scope_validation_checks_device_domain(domain_instance: dict[str, object]) -> None:
+    domain = domain_instance['domain']
+    device = Mock(domain=domain, common_name='device')
+    component = DomainScopeValidation()
+    component.authorize(BaseRequestContext(device=device, domain=domain))
+    with pytest.raises(ValueError, match='Requested domain is missing'):
+        component.authorize(BaseRequestContext(device=device))
+    with pytest.raises(ValueError, match='Unauthorized requested domain'):
+        component.authorize(BaseRequestContext(device=device, domain=Mock()))
+
+
+def test_composite_parsing_updates_context_and_wraps_errors(domain_instance: dict[str, object]) -> None:
+    domain = domain_instance['domain']
+    replacement = EstCertificateRequestContext(domain=domain)
+    first = ParsingComponent(result=replacement)
+    second = ParsingComponent()
+    composite = CompositeParsing()
+    composite.add(first)
+    composite.add(second)
+    assert composite.parse(BaseRequestContext()) is replacement
+    composite.remove(first)
+    with pytest.raises(ValueError, match='non-existent'):
+        composite.remove(first)
+    failing = CompositeParsing()
+    failing.add(ParsingComponent(error=ValueError('malformed')))
+    with pytest.raises(ValueError, match='malformed'):
+        failing.parse(BaseRequestContext())
+
+
+def test_domain_parsing_handles_missing_special_and_unknown_domains(domain_instance: dict[str, object]) -> None:
+    parser = DomainParsing()
+    context = BaseRequestContext(domain_str=domain_instance['domain'].unique_name)
+    parser.parse(context)
+    assert context.domain == domain_instance['domain']
+    parser.parse(BaseRequestContext())
+    parser.parse(BaseRequestContext(domain_str='.aoki'))
+    with pytest.raises(ValueError, match='does not exist'):
+        parser.parse(BaseRequestContext(domain_str='unknown-domain'))
+
+
+def test_certconf_acceptance_is_noop_and_rejection_without_credential_sets_error() -> None:
+    processor = CertConfProcessor()
+    processor.process_operation(CmpCertConfRequestContext(cert_conf_status=0))
+    context = CmpCertConfRequestContext(cert_conf_status=PKI_STATUS_REJECTION)
+    with pytest.raises(ValueError, match='credential_to_revoke'):
+        processor.process_operation(context)
+    assert context.http_response_status == 500
+    assert context.error_code == PKIFailureInfo.SYSTEM_FAILURE
+
+
+def test_certconf_rejection_delegates_to_revocation() -> None:
+    context = CmpCertConfRequestContext(
+        cert_conf_status=PKI_STATUS_REJECTION,
+        credential_to_revoke=Mock(common_name='credential'),
+    )
+    with patch('request.operation_processor.cert_conf.CertificateRevocationProcessor.process_operation') as process:
+        CertConfProcessor().process_operation(context)
+    process.assert_called_once_with(context)
+    with pytest.raises(TypeError, match='requires a CmpCertConfRequestContext'):
+        CertConfProcessor().process_operation(BaseRequestContext())
+
+
+def test_cmp_poll_disposition_covers_all_states() -> None:
+    statuses = {
+        CmpTransactionModel.Status.ISSUED: CmpPollDisposition.ISSUED,
+        CmpTransactionModel.Status.PROCESSING: CmpPollDisposition.READY_FOR_FINAL_ISSUANCE,
+        CmpTransactionModel.Status.WAITING: CmpPollDisposition.WAIT,
+        CmpTransactionModel.Status.FAILED: CmpPollDisposition.TERMINAL,
+    }
+    for status, expected in statuses.items():
+        record = Mock(status=status)
+        assert CmpPollProcessor._determine_poll_disposition(record) == expected
+
+
+def test_cmp_poll_requires_transaction_and_correct_context() -> None:
+    processor = CmpPollProcessor()
+    with pytest.raises(TypeError, match='requires a CmpPollRequestContext'):
+        processor.process_operation(BaseRequestContext())
+    with pytest.raises(ValueError, match='missing its CMP transaction'):
+        processor.process_operation(CmpPollRequestContext())
+
+
+def test_transaction_state_terminal_transitions_and_pending_details() -> None:
+    transaction = CmpTransactionModel.objects.create(
+        transaction_id='state-test', operation='initialization', request_body_type='ir',
+        status=CmpTransactionModel.Status.WAITING,
+    )
+    rejected = CmpTransactionState.mark_terminal_from_run_status(
+        transaction.pk, run_status='rejected'
+    )
+    assert rejected.status == CmpTransactionModel.Status.REJECTED
+    assert rejected.backend == CmpTransactionModel.Backend.NONE
+    assert CmpTransactionState._detail_for_pending_run_status('awaiting') == 'Enrollment request pending workflow approval.'
+    assert CmpTransactionState._detail_for_pending_run_status('running') == 'Enrollment request pending workflow processing.'
+    with pytest.raises(ValueError, match='requires a reject or fail'):
+        CmpTransactionState.mark_terminal_from_request_decision(transaction.pk, request_decision=Mock())
+
+
+def test_operation_processor_selects_processors_and_preserves_cmp_error() -> None:
+    context = CmpCertificateRequestContext()
+    with patch('request.operation_processor.general.CmpCertificateRequestProcessor.process_operation', side_effect=ValueError('invalid')):
+        with pytest.raises(ValueError, match='invalid'):
+            OperationProcessor().process_operation(context)
+    assert context.http_response_status == 500
+    assert context.error_details == 'PKI Operation processing failed.'
+    with pytest.raises(TypeError, match='No suitable operation processor'):
+        OperationProcessor().process_operation(BaseRequestContext())
+
+
+@pytest.mark.parametrize(
+    ('status', 'expected'),
+    [
+        (CmpTransactionModel.Status.WAITING, (3, 'pending')),
+        (CmpTransactionModel.Status.PROCESSING, (3, 'Enrollment request pending workflow processing.')),
+        (CmpTransactionModel.Status.REJECTED, (2, 'Enrollment request rejected.')),
+        (CmpTransactionModel.Status.CANCELLED, (2, 'Enrollment request cancelled.')),
+        (CmpTransactionModel.Status.FAILED, (2, 'Enrollment request failed.')),
+        (CmpTransactionModel.Status.ISSUED, (2, 'Unsupported CMP transaction state: issued.')),
+    ],
+)
+def test_transaction_responder_maps_transaction_states(status: str, expected: tuple[int, str]) -> None:
+    record = Mock(status=status, detail='pending' if status == CmpTransactionModel.Status.WAITING else None)
+    assert CmpTransactionResponder._detail_for_transaction_status(record) == expected
+
+
+def test_transaction_responder_resolves_sender_kid_and_unknown_operations() -> None:
+    empty_kid = CmpTransactionResponder._build_sender_kid(None)
+    assert bytes(empty_kid) == b''
+    context = CmpCertificateRequestContext(operation='unsupported', domain=None)
+    assert CmpTransactionResponder._build_transaction_result_message(
+        context=context, issued_cert=None, status=2, status_text='denied'
+    ) is None
+    assert CmpTransactionResponder.respond_if_needed(BaseRequestContext()) is False
+    assert CmpTransactionResponder.respond_if_needed(CmpCertificateRequestContext()) is False
+
+
+def test_cmp_responder_error_dispatch_sets_fallback_response() -> None:
+    context = CmpBaseRequestContext(error_details='bad request', http_response_status=400)
+    with patch.object(CmpErrorMessageResponder, '_build_response', side_effect=RuntimeError('cannot encode')):
+        CmpMessageResponder.build_response(context)
+    assert context.http_response_status == 400
+    assert context.http_response_content == 'An error occurred processing the CMP request.'
+
+
+def test_cmp_error_response_type_and_missing_context() -> None:
+    assert CmpErrorMessageResponder._get_response_type_for_operation('initialization') == ('ip', 1)
+    assert CmpErrorMessageResponder._get_response_type_for_operation('certification') == ('cp', 3)
+    assert CmpErrorMessageResponder._get_response_type_for_operation('revocation') == ('rp', 12)
+    assert CmpErrorMessageResponder._get_response_type_for_operation(None) == ('error', 23)
+    with pytest.raises(TypeError, match='requires a CmpBaseRequestContext'):
+        CmpErrorMessageResponder._build_response(BaseRequestContext())
+
+
+def test_cmp_poll_response_builder_creates_pollrep_without_issuer() -> None:
+    context = CmpPollRequestContext(
+        parsed_message=Mock(), poll_cert_req_id=4, domain=None,
+    )
+    with patch.object(CmpTransactionResponder, '_build_response_message_header', return_value=rfc4210.PKIHeader()):
+        response = CmpTransactionResponder._build_pollrep_message(
+            context=context, detail='awaiting approval', check_after_seconds=9,
+        )
+    assert response['body'].getName() == 'pollRep'
+    poll_content = response['body']['pollRep']
+    assert int(poll_content[0]['certReqId']) == 4
+    assert int(poll_content[0]['checkAfter']) == 9
+    assert str(poll_content[0]['reason'][0]) == 'awaiting approval'
+
+
+def test_cmp_header_validation_checks_version_lengths_and_implicit_confirm() -> None:
+    validator = CmpHeaderValidation(transaction_id_length=2, sender_nonce_length=2)
+    header = {
+        'pvno': 2,
+        'transactionID': Mock(asOctets=Mock(return_value=b'ab')),
+        'senderNonce': Mock(asOctets=Mock(return_value=b'cd')),
+    }
+    message = MagicMock()
+    message.__getitem__.side_effect = lambda key: {'header': header, 'body': Mock(getName=Mock(return_value='certConf'))}[key]
+    validator._check_header(message)
+    with pytest.raises(ValueError, match='pvno fail'):
+        header['pvno'] = 9
+        validator._check_header(message)
+    header['pvno'] = 2
+    header['transactionID'].asOctets.return_value = b'a'
+    with pytest.raises(ValueError, match='transactionID fail'):
+        validator._check_header(message)
+
+
+def test_cmp_header_validation_tracks_implicit_confirm_and_skips_prohibited_bodies() -> None:
+    validator = CmpHeaderValidation(transaction_id_length=2, sender_nonce_length=2)
+    header = {
+        'pvno': 2,
+        'transactionID': Mock(asOctets=Mock(return_value=b'ab')),
+        'senderNonce': Mock(asOctets=Mock(return_value=b'cd')),
+        'generalInfo': [],
+    }
+    body = Mock(getName=Mock(return_value='ir'))
+    message = MagicMock()
+    message.__getitem__.side_effect = lambda key: {'header': header, 'body': body}[key]
+    context = CmpBaseRequestContext(operation='initialization', parsed_message=message)
+
+    validator.parse(context)
+
+    assert context.cmp_transaction_id == '6162'
+    assert context.implicit_confirm is False
+
+    entry = MagicMock()
+    info_type = Mock(prettyPrint=Mock(return_value=validator.implicit_confirm_oid))
+    info_value = Mock(prettyPrint=Mock(return_value=validator.implicit_confirm_str_value))
+    entry.__getitem__.side_effect = lambda key: {
+        'infoType': info_type,
+        'infoValue': info_value,
+    }[key]
+    header['generalInfo'] = [entry]
+    validator.parse(context)
+    assert context.implicit_confirm is True
+
+    info_value.prettyPrint.return_value = 'wrong'
+    with pytest.raises(ValueError, match='implicit confirm entry fail'):
+        validator.parse(context)
+
+    for body_name, operation in (('certConf', 'certification'), ('pollReq', 'initialization'), ('ir', 'other')):
+        skipped = CmpBaseRequestContext(operation=operation, implicit_confirm=True)
+        skipped_message = MagicMock()
+        skipped_message.__getitem__.side_effect = lambda key, body_name=body_name: (
+            {'body': Mock(getName=Mock(return_value=body_name)), 'header': header}[key]
+        )
+        validator._check_implicit_confirm(skipped, skipped_message)
+        assert skipped.implicit_confirm is True
+
+
+def test_cmp_pki_message_parsing_extracts_extra_certs_and_wraps_failures() -> None:
+    _, certificate, _ = certificate_and_csr()
+    parser = CmpPkiMessageParsing()
+    context = CmpBaseRequestContext(parsed_message={'extraCerts': [Mock(), Mock()]})
+    with patch('request.message_parser.cmp.der_encoder.encode', side_effect=[b'signer', b'intermediate']), \
+         patch('request.message_parser.cmp.x509.load_der_x509_certificate', side_effect=[certificate, certificate]):
+        parser._extract_signer_certificate(context)
+    assert context.client_certificate is certificate
+    assert context.client_intermediate_certificate == [certificate]
+
+    with patch('request.message_parser.cmp.der_encoder.encode', side_effect=ValueError('bad cert')):
+        with pytest.raises(ValueError, match='Failed to extract CMP signer certificate'):
+            parser._extract_signer_certificate(CmpBaseRequestContext(parsed_message={'extraCerts': [Mock()]}))
+
+
+def test_cmp_pki_message_parsing_rejects_wrong_and_malformed_raw_message() -> None:
+    parser = CmpPkiMessageParsing()
+    with pytest.raises(TypeError, match='requires a CmpBaseRequestContext'):
+        parser.parse(BaseRequestContext())
+    with pytest.raises(ValueError, match='Raw message is missing'):
+        parser.parse(CmpBaseRequestContext())
+    with pytest.raises(ValueError, match='Raw message is missing body'):
+        parser.parse(CmpBaseRequestContext(raw_message=Mock(body=b'')))
+    with patch('request.message_parser.cmp.ber_decoder.decode', side_effect=ValueError('broken')):
+        with pytest.raises(ValueError, match='seems to be corrupted'):
+            parser.parse(CmpBaseRequestContext(raw_message=Mock(body=b'broken')))
+
+
+def test_cmp_certificate_body_validation_rejects_wrong_cardinality_and_request_id() -> None:
+    validator = CmpCertificateBodyValidation()
+    with pytest.raises(ValueError, match='No CertReqMessages'):
+        validator._validate_cert_req_messages([])
+    with pytest.raises(ValueError, match='Multiple CertReqMessages'):
+        validator._validate_cert_req_messages([Mock(), Mock()])
+    request = MagicMock()
+    request.__getitem__.side_effect = lambda key: 1 if key == 'certReqId' else Mock(hasValue=Mock(return_value=False))
+    with pytest.raises(ValueError, match='certReqId must be 0'):
+        validator._validate_cert_request(request)
+    request.__getitem__.side_effect = lambda key: 0 if key == 'certReqId' else Mock(hasValue=Mock(return_value=False))
+    with pytest.raises(ValueError, match='certTemplate must be contained'):
+        validator._validate_cert_request(request)
+    template = MagicMock(hasValue=Mock(return_value=True))
+    version = Mock(hasValue=Mock(return_value=True))
+    version.__ne__ = Mock(return_value=True)
+    template.__getitem__.return_value = version
+    request.__getitem__.side_effect = lambda key: 0 if key == 'certReqId' else template
+    with pytest.raises(ValueError, match='Version must be 2'):
+        validator._validate_cert_request(request)
+
+
+def test_cmp_certificate_body_parses_supported_extensions() -> None:
+    validator = CmpCertificateBodyValidation()
+    basic = rfc2459.BasicConstraints()
+    basic['cA'] = True
+    basic['pathLenConstraint'] = 1
+    result = validator._parse_basic_constraints(der_encode(basic), critical=True)
+    assert result.critical is True and result.value.ca is True and result.value.path_length == 1
+
+    key_usage = rfc2459.KeyUsage('100000000')
+    result = validator._parse_key_usage(der_encode(key_usage), critical=False)
+    assert result.value.digital_signature is True
+
+    eku = rfc2459.ExtKeyUsageSyntax()
+    eku.append(univ.ObjectIdentifier('1.3.6.1.5.5.7.3.1'))
+    result = validator._parse_extended_key_usage(der_encode(eku), critical=False)
+    assert result.value[0].dotted_string == '1.3.6.1.5.5.7.3.1'
+
+    ski = rfc2459.SubjectKeyIdentifier(b'0123456789abcdef')
+    result = validator._parse_subject_key_identifier(der_encode(ski), critical=False)
+    assert result.value.digest == b'0123456789abcdef'
+
+
+def test_cmp_certificate_body_parses_general_names_and_rejects_unknown_extension() -> None:
+    validator = CmpCertificateBodyValidation()
+    san = rfc2459.SubjectAltName()
+    name = rfc2459.GeneralName()
+    name['dNSName'] = 'device.example.test'
+    san.append(name)
+    name = rfc2459.GeneralName()
+    name['iPAddress'] = b'\xc0\x00\x02\x01'
+    san.append(name)
+    parsed = validator._parse_subject_alternative_name(der_encode(san), critical=False)
+    assert parsed.value.get_values_for_type(__import__('cryptography').x509.DNSName) == ['device.example.test']
+    assert str(parsed.value.get_values_for_type(__import__('cryptography').x509.IPAddress)[0]) == '192.0.2.1'
+
+    extension = rfc2459.Extension()
+    extension['extnID'] = '1.2.3.4'
+    extension['extnValue'] = univ.OctetString(b'unsupported')
+    extensions = rfc2459.Extensions()
+    extensions.append(extension)
+    with pytest.raises(NotImplementedError, match='not supported'):
+        validator._parse_cert_template_extensions(extensions)
+
+
+def test_cmp_body_validation_maps_and_rejects_operation_combinations() -> None:
+    validator = CmpBodyValidation()
+    assert validator._operation_from_body_type('ir') == 'initialization'
+    assert validator._operation_from_body_type('cr') == 'certification'
+    assert validator._operation_from_body_type('rr') == 'revocation'
+    assert validator._operation_from_body_type('certConf') == 'certconf'
+    for body_type in ('unknown', 'pollReq'):
+        with pytest.raises(ValueError):
+            validator._operation_from_body_type(body_type)
+    validator._validate_operation_body_match('initialization', 'certConf')
+    validator._validate_operation_body_match('certification', 'certConf')
+    with pytest.raises(ValueError, match='Expected CMP rr body'):
+        validator._validate_operation_body_match('revocation', 'cr')
+    with pytest.raises(ValueError, match='Unsupported CMP operation'):
+        validator._validate_operation_body_match('other', 'cr')
+    validator._validate_pollreq_operation(None)
+    validator._validate_pollreq_operation('initialization')
+    with pytest.raises(ValueError, match='initialization or certification'):
+        validator._validate_pollreq_operation('revocation')
+
+
+def test_cmp_body_validators_cover_empty_and_invalid_requests() -> None:
+    rr_validator = CmpRevocationBodyValidation()
+    body = MagicMock()
+    body.__getitem__.return_value = []
+    with pytest.raises(ValueError, match='No RevReqMessages'):
+        rr_validator.parse_rr_body(Mock(), body)
+
+    certconf_validator = CmpCertConfBodyValidation()
+    body = MagicMock()
+    body.__getitem__.return_value = []
+    with pytest.raises(ValueError, match='exactly one CertStatus'):
+        certconf_validator._extract_single_cert_status(body)
+    poll_validator = CmpPollReqBodyValidation()
+    body.__getitem__.return_value = [Mock()]
+    poll_entry = MagicMock()
+    poll_entry.__getitem__.return_value = 1
+    body.__getitem__.return_value = [poll_entry]
+    with pytest.raises(ValueError, match='certReqId MUST be 0'):
+        poll_validator.parse_pollreq_body(Mock(), body)
+
+    body.__getitem__.return_value = []
+    with pytest.raises(ValueError, match='exactly one CertReq reference'):
+        poll_validator.parse_pollreq_body(Mock(), body)
+    body.__getitem__.return_value = [Mock(), Mock()]
+    with pytest.raises(ValueError, match='exactly one CertReq reference'):
+        poll_validator.parse_pollreq_body(Mock(), body)
+
+
+def test_cmp_revocation_body_validation_rejects_missing_details_and_parses_reason() -> None:
+    validator = CmpRevocationBodyValidation()
+    request = MagicMock()
+    request.__getitem__.side_effect = lambda key: Mock(hasValue=Mock(return_value=False))
+    body = MagicMock()
+    body.__getitem__.return_value = [request]
+    with pytest.raises(ValueError, match='certDetails must be contained'):
+        validator.parse_rr_body(CmpRevocationRequestContext(), body)
+
+    details = MagicMock()
+    details.__getitem__.side_effect = lambda key: Mock(hasValue=Mock(return_value=False))
+    request.__getitem__.side_effect = lambda key: details if key == 'certDetails' else Mock(hasValue=Mock(return_value=False))
+    with pytest.raises(ValueError, match='serialNumber must be present'):
+        validator.parse_rr_body(CmpRevocationRequestContext(), body)
+
+    serial = Mock(hasValue=Mock(return_value=True))
+    serial.__int__ = Mock(return_value=15)
+    reason_extension = MagicMock()
+    reason_extension.__getitem__.side_effect = lambda key: {
+        'extnID': '2.5.29.21',
+        'extnValue': Mock(asOctets=Mock(return_value=b'reason')),
+    }[key]
+    crl_details = MagicMock(hasValue=Mock(return_value=True))
+    crl_details.__getitem__.return_value = reason_extension
+    details.__getitem__.side_effect = lambda key: serial if key == 'serialNumber' else Mock(hasValue=Mock(return_value=True))
+    request.__getitem__.side_effect = lambda key: (
+        details if key == 'certDetails' else crl_details
+    )
+    with patch('request.message_parser.cmp.der_decoder.decode', side_effect=ValueError('bad reason')):
+        with pytest.raises(ValueError, match='bad reason'):
+            validator.parse_rr_body(CmpRevocationRequestContext(), body)
+
+
+def test_cmp_certconf_validation_rejects_missing_fields_and_hash_algorithm() -> None:
+    validator = CmpCertConfBodyValidation()
+    status = MagicMock()
+    hash_alg = MagicMock()
+    status.__getitem__.side_effect = lambda key: {
+        'certHash': univ.OctetString(b'hash'),
+        'certReqId': univ.Integer(0),
+        'statusInfo': Mock(hasValue=Mock(return_value=False)),
+        'hashAlg': hash_alg,
+    }[key]
+    hash_alg.hasValue.return_value = True
+    hash_alg.__getitem__.return_value = Mock(prettyPrint=Mock(return_value='1.2.3.4'))
+    body = MagicMock()
+    body.__getitem__.return_value = [status]
+    with pytest.raises(ValueError, match='Unsupported certConf hashAlg OID'):
+        validator.parse_certconf_body(CmpCertConfRequestContext(), body)
+
+    hash_alg.__getitem__.return_value = Mock(
+        prettyPrint=Mock(return_value='1.3.14.3.2.26')
+    )
+    with pytest.raises(ValueError, match='not permitted'):
+        validator.parse_certconf_body(CmpCertConfRequestContext(), body)
+
+    missing_id = MagicMock()
+    missing_id.__getitem__.side_effect = lambda key: {
+        'certHash': univ.OctetString(b'hash'),
+        'certReqId': Mock(hasValue=Mock(return_value=False)),
+    }[key]
+    body.__getitem__.return_value = [missing_id]
+    with pytest.raises(ValueError, match='certReqId is REQUIRED'):
+        validator.parse_certconf_body(CmpCertConfRequestContext(), body)
+
+
+def test_cmp_body_validation_dispatches_real_typed_body_and_rejects_mismatch() -> None:
+    message = rfc4210.PKIMessage()
+    message['body']['certConf'][0]['certHash'] = b'hash'
+    message['body']['certConf'][0]['certReqId'] = 0
+    with patch.object(CmpCertConfBodyValidation, '_parse_cert_hash_algorithm_oid', return_value=None):
+        result = CmpBodyValidation().parse(
+            CmpBaseRequestContext(operation='certconf', parsed_message=message)
+        )
+    assert isinstance(result, CmpCertConfRequestContext)
+    assert result.cmp_body_type == 'certConf'
+    assert result.cert_hash == b'hash'
+    assert result.event == Events.cmp_certconf
+
+    wrong = rfc4210.PKIMessage()
+    wrong['body']['rr']
+    with pytest.raises(ValueError, match='Expected CMP certConf body'):
+        CmpBodyValidation().parse(
+            CmpBaseRequestContext(operation='certconf', parsed_message=wrong)
+        )
+
+
+def test_cmp_response_header_and_implicit_confirm_are_typed() -> None:
+    _, certificate, _ = certificate_and_csr()
+    incoming = rfc4210.PKIMessage()
+    incoming['header']['pvno'] = 2
+    incoming['header']['transactionID'] = b'ab'
+    incoming['header']['senderNonce'] = b'cd'
+    header = CmpMessageResponder._build_response_message_header(
+        incoming, rfc2459.KeyIdentifier(b'kid').subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2)
+        ), certificate,
+    )
+    assert int(header['pvno']) == 2
+    assert bytes(header['transactionID']) == b'ab'
+    assert bytes(header['recipNonce']) == b'cd'
+    message = rfc4210.PKIMessage()
+    message['header'] = header
+    message['body'] = rfc4210.PKIBody()
+    CmpMessageResponder._grant_implicit_confirm(message)
+    assert len(message['header']['generalInfo']) == 1
+    assert message['header']['generalInfo'][0]['infoType'].prettyPrint() == '1.3.6.1.5.5.7.4.13'
+
+
+def test_cmp_response_builders_assemble_real_certificate_messages() -> None:
+    key, certificate, _ = certificate_and_csr()
+    credential = Mock(pk=1)
+    credential.get_certificate.return_value = certificate
+    credential.get_certificate_chain.return_value = []
+    parsed_message = MagicMock()
+    parsed_message.__getitem__.side_effect = lambda name: {
+        'header': {'sender': rfc4210.PKIHeader()['sender'], 'transactionID': univ.OctetString(b'ab'),
+                   'senderNonce': univ.OctetString(b'cd'), 'protectionAlg': rfc4210.PKIHeader()['protectionAlg'],
+                   'generalInfo': rfc4210.PKIHeader()['generalInfo']},
+    }[name]
+    header = rfc4210.PKIHeader()
+    sender_kid = rfc2459.KeyIdentifier(b'kid')
+    with patch.object(CmpMessageResponder, '_build_response_message_header', return_value=header):
+        ip = CmpInitializationResponder._build_base_ip_message(
+            parsed_message, certificate, credential, sender_kid, context=None,
+        )
+        cp = CmpCertificationResponder._build_base_cp_message(
+            parsed_message, certificate, credential, sender_kid, context=None,
+        )
+        rp = CmpRevocationResponder._build_base_rp_message(parsed_message, credential, sender_kid)
+    assert ip['body'].getName() == 'ip' and len(ip['extraCerts']) == 1
+    assert cp['body'].getName() == 'cp' and len(cp['extraCerts']) == 1
+    assert rp['body'].getName() == 'rp' and len(rp['extraCerts']) == 1
+
+
+def _cmp_message() -> rfc4210.PKIMessage:
+    message = rfc4210.PKIMessage()
+    message['header']['pvno'] = 2
+    message['header']['sender']['dNSName'] = 'device.example.test'
+    message['header']['transactionID'] = b'transaction'
+    message['header']['senderNonce'] = b'nonce'
+    return message
+
+
+@pytest.mark.django_db
+def test_cmp_message_responder_dispatches_typed_responses_and_fallback() -> None:
+    _, certificate, _ = certificate_and_csr()
+    credential = Mock(pk=1)
+    credential.get_certificate.return_value = certificate
+    credential.get_certificate_chain.return_value = []
+    cases = [
+        (CmpCertificateRequestContext(operation='initialization', issued_certificate=certificate), 'ip'),
+        (CmpCertificateRequestContext(operation='certification', issued_certificate=certificate), 'cp'),
+        (CmpRevocationRequestContext(operation='revocation'), 'rp'),
+        (CmpCertConfRequestContext(), 'pkiconf'),
+    ]
+    for context, body_name in cases:
+        context.parsed_message = _cmp_message()
+        context.issuer_credential = credential
+        with patch.object(CmpMessageResponder, '_sign_pki_message', side_effect=lambda pki_message, context: pki_message):
+            CmpMessageResponder.build_response(context)
+        from pyasn1.codec.der.decoder import decode
+        response, _ = decode(context.http_response_content, asn1Spec=rfc4210.PKIMessage())
+        assert response['body'].getName() == body_name
+        assert context.http_response_status == 200
+        assert context.http_response_content_type == 'application/pkixcmp'
+
+    unsupported = CmpBaseRequestContext(operation='unknown', parsed_message=_cmp_message())
+    with patch.object(CmpErrorMessageResponder, '_build_response', side_effect=RuntimeError('encode')):
+        CmpMessageResponder.build_response(unsupported)
+    assert unsupported.http_response_status == 500
+    assert unsupported.http_response_content == 'No suitable responder found for this CMP message.'
+
+
+@pytest.mark.parametrize(
+    ('responder', 'context', 'message'),
+    [
+        (CmpInitializationResponder, BaseRequestContext(), 'CmpInitializationResponder requires'),
+        (CmpCertificationResponder, BaseRequestContext(), 'CmpCertificationResponder requires'),
+        (CmpRevocationResponder, BaseRequestContext(), 'CmpRevocationResponder requires'),
+        (CmpPkiConfResponder, BaseRequestContext(), 'CmpPkiConfResponder requires'),
+    ],
+)
+def test_cmp_responders_reject_wrong_context(responder: type[object], context: BaseRequestContext, message: str) -> None:
+    with pytest.raises(TypeError, match=message):
+        responder.build_response(context)  # type: ignore[attr-defined]
+
+
+def test_cmp_certificate_responders_validate_missing_fields() -> None:
+    context = CmpCertificateRequestContext()
+    with pytest.raises(ValueError, match='Issued certificate'):
+        CmpInitializationResponder.build_response(context)
+    context.issued_certificate = certificate_and_csr()[1]
+    with pytest.raises(ValueError, match='Issuer credential'):
+        CmpCertificationResponder.build_response(context)
+
+
+@pytest.mark.django_db
+def test_cmp_initialization_owner_and_implicit_confirm_onboard_device(
+    device_instance_onboarding: dict[str, object],
+) -> None:
+    device = device_instance_onboarding['device']
+    certificate = device_instance_onboarding['cert']
+    issuer = Mock(pk=1, get_certificate=Mock(return_value=certificate), get_certificate_chain=Mock(return_value=[]))
+    owner = Mock(pk=2, get_certificate=Mock(return_value=certificate), get_certificate_chain=Mock(return_value=[]))
+    context = CmpCertificateRequestContext(
+        parsed_message=_cmp_message(), issued_certificate=certificate, issuer_credential=issuer,
+        owner_credential=owner, implicit_confirm=True, device=device,
+    )
+    with patch.object(CmpMessageResponder, '_sign_pki_message', side_effect=lambda pki_message, context: pki_message):
+        CmpInitializationResponder.build_response(context)
+    from pyasn1.codec.der.decoder import decode
+    response, _ = decode(context.http_response_content, asn1Spec=rfc4210.PKIMessage())
+    assert response['body'].getName() == 'ip'
+    assert response['header']['generalInfo'][0]['infoType'].prettyPrint() == '1.3.6.1.5.5.7.4.13'
+    assert device.onboarding_config.onboarding_status == OnboardingStatus.ONBOARDED
+
+
+def test_cmp_revocation_requires_issuer_credential() -> None:
+    with pytest.raises(ValueError, match='Issuer credential'):
+        CmpRevocationResponder.build_response(CmpRevocationRequestContext(parsed_message=_cmp_message()))
+
+
+def test_cmp_pki_conf_credential_resolution_errors() -> None:
+    context = CmpCertConfRequestContext(parsed_message=_cmp_message())
+    with pytest.raises(ValueError, match='Cannot determine issuing CA credential'):
+        CmpPkiConfResponder.build_response(context)
+    context.domain = Mock(issuing_ca=Mock(get_credential=Mock(return_value=None)))
+    with pytest.raises(ValueError, match='has no credential'):
+        CmpPkiConfResponder.build_response(context)
+
+
+def test_cmp_pki_conf_acceptance_onboards_and_builds_null_body() -> None:
+    _, certificate, _ = certificate_and_csr()
+    device = Mock(onboarding_config=Mock())
+    credential = Mock(get_certificate=Mock(return_value=certificate))
+    context = CmpCertConfRequestContext(
+        parsed_message=_cmp_message(), issuer_credential=credential, device=device, cert_conf_status=0,
+    )
+    with patch.object(CmpMessageResponder, '_sign_pki_message', side_effect=lambda pki_message, context: pki_message):
+        CmpPkiConfResponder.build_response(context)
+    from pyasn1.codec.der.decoder import decode
+    response, _ = decode(context.http_response_content, asn1Spec=rfc4210.PKIMessage())
+    assert response['body'].getName() == 'pkiconf'
+    assert device.onboarding_config.onboarding_status == OnboardingStatus.ONBOARDED
+    device.onboarding_config.save.assert_called_once()
+
+
+def test_cmp_error_base_contains_rejection_and_fail_info() -> None:
+    context = CmpBaseRequestContext(
+        parsed_message=_cmp_message(), error_details='bad request', error_code=PKIFailureInfo.SYSTEM_FAILURE,
+    )
+    response = CmpErrorMessageResponder._build_base_err_message(
+        context.parsed_message,
+        None,
+        rfc2459.KeyIdentifier(b'').subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2)
+        ),
+        context,
+    )
+    status = response['body']['error']['pKIStatusInfo']
+    assert response['body'].getName() == 'error'
+    assert int(status['status']) == 2
+    assert str(status['statusString'][0]) == 'bad request'
+    assert status['failInfo'].isValue
+
+
+@pytest.mark.parametrize('operation', ['initialization', 'certification'])
+def test_cmp_transaction_result_message_selects_operation_builder(operation: str) -> None:
+    context = CmpCertificateRequestContext(operation=operation, parsed_message=_cmp_message())
+    issuer = Mock()
+    with patch.object(CmpTransactionResponder, '_resolve_issuer_credential', return_value=issuer), \
+            patch.object(CmpTransactionResponder, '_build_sender_kid', return_value=Mock()), \
+            patch.object(CmpInitializationResponder, '_build_base_ip_message', return_value='ip') as ip_builder, \
+            patch.object(CmpCertificationResponder, '_build_base_cp_message', return_value='cp') as cp_builder:
+        result = CmpTransactionResponder._build_transaction_result_message(
+            context=context, issued_cert=None, status=2, status_text='failed',
+        )
+    assert result == ('ip' if operation == 'initialization' else 'cp')
+    (ip_builder if operation == 'initialization' else cp_builder).assert_called_once()
+
+
+def test_cmp_transaction_protection_selects_shared_secret_or_signature() -> None:
+    message = rfc4210.PKIMessage()
+    shared = CmpCertificateRequestContext(cmp_shared_secret='secret')
+    signed = CmpCertificateRequestContext()
+    with patch.object(CmpTransactionResponder, '_add_protection_shared_secret', return_value='mac') as mac, \
+            patch.object(CmpTransactionResponder, '_sign_pki_message', return_value='signature') as signature:
+        assert CmpTransactionResponder._protect_pki_message(message, context=shared) == 'mac'
+        assert CmpTransactionResponder._protect_pki_message(message, context=signed) == 'signature'
+    mac.assert_called_once()
+    signature.assert_called_once()

--- a/trustpoint/request/tests/test_sign_operation_processor.py
+++ b/trustpoint/request/tests/test_sign_operation_processor.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 The Trustpoint Project Authors
+# SPDX-License-Identifier: MIT
+
 """Focused tests for CMP signing operation processing."""
 
 from unittest.mock import Mock, patch

--- a/trustpoint/request/tests/test_sign_operation_processor.py
+++ b/trustpoint/request/tests/test_sign_operation_processor.py
@@ -1,0 +1,94 @@
+"""Focused tests for CMP signing operation processing."""
+
+from unittest.mock import Mock, patch
+from typing import Any
+
+import pytest
+from cryptography.exceptions import InvalidSignature
+
+from request.operation_processor.sign import GenericSignatureVerifier, GenericSigner, LocalCaCmpSignatureProcessor
+from request.request_context import BaseRequestContext
+
+
+def test_cmp_signature_processor_requires_message_and_signature() -> None:
+    """Require message input before processing and signature output afterward."""
+    processor = LocalCaCmpSignatureProcessor()
+    with pytest.raises(ValueError, match='Data to be signed'):
+        processor.process_operation(BaseRequestContext())
+    with pytest.raises(ValueError, match='Signature not generated'):
+        processor.get_signature()
+
+
+def test_cmp_signature_processor_uses_owner_credential() -> None:
+    """Prefer the authenticated owner credential when signing CMP data."""
+    owner = Mock()
+    context = BaseRequestContext(owner_credential=owner, issuer_credential=Mock())
+    with patch('request.operation_processor.sign.GenericSigner.sign', return_value=b'signature') as sign:
+        processor = LocalCaCmpSignatureProcessor(b'cmp-header')
+        processor.process_operation(context)
+
+    sign.assert_called_once_with(b'cmp-header', owner)
+    assert processor.get_signature() == b'signature'
+
+
+def test_cmp_signature_processor_loads_issuer_credential_and_propagates_signing_error() -> None:
+    """Load a local issuer credential and preserve signing failures."""
+    context = BaseRequestContext(domain=Mock())
+    issuer = context.domain.get_issuing_ca_or_value_error.return_value.get_credential.return_value
+    with patch('request.operation_processor.sign.GenericSigner.sign', side_effect=RuntimeError('sign failed')):
+        with pytest.raises(RuntimeError, match='sign failed'):
+            LocalCaCmpSignatureProcessor(b'data').process_operation(context)
+
+    assert context.issuer_credential is issuer
+
+
+def test_cmp_signature_processor_rejects_missing_issuer_credential() -> None:
+    """Reject signing when the configured CA has no credential."""
+    context = BaseRequestContext(domain=Mock())
+    context.domain.get_issuing_ca_or_value_error.return_value.get_credential.return_value = None
+
+    with pytest.raises(ValueError, match='does not have a credential'):
+        LocalCaCmpSignatureProcessor(b'data').process_operation(context)
+
+
+def test_generic_signer_signs_and_verifies_rsa_data(credential_instance: dict[str, Any]) -> None:
+    """Exercise the RSA signing and verification path with a real credential."""
+    credential = credential_instance['credential']
+    data = b'cmp-data'
+
+    signature = GenericSigner.sign(data, credential)
+
+    GenericSignatureVerifier.verify(data, signature, credential.get_certificate())
+    with pytest.raises(InvalidSignature):
+        GenericSignatureVerifier.verify(b'changed-data', signature, credential.get_certificate())
+
+
+def test_generic_signer_rejects_non_mldsa_key_for_hashless_suite(credential_instance: dict[str, Any]) -> None:
+    credential = credential_instance['credential']
+    suite = Mock()
+    suite.algorithm_identifier.hash_algorithm = None
+
+    with patch('request.operation_processor.sign.SignatureSuite.from_certificate', return_value=suite), pytest.raises(
+        TypeError, match='hash algorithm is None'
+    ):
+        GenericSigner.sign(b'data', credential)
+
+
+def test_generic_signer_rejects_unsupported_private_key_type(credential_instance: dict[str, Any]) -> None:
+    credential = credential_instance['credential']
+
+    with patch.object(credential, 'get_private_key', return_value=object()), pytest.raises(
+        TypeError, match='unsupported private key type'
+    ):
+        GenericSigner.sign(b'data', credential)
+
+
+def test_generic_verifier_rejects_hashless_non_mldsa_certificate(credential_instance: dict[str, Any]) -> None:
+    credential = credential_instance['credential']
+    suite = Mock()
+    suite.algorithm_identifier.hash_algorithm = None
+
+    with patch('request.operation_processor.sign.SignatureSuite.from_certificate', return_value=suite), pytest.raises(
+        TypeError, match='hash algorithm is None'
+    ):
+        GenericSignatureVerifier.verify(b'data', b'signature', credential.get_certificate())

--- a/trustpoint/request/tests/test_workflows2_handler.py
+++ b/trustpoint/request/tests/test_workflows2_handler.py
@@ -12,7 +12,7 @@ from request.request_context import (
     EstCertificateRequestContext,
     RestCertificateRequestContext,
 )
-from request.workflows2_handler import Workflow2HandleResult, Workflow2Handler
+from request.workflows2_handler import Workflow2CertificateRequestHandler, Workflow2HandleResult, Workflow2Handler
 from workflows2.events.request_events import Events
 from workflows2.events.triggers import Triggers
 from workflows2.models import Workflow2Approval, Workflow2Definition, Workflow2Instance, Workflow2Run
@@ -57,6 +57,26 @@ def test_workflows2_handler_continues_without_event() -> None:
     result = Workflow2Handler().handle(context)
 
     assert result == Workflow2HandleResult.continue_processing()
+
+
+def test_workflows2_certificate_handler_rejects_non_certificate_context() -> None:
+    """Certificate dispatch must reject contexts without certificate semantics."""
+    with pytest.raises(TypeError, match='BaseCertificateRequestContext'):
+        Workflow2CertificateRequestHandler().handle(BaseRequestContext(event=Events.est_simpleenroll))
+
+
+def test_workflows2_device_updated_skips_context_without_event_payload() -> None:
+    """Device updates require the structured before/after payload."""
+    device = Mock(id='device-1')
+    context = BaseRequestContext(
+        event=Events.device_updated, device=device, protocol='device', operation='updated',
+    )
+
+    with patch('request.workflows2_handler.WorkflowDispatchService') as mock_service:
+        result = Workflow2Handler().handle(context)
+
+    assert result == Workflow2HandleResult.continue_processing()
+    mock_service.return_value.emit_event_outcome.assert_not_called()
 
 
 @pytest.mark.django_db
@@ -548,3 +568,24 @@ def test_workflows2_handler_emits_device_deleted_from_request_context() -> None:
     assert call['on'] == Triggers.DEVICE_DELETED
     assert call['event']['device']['domain_id'] == 9
     assert call['source'].ca_id == 11
+
+
+def test_workflows2_certificate_handler_continues_when_dispatch_has_no_outcome(test_csr_fixture) -> None:
+    context = EstCertificateRequestContext(
+        protocol='est', operation='simpleenroll', event=Events.est_simpleenroll,
+        device=Mock(id='device-1'), domain=Mock(id=1), cert_requested=test_csr_fixture.get_cryptography_object()
+    )
+    with patch('request.workflows2_handler.WorkflowDispatchService') as service:
+        service.return_value.emit_event_outcome.return_value = None
+        result = Workflow2CertificateRequestHandler().handle(context)
+
+    assert result == Workflow2HandleResult.continue_processing()
+    assert context.workflow2_outcome is None
+
+
+def test_workflows2_device_handler_continues_for_unknown_event() -> None:
+    context = BaseRequestContext(
+        event=Mock(handler='unknown'), protocol='device', operation='unknown', device=Mock(id='device-1')
+    )
+    result = Workflow2Handler().handle(context)
+    assert result == Workflow2HandleResult.continue_processing()


### PR DESCRIPTION
- Add EST and CMP client, parser, responder, authentication, authorization, and request-context tests using synthetic certificates and typed ASN.1 messages.
- Expand coverage for certificate issuance, revocation, workflow handling, transaction polling, GDS Push, profile validation, error propagation, and security-sensitive failure paths.
- Increase request-package coverage from 60% to 87%, adding 300+ tests while keeping production code and coverage configuration unchanged.

**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.