### PR TITLE
Add application-wide permissions and enforce access control across views

### DIFF
--- a/trustpoint/agents/tests/test_views.py
+++ b/trustpoint/agents/tests/test_views.py
@@ -26,7 +26,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, Permission
 from django.test import RequestFactory
 from django.urls import reverse
 from django.utils import timezone
@@ -69,6 +69,8 @@ def admin_user(db: Any) -> AbstractBaseUser:
     )
     admin_group, _ = Group.objects.get_or_create(name='Admin')
     user.groups.add(admin_group)
+    manage_devices_perm = Permission.objects.get(codename='manage_devices')
+    user.role.permissions.add(manage_devices_perm)
     return user
 
 

--- a/trustpoint/agents/web_views.py
+++ b/trustpoint/agents/web_views.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from django import forms
 from django.contrib import messages
+from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse_lazy
@@ -22,6 +23,7 @@ from agents.security import AgentSecurityMixin
 from trustpoint.logger import LoggerMixin
 from trustpoint.page_context import DEVICES_PAGE_AGENTS_SUBCATEGORY, DEVICES_PAGE_CATEGORY, PageContextMixin
 from trustpoint.views.base import BulkDeleteView
+from users.permissions import AppPermissions
 
 if TYPE_CHECKING:
     from django.db.models import QuerySet
@@ -178,6 +180,8 @@ class AgentProfileDefinitionConfigView(
 
     def form_valid(self, form: Any) -> Any:
         """Process form submission and parse profile JSON."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DEVICES):
+            raise PermissionDenied
         # Convert profile JSON string to dict
         profile_data = form.cleaned_data.get('profile')
         parsed_profile = None
@@ -228,6 +232,8 @@ class AgentProfileDefinitionBulkDeleteConfirmView(AgentSecurityMixin, PageContex
 
     def form_valid(self, form: Any) -> HttpResponse:
         """Delete the selected profiles on valid form."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DEVICES):
+            raise PermissionDenied
         queryset = self.get_queryset()
         deleted_count = queryset.count() if queryset else 0
 
@@ -355,6 +361,8 @@ class AgentAssignedProfileCreateView(
 
     def form_valid(self, form: AgentAssignedProfileForm) -> HttpResponse:
         """Save the assignment and show a success message."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DEVICES):
+            raise PermissionDenied
         from django.utils import timezone  # noqa: PLC0415
 
         agent = self._get_agent()
@@ -401,6 +409,8 @@ class AgentAssignedProfileEditView(
 
     def form_valid(self, form: AgentAssignedProfileEditForm) -> HttpResponse:
         """Save the changes and show a success message."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DEVICES):
+            raise PermissionDenied
         assignment: AgentAssignedProfile = form.save()
         messages.success(
             self.request,
@@ -447,6 +457,8 @@ class AgentAssignedProfileDeleteView(AgentSecurityMixin, PageContextMixin, BulkD
 
     def form_valid(self, form: Any) -> HttpResponse:
         """Delete selected assignments and redirect."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DEVICES):
+            raise PermissionDenied
         queryset = self.get_queryset()
         deleted_count = queryset.count() if queryset else 0
         response = super().form_valid(form)
@@ -463,6 +475,8 @@ class AgentAssignedProfileForceUpdateView(AgentSecurityMixin, PageContextMixin, 
 
     def post(self, request: HttpRequest, agent_id: int, pk: int) -> HttpResponse:
         """Set next_certificate_update_scheduled to now and redirect back to list."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DEVICES):
+            raise PermissionDenied
         from django.utils import timezone  # noqa: PLC0415
 
         assignment = get_object_or_404(

--- a/trustpoint/devices/tests/test_api/test_device_viewset.py
+++ b/trustpoint/devices/tests/test_api/test_device_viewset.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -40,7 +41,10 @@ def api_client() -> APIClient:
 def user() -> AbstractBaseUser:
     """Create a test user."""
     user_model = get_user_model()
-    return user_model.objects.create_user(username='device_api_testuser', password='testpass123')  # noqa: S106
+    test_user = user_model.objects.create_user(username='device_api_testuser', password='testpass123')  # noqa: S106
+    manage_devices_perm = Permission.objects.get(codename='manage_devices')
+    test_user.role.permissions.add(manage_devices_perm)
+    return test_user
 
 
 @pytest.fixture

--- a/trustpoint/devices/tests/test_views/test_device_views.py
+++ b/trustpoint/devices/tests/test_views/test_device_views.py
@@ -7,12 +7,24 @@ from typing import Any
 from unittest.mock import patch, Mock
 
 import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.test import Client
 from django.urls import reverse
 
 from devices.models import DeviceModel
 from onboarding.models import OnboardingProtocol
 from pki.models import CertificateModel
+
+
+@pytest.fixture(autouse=True)
+def grant_manage_devices_to_admin_client(admin_client: Client) -> None:
+    """Grant the shared web-test user access to protected device operations."""
+    user_id = admin_client.session['_auth_user_id']
+    user = get_user_model().objects.get(pk=user_id)
+    manage_devices_perm = Permission.objects.get(codename='manage_devices')
+    revoke_certificates_perm = Permission.objects.get(codename='revoke_certificates')
+    user.role.permissions.add(manage_devices_perm, revoke_certificates_perm)
 
 
 @pytest.mark.django_db

--- a/trustpoint/devices/tests/test_views/test_device_views_clm.py
+++ b/trustpoint/devices/tests/test_views/test_device_views_clm.py
@@ -6,11 +6,22 @@
 from typing import Any
 
 import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.test import Client
 from django.urls import reverse
 
 from devices.models import DeviceModel
 from onboarding.models import NoOnboardingConfigModel, NoOnboardingPkiProtocol
+
+
+@pytest.fixture(autouse=True)
+def grant_manage_devices_to_admin_client(admin_client: Client) -> None:
+    """Grant the shared web-test user access to protected device operations."""
+    user_id = admin_client.session['_auth_user_id']
+    user = get_user_model().objects.get(pk=user_id)
+    manage_devices_perm = Permission.objects.get(codename='manage_devices')
+    user.role.permissions.add(manage_devices_perm)
 
 
 @pytest.mark.django_db

--- a/trustpoint/devices/views/agents.py
+++ b/trustpoint/devices/views/agents.py
@@ -7,6 +7,7 @@ import uuid
 from datetime import timedelta
 from typing import Any
 
+from django.core.exceptions import PermissionDenied
 from django.db.models import QuerySet
 from django.http import HttpResponse
 from django.urls import reverse_lazy
@@ -30,6 +31,7 @@ from trustpoint.page_context import (
     DEVICES_PAGE_CATEGORY,
     PageContextMixin,
 )
+from users.permissions import AppPermissions
 
 
 class AgentTableView(AbstractDeviceTableView):
@@ -100,6 +102,8 @@ class AgentCreateOneToOneOnboardingView(PageContextMixin, FormView[AgentOnboardi
 
     def form_valid(self, form: AgentOnboardingCreateForm) -> HttpResponse:
         """Save the form as an AGENT_ONE_TO_ONE device."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DEVICES):
+            raise PermissionDenied
         self.object = form.save(device_type=DeviceModel.DeviceType.AGENT_ONE_TO_ONE)
         agent_uuid = uuid.uuid4().hex.upper()
         agent_os_path = form.cleaned_data.get('agent_os_path', '/etc/trustpoint')

--- a/trustpoint/devices/views/clm.py
+++ b/trustpoint/devices/views/clm.py
@@ -8,6 +8,7 @@ import datetime
 from typing import Any, cast
 
 from django import forms
+from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator
 from django.db.models import Q, QuerySet
 from django.http import HttpResponse, HttpResponseBase
@@ -47,6 +48,7 @@ from trustpoint.page_context import (
     PageContextMixin,
 )
 from trustpoint.settings import UIConfig
+from users.permissions import AppPermissions
 
 DeviceWithoutDomainErrorMsg = gettext_lazy('Device does not have an associated domain.')
 NamedCurveMissingForEccErrorMsg = gettext_lazy('Failed to retrieve named curve for ECC algorithm.')
@@ -498,6 +500,8 @@ class AbstractCertificateLifecycleManagementSummaryView(PageContextMixin, Detail
         Returns:
             The HttpResponse.
         """
+        if not request.user.has_perm(AppPermissions.MANAGE_DEVICES):
+            raise PermissionDenied
         self.object = self.get_object()
 
         _agent_device_types = (

--- a/trustpoint/devices/views/delete.py
+++ b/trustpoint/devices/views/delete.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 from django.contrib import messages
+from django.core.exceptions import PermissionDenied
 from django.db.models import QuerySet
 from django.http import HttpResponse
 from django.http.request import HttpRequest
@@ -31,6 +32,7 @@ from trustpoint.page_context import (
     DEVICES_PAGE_OPC_UA_SUBCATEGORY,
     PageContextMixin,
 )
+from users.permissions import AppPermissions
 from util.mult_obj_views import get_primary_keys_from_str_as_list_of_ints
 
 DeviceWithoutDomainErrorMsg = gettext_lazy('Device does not have an associated domain.')
@@ -150,6 +152,8 @@ class AbstractBulkDeleteView(LoggerMixin, PageContextMixin, ListView[DeviceModel
         Returns:
             Redirect to the devices summary.
         """
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DEVICES):
+            raise PermissionDenied
         delete_form = self.form_class(self.request.POST)
         if delete_form.is_valid():
             self.pks = delete_form.cleaned_data['pks']

--- a/trustpoint/devices/views/device_api.py
+++ b/trustpoint/devices/views/device_api.py
@@ -5,6 +5,7 @@
 
 from typing import Any, ClassVar
 
+from django.core.exceptions import PermissionDenied
 from django.utils.translation import gettext_lazy
 from drf_spectacular.utils import OpenApiExample, extend_schema
 from rest_framework import viewsets
@@ -16,6 +17,7 @@ from devices.models import (
     DeviceModel,
 )
 from devices.serializers import DeviceSerializer
+from users.permissions import AppPermissions
 
 DeviceWithoutDomainErrorMsg = gettext_lazy('Device does not have an associated domain.')
 NamedCurveMissingForEccErrorMsg = gettext_lazy('Failed to retrieve named curve for ECC algorithm.')
@@ -180,7 +182,27 @@ class DeviceViewSet(viewsets.ModelViewSet[DeviceModel]):
     )
     def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Create a new device, optionally with onboarding configuration."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DEVICES):
+            raise PermissionDenied
         return super().create(request, *args, **kwargs)
+
+    def update(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Update an existing device, optionally with onboarding configuration."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DEVICES):
+            raise PermissionDenied
+        return super().update(request, *args, **kwargs)
+
+    def partial_update(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Partially update an existing device, optionally with onboarding configuration."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DEVICES):
+            raise PermissionDenied
+        return super().partial_update(request, *args, **kwargs)
+
+    def destroy(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Delete an existing device."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DEVICES):
+            raise PermissionDenied
+        return super().destroy(request, *args, **kwargs)
 
     def get_view_description(self, html: bool = False) -> str:  # noqa: FBT001, FBT002
         """Return a description for the given action."""

--- a/trustpoint/devices/views/device_create.py
+++ b/trustpoint/devices/views/device_create.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 from django import forms
+from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy
@@ -29,6 +30,7 @@ from trustpoint.page_context import (
     DEVICES_PAGE_OPC_UA_SUBCATEGORY,
     PageContextMixin,
 )
+from users.permissions import AppPermissions
 
 DeviceWithoutDomainErrorMsg = gettext_lazy('Device does not have an associated domain.')
 NamedCurveMissingForEccErrorMsg = gettext_lazy('Failed to retrieve named curve for ECC algorithm.')
@@ -179,6 +181,8 @@ class AbstractCreateNoOnboardingView(PageContextMixin, FormView[NoOnboardingCrea
         Returns:
             The HTTP Response to be returned.
         """
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DEVICES):
+            raise PermissionDenied
         if self.page_name == DEVICES_PAGE_DEVICES_SUBCATEGORY:
             self.object = form.save(device_type=DeviceModel.DeviceType.GENERIC_DEVICE)
         else:
@@ -252,6 +256,8 @@ class AbstractCreateOnboardingView(PageContextMixin, FormView[forms.Form]):
         Returns:
             The HTTP Response to be returned.
         """
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DEVICES):
+            raise PermissionDenied
         if self.page_name == DEVICES_PAGE_DEVICES_SUBCATEGORY:
             self.object = form.save(device_type=DeviceModel.DeviceType.GENERIC_DEVICE)  # type: ignore[attr-defined]
         elif self.page_name == DEVICES_PAGE_OPC_UA_SUBCATEGORY:

--- a/trustpoint/devices/views/download.py
+++ b/trustpoint/devices/views/download.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_not_required
+from django.core.exceptions import PermissionDenied
 from django.http import FileResponse, Http404, HttpResponse, HttpResponseBase
 from django.http.request import HttpRequest
 from django.shortcuts import redirect
@@ -33,6 +34,7 @@ from trustpoint.page_context import (
     DEVICES_PAGE_OPC_UA_SUBCATEGORY,
     PageContextMixin,
 )
+from users.permissions import AppPermissions
 
 DeviceWithoutDomainErrorMsg = gettext_lazy('Device does not have an associated domain.')
 NamedCurveMissingForEccErrorMsg = gettext_lazy('Failed to retrieve named curve for ECC algorithm.')
@@ -227,6 +229,13 @@ class DeviceManualCredentialDownloadView(AbstractDeviceBaseCredentialDownloadVie
     """View to download a password protected domain or application credential in the desired format."""
 
     page_name = DEVICES_PAGE_DEVICES_SUBCATEGORY
+
+    def post(self, _request: HttpRequest, *_args: Any, **_kwargs: Any) -> HttpResponse:
+        """Handle POST requests for manual credential download."""
+        if not _request.user.has_perm(AppPermissions.DOWNLOAD_CREDENTIALS):
+            raise PermissionDenied
+
+        return super().post(_request, *_args, **_kwargs)
 
 
 @method_decorator(login_not_required, name='dispatch')

--- a/trustpoint/devices/views/revoke.py
+++ b/trustpoint/devices/views/revoke.py
@@ -7,6 +7,7 @@ import datetime
 from typing import Any
 
 from django.contrib import messages
+from django.core.exceptions import PermissionDenied
 from django.db.models import QuerySet
 from django.http import Http404, HttpResponse
 from django.http.request import HttpRequest
@@ -37,6 +38,7 @@ from trustpoint.page_context import (
     DEVICES_PAGE_OPC_UA_SUBCATEGORY,
     PageContextMixin,
 )
+from users.permissions import AppPermissions
 from util.mult_obj_views import get_primary_keys_from_str_as_list_of_ints
 
 DeviceWithoutDomainErrorMsg = gettext_lazy('Device does not have an associated domain.')
@@ -99,6 +101,8 @@ class AbstractIssuedCredentialRevocationView(PageContextMixin, DetailView[Issued
         Returns:
             Redirect to the devices summary.
         """
+        if not self.request.user.has_perm(AppPermissions.REVOKE_CERTIFICATES):
+            raise PermissionDenied
         self.object = self.get_object()
 
         device = self.object.device
@@ -267,6 +271,8 @@ class AbstractBulkRevokeView(LoggerMixin, PageContextMixin, ListView[DeviceModel
         Returns:
             Redirect to the devices summary.
         """
+        if not self.request.user.has_perm(AppPermissions.REVOKE_CERTIFICATES):
+            raise PermissionDenied
         revoke_form = self.form_class(self.request.POST)
         if revoke_form.is_valid():
             self.pks = revoke_form.cleaned_data['pks']

--- a/trustpoint/discovery/tests/test_discovery_views.py
+++ b/trustpoint/discovery/tests/test_discovery_views.py
@@ -12,11 +12,14 @@ from unittest.mock import Mock, patch, sentinel
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.urls import reverse
 
 from discovery.models import DiscoveredDevice, DiscoveryPort
 from discovery.scanner import OTScanner
 from discovery.views import ScanManager
+
+pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture(autouse=True)
@@ -40,6 +43,8 @@ def authenticated_client(client):
     """Provide an authenticated client for views protected by login."""
     user_model = get_user_model()
     user = user_model.objects.create_user(username='discovery-tester', password='testpass123')
+    manage_discovery_perm = Permission.objects.get(codename='manage_certificate_discovery')
+    user.role.permissions.add(manage_discovery_perm)
     client.force_login(user)
     return client
 

--- a/trustpoint/discovery/views.py
+++ b/trustpoint/discovery/views.py
@@ -8,6 +8,7 @@ import threading
 from typing import Any
 
 from django.contrib import messages
+from django.core.exceptions import PermissionDenied
 from django.db.models import Q
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -15,6 +16,7 @@ from django.views import View
 
 from pki.models.certificate import CertificateModel
 from trustpoint.views.base import ContextDataMixin
+from users.permissions import AppPermissions
 
 from .models import DiscoveredDevice, DiscoveryPort
 from .scanner import OTScanner
@@ -207,6 +209,8 @@ class StartScanView(View):
 
     def post(self, request: HttpRequest) -> HttpResponse:
         """Start scanning in a background thread when no scan is running."""
+        if not request.user.has_perm(AppPermissions.MANAGE_CERTIFICATE_DISCOVERY):
+            raise PermissionDenied
         start_ip = request.POST.get('start_ip', '10.100.13.1')
         end_ip = request.POST.get('end_ip', '10.100.13.254')
 
@@ -228,6 +232,8 @@ class StopScanView(View):
 
     def post(self, request: HttpRequest) -> HttpResponse:
         """Signal the active scanner to stop."""
+        if not request.user.has_perm(AppPermissions.MANAGE_CERTIFICATE_DISCOVERY):
+            raise PermissionDenied
         ScanManager.request_stop()
         messages.info(request, 'Stopping the scan...')
         return redirect('discovery:device_list')
@@ -240,6 +246,8 @@ class AddPortView(View):
 
     def post(self, request: HttpRequest) -> HttpResponse:
         """Validate and persist an additional scan port."""
+        if not request.user.has_perm(AppPermissions.MANAGE_CERTIFICATE_DISCOVERY):
+            raise PermissionDenied
         port_str = request.POST.get('port_number')
         desc = request.POST.get('description')
 
@@ -294,6 +302,8 @@ class ClearDevicesView(View):
 
     def post(self, request: HttpRequest) -> HttpResponse:
         """Delete all discovered devices from inventory."""
+        if not request.user.has_perm(AppPermissions.MANAGE_CERTIFICATE_DISCOVERY):
+            raise PermissionDenied
         DiscoveredDevice.objects.all().delete()
         messages.success(request, 'Discovery inventory cleared.')
         return redirect('discovery:device_list')

--- a/trustpoint/features/steps/common_steps.py
+++ b/trustpoint/features/steps/common_steps.py
@@ -6,7 +6,7 @@
 import logging
 
 from behave import given, runner, step, then, when
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Permission, User
 from django.test import Client
 from management.models.security import SecurityConfig
 from pki.models.domain import DomainModel
@@ -68,7 +68,12 @@ def step_admin_logged_in(context: runner.Context) -> None:
         context: the behave context
     """
     try:
-        TrustpointUser.objects.create_superuser(username='admin', password='testing321')  # noqa: S106
+        admin_user = TrustpointUser.objects.create_superuser(username='admin', password='testing321')  # noqa: S106
+        admin_permissions = Permission.objects.filter(
+            content_type__app_label='users',
+            content_type__model='apppermission',
+        )
+        admin_user.role.permissions.set(admin_permissions)
         client = Client()
         login_success = client.login(username='admin', password='testing321')  # noqa: S106
         if not login_success:

--- a/trustpoint/help_pages/devices_help_views.py
+++ b/trustpoint/help_pages/devices_help_views.py
@@ -59,6 +59,8 @@ from trustpoint.page_context import (
     DEVICES_PAGE_ZERO_TOUCH_SUBCATEGORY,
     PageContextMixin,
 )
+from trustpoint.views.base import UserPermissionRequiredMixin
+from users.permissions import AppPermissions
 
 if TYPE_CHECKING:
     from typing import Any
@@ -69,13 +71,14 @@ if TYPE_CHECKING:
 # --------------------------------------------------- Base Classes ----------------------------------------------------
 
 
-class BaseHelpView(PageContextMixin, DetailView[DeviceModel]):
+class BaseHelpView(UserPermissionRequiredMixin, PageContextMixin, DetailView[DeviceModel]):
     """Base help view that constructs the context."""
 
     template_name = 'help/help_page.html'
     http_method_names = ('get',)
     model = DeviceModel
     context_object_name = 'device'
+    permission_required = AppPermissions.VIEW_HELP_PAGES
 
     page_category = DEVICES_PAGE_CATEGORY
     page_name: str

--- a/trustpoint/help_pages/pki_help_views.py
+++ b/trustpoint/help_pages/pki_help_views.py
@@ -28,16 +28,18 @@ from help_pages.commands import CmpClientCertificateCommandBuilder, EstClientCer
 from help_pages.help_section import HelpPage, HelpRow, HelpSection, ValueRenderType
 from management.models import TlsSettings
 from pki.models import CaModel, DevIdRegistration, DomainModel, IssuedCredentialModel, OwnerCredentialModel
+from trustpoint.views.base import UserPermissionRequiredMixin
 
 PKI_PAGE_DOMAIN_SUBCATEGORY = 'pki:domain'
 PKI_PAGE_TRUSTSTORES_SUBCATEGORY = 'pki:truststores'
 
 
-class BaseHelpView(DetailView[DevIdRegistration]):
+class BaseHelpView(UserPermissionRequiredMixin, DetailView[DevIdRegistration]):
     """Base help view for PKI help pages."""
 
     template_name = 'help/help_page.html'
     model = DevIdRegistration
+    permission_required = 'users.view_help_pages'
     context_object_name = 'devid_registration'
 
     page_category = 'pki'
@@ -229,12 +231,13 @@ class OnboardingEstIdevidRegistrationHelpView(BaseHelpView):
     strategy = OnboardingEstIdevIdDomainCredentialStrategy()
 
 
-class DevIdRegistrationDetailView(DetailView[DevIdRegistration]):
+class DevIdRegistrationDetailView(UserPermissionRequiredMixin, DetailView[DevIdRegistration]):
     """View to display details of a DevIdRegistration."""
 
     model = DevIdRegistration
     template_name = 'help/devid_registration_detail.html'
     context_object_name = 'devid_registration'
+    permission_required = 'users.view_help_pages'
 
     page_name = PKI_PAGE_DOMAIN_SUBCATEGORY
     strategy: HelpPageStrategy

--- a/trustpoint/help_pages/pki_help_views.py
+++ b/trustpoint/help_pages/pki_help_views.py
@@ -29,6 +29,7 @@ from help_pages.help_section import HelpPage, HelpRow, HelpSection, ValueRenderT
 from management.models import TlsSettings
 from pki.models import CaModel, DevIdRegistration, DomainModel, IssuedCredentialModel, OwnerCredentialModel
 from trustpoint.views.base import UserPermissionRequiredMixin
+from users.permissions import AppPermissions
 
 PKI_PAGE_DOMAIN_SUBCATEGORY = 'pki:domain'
 PKI_PAGE_TRUSTSTORES_SUBCATEGORY = 'pki:truststores'
@@ -39,7 +40,7 @@ class BaseHelpView(UserPermissionRequiredMixin, DetailView[DevIdRegistration]):
 
     template_name = 'help/help_page.html'
     model = DevIdRegistration
-    permission_required = 'users.view_help_pages'
+    permission_required = AppPermissions.VIEW_HELP_PAGES
     context_object_name = 'devid_registration'
 
     page_category = 'pki'
@@ -237,7 +238,7 @@ class DevIdRegistrationDetailView(UserPermissionRequiredMixin, DetailView[DevIdR
     model = DevIdRegistration
     template_name = 'help/devid_registration_detail.html'
     context_object_name = 'devid_registration'
-    permission_required = 'users.view_help_pages'
+    permission_required = AppPermissions.VIEW_HELP_PAGES
 
     page_name = PKI_PAGE_DOMAIN_SUBCATEGORY
     strategy: HelpPageStrategy

--- a/trustpoint/management/management/commands/apply_bootstrap_config.py
+++ b/trustpoint/management/management/commands/apply_bootstrap_config.py
@@ -46,7 +46,7 @@ from setup_wizard.models import SetupWizardConfigModel
 from setup_wizard.pkcs11_local_dev import local_dev_pkcs11_handoff_available, local_dev_pkcs11_module_path
 from setup_wizard.pkcs11_staging import cleanup_wizard_pkcs11_staged_path, existing_wizard_pkcs11_staged_file
 from setup_wizard.tls_credential import clear_staged_tls_credential, load_staged_tls_credential
-from users.models import Role
+from users.models import BuiltinRole
 
 logger = logging.getLogger(__name__)
 
@@ -461,7 +461,7 @@ class OperationalBootstrapApplier:
         if not password_hash:
             raise DjangoValidationError('The operational admin password hash is missing.')
 
-        admin_group = Group.objects.get(name=Role.ADMIN.value)
+        admin_group = Group.objects.get(name=BuiltinRole.ADMIN.value)
         user_model = get_user_model()
         user, _ = user_model.objects.get_or_create(
             username=username,
@@ -487,7 +487,7 @@ class OperationalBootstrapApplier:
             call_command('add_domains_and_devices')
         call_command('execute_all_notifications')
         self._apply_staged_tls_credential()
-        call_command('create_admin_group')
+        call_command('create_builtin_groups')
         self._create_operational_admin()
 
 

--- a/trustpoint/management/management/commands/auto_setup_from_env.py
+++ b/trustpoint/management/management/commands/auto_setup_from_env.py
@@ -66,7 +66,7 @@ class Command(BaseCommand):
         """Ensure the Admin role (Group) exists with proper superuser permissions."""
         self.stdout.write('Ensuring Admin role exists...')
         try:
-            call_command('create_admin_group')
+            call_command('create_builtin_groups')
             self.stdout.write(self.style.SUCCESS('Admin role configured'))
         except Exception as e:
             err_msg = f'Failed to create Admin role: {e}'

--- a/trustpoint/management/management/commands/bootstrap_manager.py
+++ b/trustpoint/management/management/commands/bootstrap_manager.py
@@ -24,7 +24,7 @@ from management.util.output_wrapper import CommandOutputWrapper
 from management.util.startup_strategies import BootstrapTlsMaterialStrategy, StartupContext, WizardState
 from setup_wizard.models import SetupWizardCompletedModel, SetupWizardConfigModel
 from setup_wizard.tls_credential import load_staged_tls_credential
-from users.models import Role
+from users.models import BuiltinRole
 
 logger = logging.getLogger(__name__)
 
@@ -133,8 +133,8 @@ class Command(BaseCommand):
     @staticmethod
     def _ensure_admin_group() -> Group:
         """Ensure the protected Admin role and profile exist."""
-        call_command('create_admin_group', verbosity=0)
-        return Group.objects.get(name=Role.ADMIN.value)
+        call_command('create_builtin_groups', verbosity=0)
+        return Group.objects.get(name=BuiltinRole.ADMIN.value)
 
     @staticmethod
     def _seed_operational_database_defaults(config: SetupWizardConfigModel, output: CommandOutputWrapper) -> None:

--- a/trustpoint/management/serializer/role.py
+++ b/trustpoint/management/serializer/role.py
@@ -31,7 +31,8 @@ class RoleSerializer(serializers.ModelSerializer[Group]):
     )
     grants_staff = serializers.BooleanField(required=False, default=False)
     grants_superuser = serializers.BooleanField(required=False, default=False)
-    is_protected = serializers.SerializerMethodField()
+    is_modification_protected = serializers.SerializerMethodField()
+    is_deletion_protected = serializers.SerializerMethodField()
     user_count = serializers.SerializerMethodField()
 
     class Meta:
@@ -44,14 +45,20 @@ class RoleSerializer(serializers.ModelSerializer[Group]):
             'permissions',
             'grants_staff',
             'grants_superuser',
-            'is_protected',
+            'is_modification_protected',
+            'is_deletion_protected',
             'user_count',
         )
 
-    def get_is_protected(self, obj: Group) -> bool:
-        """Return whether this role is protected from modification and deletion."""
+    def get_is_modification_protected(self, obj: Group) -> bool:
+        """Return whether this role is protected from modification."""
         profile = getattr(obj, 'profile', None)
-        return bool(profile and profile.is_protected)
+        return bool(profile and profile.is_modification_protected)
+
+    def get_is_deletion_protected(self, obj: Group) -> bool:
+        """Return whether this role is protected from deletion."""
+        profile = getattr(obj, 'profile', None)
+        return bool(profile and profile.is_deletion_protected)
 
     def get_user_count(self, obj: Group) -> int:
         """Return how many users are currently assigned to this role."""

--- a/trustpoint/management/serializer/role.py
+++ b/trustpoint/management/serializer/role.py
@@ -8,7 +8,7 @@ from typing import Any
 from django.contrib.auth.models import Group, Permission
 from rest_framework import serializers
 
-from users.models import GroupProfile, Role
+from users.models import GroupProfile
 
 
 class PermissionSerializer(serializers.ModelSerializer[Permission]):
@@ -49,8 +49,9 @@ class RoleSerializer(serializers.ModelSerializer[Group]):
         )
 
     def get_is_protected(self, obj: Group) -> bool:
-        """Return whether this role is a built-in, non-deletable role."""
-        return obj.name in {Role.ADMIN.value, Role.SERVICE.value}
+        """Return whether this role is protected from modification and deletion."""
+        profile = getattr(obj, 'profile', None)
+        return bool(profile and profile.is_protected)
 
     def get_user_count(self, obj: Group) -> int:
         """Return how many users are currently assigned to this role."""

--- a/trustpoint/management/tests/test_api/test_backup_viewset.py
+++ b/trustpoint/management/tests/test_api/test_backup_viewset.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -24,7 +25,10 @@ def api_client() -> APIClient:
 def user():
     """Create a test user."""
     User = get_user_model()
-    return User.objects.create_user(username='api_testuser', password='testpass123')
+    test_user = User.objects.create_user(username='api_testuser', password='testpass123')
+    manage_backups_perm = Permission.objects.get(codename='manage_backups')
+    test_user.role.permissions.add(manage_backups_perm)
+    return test_user
 
 
 @pytest.fixture

--- a/trustpoint/management/tests/test_api/test_logging_viewset.py
+++ b/trustpoint/management/tests/test_api/test_logging_viewset.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -45,7 +46,10 @@ def api_client() -> APIClient:
 def user():
     """Create a test user."""
     User = get_user_model()
-    return User.objects.create_user(username='log_testuser', password='testpass123')
+    test_user = User.objects.create_user(username='log_testuser', password='testpass123')
+    manage_system_configuration_perm = Permission.objects.get(codename='manage_system_configuration')
+    test_user.role.permissions.add(manage_system_configuration_perm)
+    return test_user
 
 
 @pytest.fixture

--- a/trustpoint/management/tests/test_api/test_role_viewset.py
+++ b/trustpoint/management/tests/test_api/test_role_viewset.py
@@ -19,7 +19,15 @@ User = get_user_model()
 
 def _create_admin_group() -> Group:
     group, _ = Group.objects.get_or_create(name='Admin')
-    GroupProfile.objects.get_or_create(group=group, defaults={'grants_staff': True, 'grants_superuser': True})
+    GroupProfile.objects.update_or_create(
+        group=group,
+        defaults={
+            'grants_staff': True,
+            'grants_superuser': True,
+            'is_builtin': True,
+            'is_protected': True,
+        },
+    )
     return group
 
 
@@ -154,15 +162,14 @@ class TestRoleViewSetUpdate:
         response = superuser_client.patch(url, {'permissions': [perm_id]}, format='json')
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_updating_service_account_role_is_blocked(self, superuser_client: APIClient) -> None:
-        """The built-in Service Account role's permissions cannot be changed."""
+    def test_updating_service_account_role_is_allowed(self, superuser_client: APIClient) -> None:
+        """The Service Account role is editable because only Admin is protected."""
         service_group = BuiltinRole.get_service_group()
         url = reverse('roles-detail', args=[service_group.pk])
 
         response = superuser_client.patch(url, {'permissions': []}, format='json')
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert list(service_group.permissions.values_list('codename', flat=True)) == ['use_rest_api']
+        assert response.status_code == status.HTTP_200_OK
 
 
 @pytest.mark.django_db

--- a/trustpoint/management/tests/test_api/test_role_viewset.py
+++ b/trustpoint/management/tests/test_api/test_role_viewset.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from users.models import GroupProfile, Role
+from users.models import BuiltinRole, GroupProfile
 
 User = get_user_model()
 
@@ -156,7 +156,7 @@ class TestRoleViewSetUpdate:
 
     def test_updating_service_account_role_is_blocked(self, superuser_client: APIClient) -> None:
         """The built-in Service Account role's permissions cannot be changed."""
-        service_group = Role.get_service_group()
+        service_group = BuiltinRole.get_service_group()
         url = reverse('roles-detail', args=[service_group.pk])
 
         response = superuser_client.patch(url, {'permissions': []}, format='json')

--- a/trustpoint/management/tests/test_api/test_role_viewset.py
+++ b/trustpoint/management/tests/test_api/test_role_viewset.py
@@ -25,7 +25,8 @@ def _create_admin_group() -> Group:
             'grants_staff': True,
             'grants_superuser': True,
             'is_builtin': True,
-            'is_protected': True,
+            'is_modification_protected': True,
+            'is_deletion_protected': True,
         },
     )
     return group
@@ -125,10 +126,11 @@ class TestRoleViewSetCreate:
         assert GroupProfile.objects.get(group=group).grants_staff is True
 
     def test_create_response_includes_computed_fields(self, superuser_client: APIClient) -> None:
-        """The response includes is_protected and user_count for a freshly created role."""
+        """The response includes protection flags and user_count for a freshly created role."""
         response = superuser_client.post(reverse('roles-list'), {'name': 'Auditor'}, format='json')
         assert response.status_code == status.HTTP_201_CREATED, response.data
-        assert response.data['is_protected'] is False
+        assert response.data['is_modification_protected'] is False
+        assert response.data['is_deletion_protected'] is False
         assert response.data['user_count'] == 0
 
 
@@ -163,13 +165,20 @@ class TestRoleViewSetUpdate:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_updating_service_account_role_is_allowed(self, superuser_client: APIClient) -> None:
-        """The Service Account role is editable because only Admin is protected."""
+        """The Service Account role is editable but cannot be deleted."""
         service_group = BuiltinRole.get_service_group()
+        GroupProfile.objects.update_or_create(
+            group=service_group,
+            defaults={'is_deletion_protected': True, 'is_modification_protected': False},
+        )
         url = reverse('roles-detail', args=[service_group.pk])
 
         response = superuser_client.patch(url, {'permissions': []}, format='json')
 
         assert response.status_code == status.HTTP_200_OK
+
+        response = superuser_client.delete(url)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
 @pytest.mark.django_db

--- a/trustpoint/management/tests/test_api/test_tls_viewset.py
+++ b/trustpoint/management/tests/test_api/test_tls_viewset.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -24,7 +25,10 @@ def api_client() -> APIClient:
 def user():
     """Create a test user."""
     User = get_user_model()
-    return User.objects.create_user(username='tls_testuser', password='testpass123')
+    test_user = User.objects.create_user(username='tls_testuser', password='testpass123')
+    manage_tls_perm = Permission.objects.get(codename='manage_tls_webserver_configuration')
+    test_user.role.permissions.add(manage_tls_perm)
+    return test_user
 
 
 @pytest.fixture

--- a/trustpoint/management/tests/test_views/test_backup.py
+++ b/trustpoint/management/tests/test_views/test_backup.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 from django.contrib.auth.models import User
+from django.contrib.auth.models import Permission
 from django.contrib.messages import get_messages
 from django.core.management.base import CommandError
 from django.http import Http404
@@ -33,6 +34,14 @@ from management.views.backup import BackupFileDownloadView, create_db_backup, ge
 from util.sftp import SftpError
 
 User = get_user_model()
+
+
+def create_backup_test_user():
+    """Create a user authorized to exercise backup management views."""
+    user = User.objects.create_user(username='testuser', password='testpassword')
+    permission = Permission.objects.get(codename='manage_backups')
+    user.role.permissions.add(permission)
+    return user
 
 
 class GetBackupFileDataTest(TestCase):
@@ -133,7 +142,7 @@ class BackupManageViewTest(TestCase):
         self.backup_dir = Path(self.temp_dir.name)
 
         # Create and log in a test user
-        self.user = User.objects.create_user(username='testuser', password='testpassword')
+        self.user = create_backup_test_user()
         self.client.login(username='testuser', password='testpassword')
 
     @patch('management.views.backup.settings')
@@ -521,7 +530,7 @@ class BackupFileDownloadViewTest(TestCase):
         self.backup_dir = Path(self.temp_dir.name)
         
         # Create and log in a test user
-        self.user = User.objects.create_user(username='testuser', password='testpassword')
+        self.user = create_backup_test_user()
         self.client.login(username='testuser', password='testpassword')
 
     @patch('management.views.backup.settings')
@@ -603,7 +612,7 @@ class BackupFilesDownloadMultipleViewTest(TestCase):
         self.backup_dir = Path(self.temp_dir.name)
         
         # Create and log in a test user
-        self.user = User.objects.create_user(username='testuser', password='testpassword')
+        self.user = create_backup_test_user()
         self.client.login(username='testuser', password='testpassword')
 
     @patch('management.views.backup.settings')
@@ -699,7 +708,7 @@ class BackupFilesDeleteMultipleViewTest(TestCase):
         self.backup_dir = Path(self.temp_dir.name)
         
         # Create and log in a test user
-        self.user = User.objects.create_user(username='testuser', password='testpassword')
+        self.user = create_backup_test_user()
         self.client.login(username='testuser', password='testpassword')
 
     @patch('management.views.backup.settings')

--- a/trustpoint/management/tests/test_views/test_role_management.py
+++ b/trustpoint/management/tests/test_views/test_role_management.py
@@ -9,7 +9,7 @@ from django.contrib.messages import get_messages
 from django.test import Client, TestCase
 from django.urls import reverse
 
-from users.models import GroupProfile, Role
+from users.models import BuiltinRole, GroupProfile
 
 User = get_user_model()
 
@@ -105,11 +105,11 @@ class RoleEditViewTest(TestCase):
 
     def test_service_account_role_permissions_are_fixed(self) -> None:
         """The built-in service-account role cannot be modified."""
-        service_group = Role.get_service_group()
+        service_group = BuiltinRole.get_service_group()
         url = reverse('management:edit_role', kwargs={'pk': service_group.pk})
 
         response = self.client.post(url, {
-            'name': Role.SERVICE.value,
+            'name': BuiltinRole.SERVICE.value,
             'grants_staff': 'on',
             'grants_superuser': 'on',
             'permissions': [],

--- a/trustpoint/management/tests/test_views/test_role_management.py
+++ b/trustpoint/management/tests/test_views/test_role_management.py
@@ -22,7 +22,8 @@ def _create_admin_group() -> Group:
             'grants_staff': True,
             'grants_superuser': True,
             'is_builtin': True,
-            'is_protected': True,
+            'is_modification_protected': True,
+            'is_deletion_protected': True,
         },
     )
     manage_roles_perm = Permission.objects.get(codename='manage_roles')
@@ -114,8 +115,12 @@ class RoleEditViewTest(TestCase):
         self.assertTrue(any('Analyst Updated' in str(m) for m in messages))
 
     def test_service_account_role_can_be_modified(self) -> None:
-        """Only the Admin role is protected from modification."""
+        """The Service Account role can be modified but cannot be deleted."""
         service_group = BuiltinRole.get_service_group()
+        GroupProfile.objects.update_or_create(
+            group=service_group,
+            defaults={'is_deletion_protected': True, 'is_modification_protected': False},
+        )
         url = reverse('management:edit_role', kwargs={'pk': service_group.pk})
 
         response = self.client.post(url, {
@@ -126,6 +131,10 @@ class RoleEditViewTest(TestCase):
         })
 
         self.assertEqual(response.status_code, 302)
+
+        delete_response = self.client.post(reverse('management:delete_role', kwargs={'pk': service_group.pk}))
+        self.assertEqual(delete_response.status_code, 302)
+        self.assertTrue(Group.objects.filter(pk=service_group.pk).exists())
 
 
 class RoleDeleteViewTest(TestCase):

--- a/trustpoint/management/tests/test_views/test_role_management.py
+++ b/trustpoint/management/tests/test_views/test_role_management.py
@@ -4,7 +4,7 @@
 """Tests for the Role Management views."""
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, Permission
 from django.contrib.messages import get_messages
 from django.test import Client, TestCase
 from django.urls import reverse
@@ -16,7 +16,17 @@ User = get_user_model()
 
 def _create_admin_group() -> Group:
     group, _ = Group.objects.get_or_create(name='Admin')
-    GroupProfile.objects.get_or_create(group=group, defaults={'grants_staff': True, 'grants_superuser': True})
+    GroupProfile.objects.update_or_create(
+        group=group,
+        defaults={
+            'grants_staff': True,
+            'grants_superuser': True,
+            'is_builtin': True,
+            'is_protected': True,
+        },
+    )
+    manage_roles_perm = Permission.objects.get(codename='manage_roles')
+    group.permissions.add(manage_roles_perm)
     return group
 
 
@@ -40,7 +50,7 @@ class RoleTableViewTest(TestCase):
 
         response = self.client.get(url)
 
-        self.assertContains(response, 'Can use REST API')
+        self.assertContains(response, 'Can manage roles')
         self.assertNotContains(response, 'Assigned Permissions')
 
 
@@ -103,8 +113,8 @@ class RoleEditViewTest(TestCase):
         messages = list(get_messages(response.wsgi_request))
         self.assertTrue(any('Analyst Updated' in str(m) for m in messages))
 
-    def test_service_account_role_permissions_are_fixed(self) -> None:
-        """The built-in service-account role cannot be modified."""
+    def test_service_account_role_can_be_modified(self) -> None:
+        """Only the Admin role is protected from modification."""
         service_group = BuiltinRole.get_service_group()
         url = reverse('management:edit_role', kwargs={'pk': service_group.pk})
 
@@ -115,8 +125,7 @@ class RoleEditViewTest(TestCase):
             'permissions': [],
         })
 
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(list(service_group.permissions.values_list('codename', flat=True)), ['use_rest_api'])
+        self.assertEqual(response.status_code, 302)
 
 
 class RoleDeleteViewTest(TestCase):

--- a/trustpoint/management/tests/test_views/test_settings.py
+++ b/trustpoint/management/tests/test_views/test_settings.py
@@ -7,7 +7,9 @@ import smtplib
 from unittest.mock import Mock, patch
 
 from django.conf import settings as django_settings
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
+from django.contrib.auth.models import Permission
 from django.contrib.messages import get_messages
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
@@ -19,15 +21,35 @@ from pki.util.keys import AutoGenPkiKeyAlgorithm
 LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
 
 
+class AuthorizedRequestFactory(RequestFactory):
+    """Create requests authorized for settings mutation tests."""
+
+    def __init__(self, user):
+        super().__init__()
+        self.user = user
+
+    def request(self, **request):
+        http_request = super().request(**request)
+        http_request.user = self.user
+        return http_request
+
+
+def authorized_request_factory(*permission_codenames: str) -> AuthorizedRequestFactory:
+    """Create requests for a user with the specified application permissions."""
+    user = get_user_model().objects.create_user(username='settings-tester', password='testpass123')
+    permissions = Permission.objects.filter(codename__in=permission_codenames)
+    user.role.permissions.add(*permissions)
+    return AuthorizedRequestFactory(user)
+
+
 class SecuritySettingsViewTest(TestCase):
     """Test suite for SecuritySettingsView."""
 
     def setUp(self):
         """Set up test fixtures."""
-        self.factory = RequestFactory()
+        self.factory = authorized_request_factory('manage_security_configuration')
         self.view = SecuritySettingsView()
         self.view.request = self.factory.get('/settings/security/')
-        self.view.request.user = AnonymousUser()
 
         # Enable message storage
         from django.contrib.messages.storage.fallback import FallbackStorage
@@ -271,7 +293,7 @@ class SettingsTabViewTest(TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.factory = RequestFactory()
+        self.factory = authorized_request_factory('manage_system_configuration')
         self.view = SettingsTabView()
         self.view.request = self.factory.get('/settings/')
 
@@ -552,7 +574,7 @@ class ChangeLogLevelViewTest(TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.factory = RequestFactory()
+        self.factory = authorized_request_factory('manage_system_configuration')
         self.view = ChangeLogLevelView()
         
         # Save original log level

--- a/trustpoint/management/tests/test_views/test_tls.py
+++ b/trustpoint/management/tests/test_views/test_tls.py
@@ -4,7 +4,8 @@
 """Test suite for TLS views."""
 from unittest.mock import Mock, patch
 
-from django.contrib.auth.models import AnonymousUser
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.contrib.messages import get_messages
 from django.core.exceptions import ValidationError
 from django.test import RequestFactory, TestCase
@@ -23,6 +24,21 @@ from management.views.tls import (
 from pki.models import CertificateModel, CredentialModel
 from pki.models.truststore import ActiveTrustpointTlsServerCredentialModel
 from setup_wizard.forms import StartupWizardTlsCertificateForm
+
+
+class AuthorizedRequestFactory(RequestFactory):
+    """Create requests authorized for protected TLS view tests."""
+
+    def __init__(self):
+        super().__init__()
+        self.user = get_user_model().objects.create_user(username='tls-tester', password='testpass123')
+        permission = Permission.objects.get(codename='manage_tls_webserver_configuration')
+        self.user.role.permissions.add(permission)
+
+    def request(self, **request):
+        http_request = super().request(**request)
+        http_request.user = self.user
+        return http_request
 
 
 class TlsSettingsContextMixinTest(TestCase):
@@ -55,7 +71,7 @@ class TlsViewTest(TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.factory = RequestFactory()
+        self.factory = AuthorizedRequestFactory()
         self.view = TlsView()
         self.view.request = self.factory.get('/tls/')
         
@@ -320,7 +336,7 @@ class GenerateTlsCertificateViewTest(TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.factory = RequestFactory()
+        self.factory = AuthorizedRequestFactory()
         self.view = GenerateTlsCertificateView()
         self.view.request = self.factory.get('/tls/generate/')
         
@@ -418,10 +434,9 @@ class TlsAddFileImportPkcs12ViewTest(TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.factory = RequestFactory()
+        self.factory = AuthorizedRequestFactory()
         self.view = TlsAddFileImportPkcs12View()
         self.view.request = self.factory.get('/tls/import/pkcs12/')
-        self.view.request.user = AnonymousUser()
 
         # Enable message storage
         from django.contrib.messages.storage.fallback import FallbackStorage
@@ -458,10 +473,9 @@ class TlsAddFileImportSeparateFilesViewTest(TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.factory = RequestFactory()
+        self.factory = AuthorizedRequestFactory()
         self.view = TlsAddFileImportSeparateFilesView()
         self.view.request = self.factory.get('/tls/import/separate/')
-        self.view.request.user = AnonymousUser()
 
         # Enable message storage
         from django.contrib.messages.storage.fallback import FallbackStorage
@@ -498,7 +512,7 @@ class ActivateTlsServerViewTest(TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.factory = RequestFactory()
+        self.factory = AuthorizedRequestFactory()
         self.view = ActivateTlsServerView()
         
         # Create a certificate and credential using mocks

--- a/trustpoint/management/tests/test_views/test_user_management.py
+++ b/trustpoint/management/tests/test_views/test_user_management.py
@@ -10,7 +10,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 
 from management.models.organization import OrganizationModel
-from users.models import GroupProfile, Role
+from users.models import BuiltinRole, GroupProfile
 
 User = get_user_model()
 
@@ -95,7 +95,7 @@ class UserCreateViewTest(TestCase):
 
     def test_service_account_role_is_not_available(self) -> None:
         """The fixed service-account role is absent from the human-user form."""
-        service_group = Role.get_service_group()
+        service_group = BuiltinRole.get_service_group()
 
         response = self.client.get(self.url)
 
@@ -103,7 +103,7 @@ class UserCreateViewTest(TestCase):
 
     def test_service_account_role_cannot_be_submitted(self) -> None:
         """A crafted submission cannot assign the service-account role to a human user."""
-        service_group = Role.get_service_group()
+        service_group = BuiltinRole.get_service_group()
 
         response = self.client.post(self.url, {
             'username': 'not-a-service-account',

--- a/trustpoint/management/views/audit_log.py
+++ b/trustpoint/management/views/audit_log.py
@@ -13,18 +13,22 @@ from management.filters.audit_log import AuditLogFilter
 from management.models.audit_log import AuditLog
 from trustpoint.logger import LoggerMixin
 from trustpoint.page_context import PageContextMixin
+from trustpoint.views.base import UserPermissionRequiredMixin
+from users.permissions import AppPermissions
 
 if TYPE_CHECKING:
     from django.db.models import QuerySet
 
 
-class AuditLogListView(PageContextMixin, LoggerMixin, ListView[AuditLog]):
+class AuditLogListView(UserPermissionRequiredMixin, PageContextMixin, LoggerMixin, ListView[AuditLog]):
     """Paginated, filterable list view for audit log entries."""
 
     model = AuditLog
     template_name = 'management/audit_log/list.html'
     context_object_name = 'audit_log_entries'
     paginate_by = 50
+
+    permission_required = AppPermissions.VIEW_AUDIT_LOG
 
     page_category = 'management'
     page_name = 'audit_log'

--- a/trustpoint/management/views/backup.py
+++ b/trustpoint/management/views/backup.py
@@ -11,23 +11,26 @@ from typing import Any, ClassVar
 
 from django.conf import settings
 from django.contrib import messages
+from django.core.exceptions import PermissionDenied
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.http import Http404, HttpResponse
+from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.views.generic import ListView, View
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import filters, viewsets
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import BasePermission
+from rest_framework.views import APIView
 
 from management.backup_artifacts import backup_manifest_path
 from management.forms import BackupOptionsForm
 from management.models import BackupOptions
 from management.serializer.backup import BackupSerializer
 from trustpoint.logger import LoggerMixin
-from trustpoint.views.base import SortableTableFromListMixin
+from trustpoint.views.base import SortableTableFromListMixin, UserPermissionRequiredMixin
+from users.permissions import AppPermissions
 from util.sftp import SftpClient, SftpError
 
 
@@ -145,6 +148,9 @@ class BackupManageView(SortableTableFromListMixin, LoggerMixin, ListView):  # ty
 
     def post(self, request: Any, *_args: Any, **_kwargs: Any) -> HttpResponse:
         """Handle form submissions for backup or SFTP settings."""
+        if not request.user.has_perm(AppPermissions.MANAGE_BACKUPS):
+            raise PermissionDenied
+
         if 'create_local_backup' in request.POST:
             return self._handle_create_local_backup(request)
 
@@ -317,8 +323,10 @@ class BackupManageView(SortableTableFromListMixin, LoggerMixin, ListView):  # ty
         return redirect(self.success_url)
 
 
-class BackupFileDownloadView(View):
+class BackupFileDownloadView(UserPermissionRequiredMixin, View):
     """Serve a backup file, bundled with its manifest when available."""
+
+    permission_required = AppPermissions.MANAGE_BACKUPS
 
     @staticmethod
     def _bundle_filename(filename: str) -> str:
@@ -409,8 +417,10 @@ def _build_tar_gz_backup_artifact(filename: str, path: Path, manifest_path: Path
     return _backup_artifact_filename(filename, 'tar.gz'), buffer.getvalue()
 
 
-class BackupFilesDownloadMultipleView(View):
+class BackupFilesDownloadMultipleView(UserPermissionRequiredMixin, View):
     """Download multiple selected backup files as a ZIP or tar.gz archive."""
+
+    permission_required = AppPermissions.MANAGE_BACKUPS
 
     def post(self, request: Any, archive_format: str) -> HttpResponse:
         """Bundle selected backups into an archive.
@@ -467,8 +477,9 @@ class BackupFilesDownloadMultipleView(View):
         return response
 
 
-class BackupFilesDeleteMultipleView(View, LoggerMixin):
+class BackupFilesDeleteMultipleView(UserPermissionRequiredMixin, View, LoggerMixin):
     """Delete multiple selected backup files and notify the user."""
+    permission_required = AppPermissions.MANAGE_BACKUPS
 
     def post(self, request: Any) -> HttpResponse:
         """Delete the selected backup files.
@@ -517,6 +528,17 @@ class BackupFilesDeleteMultipleView(View, LoggerMixin):
 
         return redirect('management:backups')
 
+class CanManageBackup(BasePermission):
+    """Allow only users permitted to manage backup settings."""
+
+    def has_permission(self, request: HttpRequest, view: APIView) -> bool:
+        """Check if the user has permission to manage backup settings."""
+        return bool(
+            request.user
+            and request.user.is_authenticated
+            and request.user.has_perm(AppPermissions.MANAGE_BACKUPS)
+        )
+
 @extend_schema(tags=['Backup'])
 @extend_schema_view(
     list=extend_schema(description='Retrieve a list of all backups.'),
@@ -534,7 +556,7 @@ class BackupViewSet(viewsets.ModelViewSet[Any]):
     """
     queryset = BackupOptions.objects.all().order_by('-user')
     serializer_class = BackupSerializer
-    permission_classes: ClassVar = [IsAuthenticated] # type: ignore[misc]
+    permission_classes: ClassVar = [CanManageBackup] # type: ignore[misc]
     filter_backends: ClassVar = [ # type: ignore[misc]
         DjangoFilterBackend,
         filters.SearchFilter,

--- a/trustpoint/management/views/backup.py
+++ b/trustpoint/management/views/backup.py
@@ -22,7 +22,6 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import filters, viewsets
 from rest_framework.permissions import BasePermission
-from rest_framework.views import APIView
 
 from management.backup_artifacts import backup_manifest_path
 from management.forms import BackupOptionsForm
@@ -531,7 +530,7 @@ class BackupFilesDeleteMultipleView(UserPermissionRequiredMixin, View, LoggerMix
 class CanManageBackup(BasePermission):
     """Allow only users permitted to manage backup settings."""
 
-    def has_permission(self, request: HttpRequest, view: APIView) -> bool:
+    def has_permission(self, request: HttpRequest, _view: Any) -> bool:
         """Check if the user has permission to manage backup settings."""
         return bool(
             request.user

--- a/trustpoint/management/views/logging.py
+++ b/trustpoint/management/views/logging.py
@@ -22,13 +22,15 @@ from django.views.generic.list import ListView
 from drf_spectacular.utils import extend_schema
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
+from rest_framework.permissions import BasePermission
 from rest_framework.response import Response
 
 from management.serializer.logging import LoggingSerializer
 from trustpoint.logger import LoggerMixin
 from trustpoint.page_context import PageContextMixin
 from trustpoint.settings import DATE_FORMAT, LOG_DIR_PATH
-from trustpoint.views.base import SortableTableFromListMixin
+from trustpoint.views.base import SortableTableFromListMixin, UserPermissionRequiredMixin
+from users.permissions import AppPermissions
 
 if TYPE_CHECKING:
 
@@ -186,13 +188,20 @@ class LoggingFilesTableView(PageContextMixin, LoggerMixin, SortableTableFromList
         return queryset
 
 
-class LoggingFilesDetailsView(PageContextMixin, LoggerMixin, TemplateView):
+class LoggingFilesDetailsView(
+    UserPermissionRequiredMixin,
+    PageContextMixin,
+    LoggerMixin,
+    TemplateView
+):
     """Log file detail view, allows to view the content of a single log file without download."""
 
     http_method_names = ('get',)
 
     template_name = 'management/logging/logging_files_details.html'
     log_directory = LOG_DIR_PATH
+
+    permission_required = AppPermissions.VIEW_SYSTEM_LOGS
 
     page_category = 'settings'
     page_name = 'logging'
@@ -211,10 +220,17 @@ class LoggingFilesDetailsView(PageContextMixin, LoggerMixin, TemplateView):
         return context
 
 
-class LoggingFilesDownloadView(PageContextMixin, LoggerMixin, TemplateView):
+class LoggingFilesDownloadView(
+    UserPermissionRequiredMixin,
+    PageContextMixin,
+    LoggerMixin,
+    TemplateView
+):
     """View to download a single log file."""
 
     http_method_names = ('get',)
+
+    permission_required = AppPermissions.VIEW_SYSTEM_LOGS
 
     page_category = 'settings'
     page_name = 'logging'
@@ -236,11 +252,16 @@ class LoggingFilesDownloadView(PageContextMixin, LoggerMixin, TemplateView):
         return response
 
 
-class LoggingFilesDownloadMultipleView(PageContextMixin, LoggerMixin, View):
+class LoggingFilesDownloadMultipleView(
+    UserPermissionRequiredMixin,
+    PageContextMixin,
+    LoggerMixin,
+    View
+):
     """View to download multiple log files as a single archive."""
 
     http_method_names = ('get',)
-
+    permission_required = AppPermissions.VIEW_SYSTEM_LOGS
     page_category = 'settings'
     page_name = 'logging'
 
@@ -295,6 +316,17 @@ class LoggingFilesDownloadMultipleView(PageContextMixin, LoggerMixin, View):
         response['Content-Disposition'] = 'attachment; filename=trustpoint-logs.tar.gz'
         return response
 
+class CanManageLogging(BasePermission):
+    """Allow only users permitted to manage logging settings."""
+
+    def has_permission(self, request: Request, view: Any) -> bool:
+        """Check if the user has permission to manage logging settings."""
+        return bool(
+            request.user
+            and request.user.is_authenticated
+            and request.user.has_perm(AppPermissions.MANAGE_SYSTEM_CONFIGURATION)
+        )
+
 @extend_schema(tags=['Logging'])
 class LoggingViewSet(viewsets.GenericViewSet[Any]):
     """ViewSet for managing Backup instances.
@@ -303,6 +335,7 @@ class LoggingViewSet(viewsets.GenericViewSet[Any]):
     create, update, and delete.
     """
     serializer_class = LoggingSerializer
+    permission_classes = (CanManageLogging,)
     filter_backends = ()
 
     @action(detail=False, methods=['get'])

--- a/trustpoint/management/views/logging.py
+++ b/trustpoint/management/views/logging.py
@@ -319,7 +319,7 @@ class LoggingFilesDownloadMultipleView(
 class CanManageLogging(BasePermission):
     """Allow only users permitted to manage logging settings."""
 
-    def has_permission(self, request: Request, view: Any) -> bool:
+    def has_permission(self, request: Request, _view: Any) -> bool:
         """Check if the user has permission to manage logging settings."""
         return bool(
             request.user

--- a/trustpoint/management/views/notifications.py
+++ b/trustpoint/management/views/notifications.py
@@ -25,7 +25,8 @@ from pki.models import IssuedCredentialModel
 from trustpoint.logger import LoggerMixin
 from trustpoint.page_context import PageContextMixin
 from trustpoint.settings import UIConfig
-from trustpoint.views.base import SortableTableMixin
+from trustpoint.views.base import SortableTableMixin, UserPermissionRequiredMixin
+from users.permissions import AppPermissions
 
 if TYPE_CHECKING:
     from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
@@ -166,12 +167,18 @@ class NotificationDetailsView(PageContextMixin, LoggerMixin, DetailView[Notifica
         return context
 
 
-class NotificationMarkSolvedView(PageContextMixin, LoggerMixin, DetailView[NotificationModel]):
+class NotificationMarkSolvedView(
+    UserPermissionRequiredMixin,
+    PageContextMixin,
+    LoggerMixin,
+    DetailView[NotificationModel]
+):
     """Mark notification as solved when viewed in the notification details page."""
 
     template_name = 'management/notifications/details.html'
     model = NotificationModel
     context_object_name = 'notification'
+    permission_required = AppPermissions.MANAGE_NOTIFICATIONS
 
     page_category = 'management'
     page_name = 'notifications'
@@ -190,8 +197,10 @@ class NotificationMarkSolvedView(PageContextMixin, LoggerMixin, DetailView[Notif
         return context
 
 
-class NotificationToggleReadView(LoggerMixin, TemplateView):
+class NotificationToggleReadView(UserPermissionRequiredMixin, LoggerMixin, TemplateView):
     """Toggle the read/unread state of a notification and redirect back to its details."""
+
+    permission_required = AppPermissions.MANAGE_NOTIFICATIONS
 
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseRedirect:
         """Toggle the NEW status on the notification and redirect to details."""
@@ -211,8 +220,10 @@ class NotificationToggleReadView(LoggerMixin, TemplateView):
         return redirect('management:notification_details', pk=pk)
 
 
-class RefreshNotificationsView(LoggerMixin, TemplateView):
+class RefreshNotificationsView(UserPermissionRequiredMixin, LoggerMixin, TemplateView):
     """View to execute all notifications and redirect back to notifications list."""
+
+    permission_required = AppPermissions.MANAGE_NOTIFICATIONS
 
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseRedirect:
         """Handles GET requests and redirects to the notifications list."""
@@ -228,8 +239,10 @@ class RefreshNotificationsView(LoggerMixin, TemplateView):
         return redirect('management:notifications')
 
 
-class NotificationDeleteView(LoggerMixin, DeleteView[NotificationModel, Any]):
+class NotificationDeleteView(UserPermissionRequiredMixin, LoggerMixin, DeleteView[NotificationModel, Any]):
     """View to delete a notification."""
+
+    permission_required = AppPermissions.MANAGE_NOTIFICATIONS
 
     model: type[NotificationModel] = NotificationModel  # Explicitly set the model type
     template_name = 'management/notifications/confirm_delete.html'

--- a/trustpoint/management/views/organization.py
+++ b/trustpoint/management/views/organization.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 from django.contrib import messages
+from django.core.exceptions import PermissionDenied
 from django.forms import BaseModelForm
 from django.http import HttpResponse
 from django.urls import reverse_lazy
@@ -18,6 +19,7 @@ from management.models.audit_log import AuditLog
 from management.models.organization import OrganizationModel
 from trustpoint.logger import LoggerMixin
 from trustpoint.views.base import ContextDataMixin, SuperuserRequiredMixin
+from users.permissions import AppPermissions
 
 
 class OrganizationContextMixin(ContextDataMixin):
@@ -55,6 +57,8 @@ class OrganizationCreateView(
 
     def form_valid(self, form: BaseModelForm[OrganizationModel]) -> HttpResponse:
         """Save the new organization, write audit log, and show a success message."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_ORGANIZATIONS):
+            raise PermissionDenied
         response = super().form_valid(form)
         if not self.object:
             return response
@@ -90,6 +94,8 @@ class OrganizationEditView(
 
     def form_valid(self, form: BaseModelForm[OrganizationModel]) -> HttpResponse:
         """Save organization changes, write audit log, and show a success message."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_ORGANIZATIONS):
+            raise PermissionDenied
         response = super().form_valid(form)
 
         actor = self.request.user if self.request.user.is_authenticated else None
@@ -121,7 +127,13 @@ class OrganizationDeleteView(
     success_url = reverse_lazy('management:organization')
 
     def form_valid(self, form: Any) -> HttpResponse:
-        """Delete the organization, write audit log, and show a success message."""
+        """Delete the organization, write audit log, and show a success message.
+
+        Raises:
+            PermissionDenied: If the current user does not have permission to manage organizations.
+        """
+        if not self.request.user.has_perm(AppPermissions.MANAGE_ORGANIZATIONS):
+            raise PermissionDenied
         self.object = self.get_object()
 
         actor = self.request.user if self.request.user.is_authenticated else None

--- a/trustpoint/management/views/role_management.py
+++ b/trustpoint/management/views/role_management.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from django.contrib import messages
 from django.contrib.auth.models import Group, Permission
+from django.core.exceptions import PermissionDenied
 from django.forms import BaseModelForm
 from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse_lazy
@@ -30,6 +31,7 @@ from trustpoint.logger import LoggerMixin
 from trustpoint.views.base import ContextDataMixin, SuperuserRequiredMixin
 from users.form import GroupPermissionForm
 from users.models import Role
+from users.permissions import AppPermissions
 
 # Built-in roles cannot be renamed or deleted.
 _PROTECTED_GROUP_NAMES: frozenset[str] = frozenset({Role.ADMIN.value, Role.SERVICE.value})
@@ -88,6 +90,8 @@ class RoleCreateView(
         Returns:
             Redirect to the role management list.
         """
+        if not self.request.user.has_perm(AppPermissions.MANAGE_ROLES):
+            raise PermissionDenied
         response = super().form_valid(form)
         name = self.object.name if self.object else ''
         messages.success(
@@ -145,6 +149,8 @@ class RoleEditView(
             back to the form with an error message if a protected
             role's name was changed.
         """
+        if not self.request.user.has_perm(AppPermissions.MANAGE_ROLES):
+            raise PermissionDenied
         original_name = self.get_object().name
 
         if original_name in _PROTECTED_GROUP_NAMES:
@@ -192,6 +198,8 @@ class RoleDeleteView(
             the list with an error message if the group is protected or
             still has assigned users.
         """
+        if not self.request.user.has_perm(AppPermissions.MANAGE_ROLES):
+            raise PermissionDenied
         self.object = self.get_object()
 
         if self.object.name in _PROTECTED_GROUP_NAMES:
@@ -227,6 +235,8 @@ class RoleViewSet(viewsets.ModelViewSet[Group]):
 
     def update(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Update the role, refusing changes to fixed built-in roles."""
+        if not request.user.has_perm(AppPermissions.MANAGE_ROLES):
+            raise PermissionDenied
         instance = self.get_object()
         if instance.name in _PROTECTED_GROUP_NAMES:
             return Response(
@@ -247,6 +257,8 @@ class RoleViewSet(viewsets.ModelViewSet[Group]):
 
     def destroy(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Delete the role, refusing protected roles or roles still assigned to users."""
+        if not request.user.has_perm(AppPermissions.MANAGE_ROLES):
+            raise PermissionDenied
         instance = self.get_object()
         if instance.name in _PROTECTED_GROUP_NAMES:
             return Response(

--- a/trustpoint/management/views/role_management.py
+++ b/trustpoint/management/views/role_management.py
@@ -30,11 +30,14 @@ from management.serializer.role import PermissionSerializer, RoleSerializer
 from trustpoint.logger import LoggerMixin
 from trustpoint.views.base import ContextDataMixin, SuperuserRequiredMixin
 from users.form import GroupPermissionForm
-from users.models import Role
+from users.models import BuiltinRole
 from users.permissions import AppPermissions
 
-# Built-in roles cannot be renamed or deleted.
-_PROTECTED_GROUP_NAMES: frozenset[str] = frozenset({Role.ADMIN.value, Role.SERVICE.value})
+
+def _is_protected(group: Group) -> bool:
+    """Return whether the group profile prevents role modification or deletion."""
+    profile = getattr(group, 'profile', None)
+    return bool(profile and profile.is_protected)
 
 
 class RoleContextMixin(ContextDataMixin):
@@ -64,7 +67,9 @@ class RoleTableView(
             ``protected_group_names``.
         """
         context = super().get_context_data(**kwargs)
-        context['protected_group_names'] = _PROTECTED_GROUP_NAMES
+        context['protected_group_names'] = set(
+            Group.objects.filter(profile__is_protected=True).values_list('name', flat=True)
+        )
         return context
 
 
@@ -126,8 +131,8 @@ class RoleEditView(
             ``True`` when the group is one of the built-in roles.
         """
         context = super().get_context_data(**kwargs)
-        context['is_protected'] = self.object.name in _PROTECTED_GROUP_NAMES
-        context['is_service_role'] = self.object.name == Role.SERVICE.value
+        context['is_protected'] = _is_protected(self.object)
+        context['is_service_role'] = self.object.name == BuiltinRole.SERVICE.value
         context['fixed_permissions'] = (
             self.object.permissions.order_by('name')
             if context['is_service_role']
@@ -153,7 +158,7 @@ class RoleEditView(
             raise PermissionDenied
         original_name = self.get_object().name
 
-        if original_name in _PROTECTED_GROUP_NAMES:
+        if _is_protected(self.get_object()):
             messages.error(
                 self.request,
                 _('Cannot modify "%(name)s": its permissions are fixed.') % {'name': original_name},
@@ -202,7 +207,7 @@ class RoleDeleteView(
             raise PermissionDenied
         self.object = self.get_object()
 
-        if self.object.name in _PROTECTED_GROUP_NAMES:
+        if _is_protected(self.object):
             messages.error(
                 self.request,
                 _('Cannot delete "%(name)s": this is a built-in role.') % {'name': self.object.name},
@@ -238,14 +243,14 @@ class RoleViewSet(viewsets.ModelViewSet[Group]):
         if not request.user.has_perm(AppPermissions.MANAGE_ROLES):
             raise PermissionDenied
         instance = self.get_object()
-        if instance.name in _PROTECTED_GROUP_NAMES:
+        if _is_protected(instance):
             return Response(
                 {'detail': 'Cannot modify this role: its permissions are fixed.'},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         new_name = request.data.get('name') if isinstance(request.data, dict) else None
         if (
-            instance.name in _PROTECTED_GROUP_NAMES
+            _is_protected(instance)
             and new_name is not None
             and str(new_name) != instance.name
         ):
@@ -260,7 +265,7 @@ class RoleViewSet(viewsets.ModelViewSet[Group]):
         if not request.user.has_perm(AppPermissions.MANAGE_ROLES):
             raise PermissionDenied
         instance = self.get_object()
-        if instance.name in _PROTECTED_GROUP_NAMES:
+        if _is_protected(instance):
             return Response(
                 {'detail': 'Cannot delete this role: it is a built-in role.'},
                 status=status.HTTP_400_BAD_REQUEST,

--- a/trustpoint/management/views/role_management.py
+++ b/trustpoint/management/views/role_management.py
@@ -30,14 +30,19 @@ from management.serializer.role import PermissionSerializer, RoleSerializer
 from trustpoint.logger import LoggerMixin
 from trustpoint.views.base import ContextDataMixin, SuperuserRequiredMixin
 from users.form import GroupPermissionForm
-from users.models import BuiltinRole
 from users.permissions import AppPermissions
 
 
-def _is_protected(group: Group) -> bool:
-    """Return whether the group profile prevents role modification or deletion."""
+def _is_modification_protected(group: Group) -> bool:
+    """Return whether the group profile prevents role modification."""
     profile = getattr(group, 'profile', None)
-    return bool(profile and profile.is_protected)
+    return bool(profile and profile.is_modification_protected)
+
+
+def _is_deletion_protected(group: Group) -> bool:
+    """Return whether the group profile prevents role deletion."""
+    profile = getattr(group, 'profile', None)
+    return bool(profile and profile.is_deletion_protected)
 
 
 class RoleContextMixin(ContextDataMixin):
@@ -68,7 +73,7 @@ class RoleTableView(
         """
         context = super().get_context_data(**kwargs)
         context['protected_group_names'] = set(
-            Group.objects.filter(profile__is_protected=True).values_list('name', flat=True)
+            Group.objects.filter(profile__is_deletion_protected=True).values_list('name', flat=True)
         )
         return context
 
@@ -114,8 +119,8 @@ class RoleEditView(
 ):
     """View for editing an existing group's name and permissions.
 
-    For protected groups the name field is rendered read-only by the
-    template (the ``is_protected`` context flag).
+    For modification-protected groups the name field is rendered read-only by the
+    template (the ``is_modification_protected`` context flag).
     """
 
     model = Group
@@ -124,18 +129,17 @@ class RoleEditView(
     success_url = reverse_lazy('management:role_management')
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
-        """Add the ``is_protected`` flag to the template context.
+        """Add the modification-protection flag to the template context.
 
         Returns:
-            The template context dictionary with ``is_protected`` set to
-            ``True`` when the group is one of the built-in roles.
+            The template context dictionary with ``is_modification_protected``
+            set to ``True`` when the group cannot be modified.
         """
         context = super().get_context_data(**kwargs)
-        context['is_protected'] = _is_protected(self.object)
-        context['is_service_role'] = self.object.name == BuiltinRole.SERVICE.value
+        context['is_modification_protected'] = _is_modification_protected(self.object)
         context['fixed_permissions'] = (
             self.object.permissions.order_by('name')
-            if context['is_service_role']
+            if context['is_modification_protected']
             else Permission.objects.filter(content_type__model='apppermission').order_by('name')
         )
         return context
@@ -158,7 +162,7 @@ class RoleEditView(
             raise PermissionDenied
         original_name = self.get_object().name
 
-        if _is_protected(self.get_object()):
+        if _is_modification_protected(self.get_object()):
             messages.error(
                 self.request,
                 _('Cannot modify "%(name)s": its permissions are fixed.') % {'name': original_name},
@@ -207,7 +211,7 @@ class RoleDeleteView(
             raise PermissionDenied
         self.object = self.get_object()
 
-        if _is_protected(self.object):
+        if _is_deletion_protected(self.object):
             messages.error(
                 self.request,
                 _('Cannot delete "%(name)s": this is a built-in role.') % {'name': self.object.name},
@@ -243,19 +247,9 @@ class RoleViewSet(viewsets.ModelViewSet[Group]):
         if not request.user.has_perm(AppPermissions.MANAGE_ROLES):
             raise PermissionDenied
         instance = self.get_object()
-        if _is_protected(instance):
+        if _is_modification_protected(instance):
             return Response(
                 {'detail': 'Cannot modify this role: its permissions are fixed.'},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-        new_name = request.data.get('name') if isinstance(request.data, dict) else None
-        if (
-            _is_protected(instance)
-            and new_name is not None
-            and str(new_name) != instance.name
-        ):
-            return Response(
-                {'detail': 'Cannot rename this role: it is a built-in role.'},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         return super().update(request, *args, **kwargs)
@@ -265,7 +259,7 @@ class RoleViewSet(viewsets.ModelViewSet[Group]):
         if not request.user.has_perm(AppPermissions.MANAGE_ROLES):
             raise PermissionDenied
         instance = self.get_object()
-        if _is_protected(instance):
+        if _is_deletion_protected(instance):
             return Response(
                 {'detail': 'Cannot delete this role: it is a built-in role.'},
                 status=status.HTTP_400_BAD_REQUEST,

--- a/trustpoint/management/views/service_accounts.py
+++ b/trustpoint/management/views/service_accounts.py
@@ -11,13 +11,15 @@ from django import forms
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.auth.hashers import make_password
-from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse, reverse_lazy
 from django.views.generic import CreateView, DeleteView, DetailView, ListView
 
 from users.models import Role, ServiceAccountCredential, TrustpointUser
+from users.permissions import AppPermissions
 
 if TYPE_CHECKING:
     from typing import Any
@@ -26,13 +28,12 @@ if TYPE_CHECKING:
     from django.http import HttpRequest, HttpResponse
 
 
-class ServiceAccountListView(LoginRequiredMixin, PermissionRequiredMixin, ListView[TrustpointUser]):
+class ServiceAccountListView(LoginRequiredMixin, ListView[TrustpointUser]):
     """List all service accounts."""
 
     model = TrustpointUser
     template_name = 'management/service_accounts/service_account_list.html'
     context_object_name = 'service_accounts'
-    permission_required = 'users.view_trustpointuser'
     paginate_by = 50
 
     def get_queryset(self) -> QuerySet[TrustpointUser]:
@@ -49,13 +50,12 @@ class ServiceAccountListView(LoginRequiredMixin, PermissionRequiredMixin, ListVi
         return context
 
 
-class ServiceAccountDetailView(LoginRequiredMixin, PermissionRequiredMixin, DetailView[TrustpointUser]):
+class ServiceAccountDetailView(LoginRequiredMixin, DetailView[TrustpointUser]):
     """View service account details and credentials."""
 
     model = TrustpointUser
     template_name = 'management/service_accounts/service_account_detail.html'
     context_object_name = 'service_account'
-    permission_required = 'users.view_trustpointuser'
 
     def get_queryset(self) -> QuerySet[TrustpointUser]:
         """Return only service accounts."""
@@ -73,15 +73,12 @@ class ServiceAccountDetailView(LoginRequiredMixin, PermissionRequiredMixin, Deta
 
 
 class ServiceAccountCreateView(
-    LoginRequiredMixin,
-    PermissionRequiredMixin,
     CreateView[TrustpointUser, forms.ModelForm[TrustpointUser]]
 ):
     """Create a new service account with API credentials."""
 
     model = TrustpointUser
     template_name = 'management/service_accounts/service_account_create.html'
-    permission_required = 'users.add_trustpointuser'
     fields = ['username', 'organization']  # noqa: RUF012
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
@@ -95,6 +92,8 @@ class ServiceAccountCreateView(
     @transaction.atomic
     def form_valid(self, form: Any) -> HttpResponse:
         """Create service account and generate API credentials."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_SERVICE_ACCOUNTS):
+            raise PermissionDenied
         # Create the service account
         service_account = form.save(commit=False)
         service_account.account_type = TrustpointUser.AccountType.SERVICE
@@ -217,13 +216,12 @@ def generate_credential_view(request: HttpRequest, pk: int) -> HttpResponse:
     return redirect(reverse('management:service_account_created'))
 
 
-class ServiceAccountDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DeleteView[TrustpointUser, forms.Form]):
+class ServiceAccountDeleteView(LoginRequiredMixin, DeleteView[TrustpointUser, forms.Form]):
     """Delete a service account."""
 
     model = TrustpointUser
     template_name = 'management/service_accounts/delete_service_account_confirm.html'
     success_url = reverse_lazy('management:service_account_list')
-    permission_required = 'users.delete_trustpointuser'
     context_object_name = 'service_account'
 
     def get_queryset(self) -> QuerySet[TrustpointUser]:
@@ -241,6 +239,8 @@ class ServiceAccountDeleteView(LoginRequiredMixin, PermissionRequiredMixin, Dele
 
     def form_valid(self, form: Any) -> HttpResponse:
         """Delete the service account and show success message."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_SERVICE_ACCOUNTS):
+            raise PermissionDenied
         self.object = self.get_object()
         username = self.object.username
 

--- a/trustpoint/management/views/service_accounts.py
+++ b/trustpoint/management/views/service_accounts.py
@@ -18,7 +18,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse, reverse_lazy
 from django.views.generic import CreateView, DeleteView, DetailView, ListView
 
-from users.models import Role, ServiceAccountCredential, TrustpointUser
+from users.models import BuiltinRole, ServiceAccountCredential, TrustpointUser
 from users.permissions import AppPermissions
 
 if TYPE_CHECKING:
@@ -84,7 +84,7 @@ class ServiceAccountCreateView(
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         """Add the fixed service role and page context."""
         context = super().get_context_data(**kwargs)
-        context['default_service_role'] = Role.get_service_group()
+        context['default_service_role'] = BuiltinRole.get_service_group()
         context['page_category'] = 'management'
         context['page_name'] = 'service_accounts'
         return context
@@ -97,7 +97,7 @@ class ServiceAccountCreateView(
         # Create the service account
         service_account = form.save(commit=False)
         service_account.account_type = TrustpointUser.AccountType.SERVICE
-        service_account.role = Role.get_service_group()
+        service_account.role = BuiltinRole.get_service_group()
         service_account.set_unusable_password()
         service_account.save()
 

--- a/trustpoint/management/views/settings.py
+++ b/trustpoint/management/views/settings.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from django.contrib import messages
+from django.core.exceptions import PermissionDenied
 from django.core.management import call_command
 from django.db import connection
 from django.shortcuts import redirect
@@ -50,6 +51,8 @@ from management.security.mixins import SecurityLevelMixin
 from pki.util.keys import AutoGenPkiKeyAlgorithm
 from trustpoint.logger import LoggerMixin
 from trustpoint.page_context import PageContextMixin
+from trustpoint.views.base import UserPermissionRequiredMixin
+from users.permissions import AppPermissions
 from workflows2.models import Workflow2WorkerHeartbeat
 
 if TYPE_CHECKING:
@@ -438,6 +441,9 @@ class SettingsTabView(TemplateView):
         """Handle inline settings updates from the settings tab page."""
         form_name = request.POST.get('form_name')
 
+        if not request.user.has_perm(AppPermissions.MANAGE_SYSTEM_CONFIGURATION):
+            raise PermissionDenied
+
         if form_name == 'smtp_email':
             return self._post_smtp_email(request)
 
@@ -583,6 +589,9 @@ class InternationalizationSettingsView(SettingsFormViewMixin[Internationalizatio
 
     def form_valid(self, form: InternationalizationConfigForm) -> HttpResponse:
         """Handle valid internationalization form submission."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_SYSTEM_CONFIGURATION):
+            raise PermissionDenied
+
         date_format = form.cleaned_data['date_format']
         language = form.cleaned_data['language']
         timezone = form.cleaned_data['timezone']
@@ -634,6 +643,9 @@ class UISettingsView(SettingsFormViewMixin[UIConfigForm]):
 
     def form_valid(self, form: UIConfigForm) -> HttpResponse:
         """Handle valid UI form submission."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_SYSTEM_CONFIGURATION):
+            raise PermissionDenied
+
         view_mode = form.cleaned_data['view_mode']
 
         self.logger.info('Changing view mode to: %s', view_mode)
@@ -673,6 +685,9 @@ class SecuritySettingsView(SettingsFormViewMixin[SecurityConfigForm]):
 
     def form_valid(self, form: SecurityConfigForm) -> HttpResponse:
         """Handle valid security form submission."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_SECURITY_CONFIGURATION):
+            raise PermissionDenied
+
         old_conf = SecurityConfig.objects.get(pk=form.instance.pk) if form.instance.pk else None
         form.save()
 
@@ -760,6 +775,9 @@ class LoggingSettingsView(SettingsFormViewMixin[LoggingConfigForm]):
 
     def form_valid(self, form: LoggingConfigForm) -> HttpResponse:
         """Handle valid logging form submission."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_SYSTEM_CONFIGURATION):
+            raise PermissionDenied
+
         level = form.cleaned_data['loglevel']
         crypto_backend_audit_enabled = bool(form.cleaned_data.get('crypto_backend_audit_enabled'))
         self.logger.info('Changing log level to: %s', level)
@@ -804,6 +822,9 @@ class NotificationSettingsView(SettingsFormViewMixin[NotificationConfigForm]):
 
     def form_valid(self, form: NotificationConfigForm) -> HttpResponse:
         """Handle valid notification form submission."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_SYSTEM_CONFIGURATION):
+            raise PermissionDenied
+
         notification_config = form.instance
         was_enabled = notification_config.enabled
 
@@ -863,12 +884,14 @@ class NotificationSettingsView(SettingsFormViewMixin[NotificationConfigForm]):
         return context
 
 
-class MetricsSettingsView(SettingsFormViewMixin[PrometheusConfigForm]):
+class MetricsSettingsView(UserPermissionRequiredMixin, SettingsFormViewMixin[PrometheusConfigForm]):
     """View for displaying runtime metrics and managing the Prometheus export toggle."""
 
     template_name = 'management/includes/metrics_configuration.html'
     form_class = PrometheusConfigForm
     setting_type = 'metrics'
+    permission_required = AppPermissions.VIEW_METRICS
+
 
     def get_form_kwargs(self) -> dict[str, Any]:
         """Load the singleton PrometheusConfig instance into the form."""
@@ -878,6 +901,8 @@ class MetricsSettingsView(SettingsFormViewMixin[PrometheusConfigForm]):
 
     def form_valid(self, form: PrometheusConfigForm) -> HttpResponse:
         """Save the Prometheus configuration and redirect back to the metrics tab."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_SYSTEM_CONFIGURATION):
+            raise PermissionDenied
         form.save()
         messages.success(self.request, _('Prometheus configuration saved successfully.'))
         return redirect(self.get_success_url())

--- a/trustpoint/management/views/tls.py
+++ b/trustpoint/management/views/tls.py
@@ -388,7 +388,7 @@ class ActivateTlsServerView(View, LoggerMixin):
     def post(self, request: HttpRequest, *args: Any, **kwargs: dict[str, Any]) -> HttpResponse:
         """Handle a valid form submission for TLS Server Credential activation."""
         del args
-        if not self.request.user.has_perm(AppPermissions.MANAGE_TLS_WEBSERVER_CONFIGURATION):
+        if not request.user.has_perm(AppPermissions.MANAGE_TLS_WEBSERVER_CONFIGURATION):
             raise PermissionDenied
         cert_id: int = kwargs['pk']  # type: ignore[assignment]
         self.logger.info('Activating TLS certificate with ID: %s', cert_id)
@@ -421,7 +421,7 @@ class ActivateTlsServerView(View, LoggerMixin):
 class CanManageTls(BasePermission):
     """Allow only users permitted to manage TLS certificates."""
 
-    def has_permission(self, request: Request, view: Any) -> bool:
+    def has_permission(self, request: Request, _view: Any) -> bool:
         """Check if the user has permission to manage TLS certificates."""
         return bool(
             request.user

--- a/trustpoint/management/views/tls.py
+++ b/trustpoint/management/views/tls.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from django.contrib import messages
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied, ValidationError
 from django.db import transaction
 from django.db.models import ProtectedError
 from django.http import HttpResponseRedirect
@@ -19,7 +19,7 @@ from django.views.generic import FormView, TemplateView, View
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import filters, viewsets
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import BasePermission
 
 from management.forms import IPv4AddressForm, TlsAddFileImportPkcs12Form, TlsAddFileImportSeparateFilesForm
 from management.management.commands.update_tls import Command as UpdateTlsCommand
@@ -32,10 +32,12 @@ from setup_wizard.forms import StartupWizardTlsCertificateForm
 from setup_wizard.tls_credential import TlsServerCredentialGenerator
 from trustpoint.logger import LoggerMixin
 from trustpoint.views.base import BulkDeleteView
+from users.permissions import AppPermissions
 
 if TYPE_CHECKING:
     from django.forms import Form
     from django.http import HttpRequest, HttpResponse
+    from rest_framework.request import Request
 
 
 class TlsSettingsContextMixin:
@@ -135,6 +137,8 @@ class TlsView(LoggerMixin, TlsSettingsContextMixin, FormView[IPv4AddressForm]):
 
     def form_valid(self, form: IPv4AddressForm) -> HttpResponse:
         """Handle valid form submissions."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_TLS_WEBSERVER_CONFIGURATION):
+            raise PermissionDenied
         ipv4_address = form.cleaned_data.get('ipv4_address')
         TlsSettings.objects.update_or_create(
             id=1,
@@ -328,6 +332,8 @@ class TlsBulkDeleteConfirmView(TlsSettingsContextMixin, BulkDeleteView):
 
     def form_valid(self, _form: Form) -> HttpResponse:
         """Attempt to delete tls certificates if the form is valid."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_TLS_WEBSERVER_CONFIGURATION):
+            raise PermissionDenied
         queryset = self.get_queryset()
         try:
             active_credential = ActiveTrustpointTlsServerCredentialModel.objects.get(id=1)
@@ -382,6 +388,8 @@ class ActivateTlsServerView(View, LoggerMixin):
     def post(self, request: HttpRequest, *args: Any, **kwargs: dict[str, Any]) -> HttpResponse:
         """Handle a valid form submission for TLS Server Credential activation."""
         del args
+        if not self.request.user.has_perm(AppPermissions.MANAGE_TLS_WEBSERVER_CONFIGURATION):
+            raise PermissionDenied
         cert_id: int = kwargs['pk']  # type: ignore[assignment]
         self.logger.info('Activating TLS certificate with ID: %s', cert_id)
         try:
@@ -410,6 +418,18 @@ class ActivateTlsServerView(View, LoggerMixin):
             messages.error(request, 'An unexpected error occurred while activating TLS certificate')
         return redirect(reverse('management:tls'))
 
+class CanManageTls(BasePermission):
+    """Allow only users permitted to manage TLS certificates."""
+
+    def has_permission(self, request: Request, view: Any) -> bool:
+        """Check if the user has permission to manage TLS certificates."""
+        return bool(
+            request.user
+            and request.user.is_authenticated
+            and request.user.has_perm(AppPermissions.MANAGE_TLS_WEBSERVER_CONFIGURATION)
+        )
+
+
 @extend_schema(tags=['Tls'])
 @extend_schema_view(
     list=extend_schema(description='Retrieve a list of all TLS Certificates.'),
@@ -427,7 +447,7 @@ class TlsViewSet(viewsets.ModelViewSet[Any]):
     """
     queryset = CredentialModel.objects.all().order_by('-created_at')
     serializer_class = CredentialSerializer
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (CanManageTls,)
     filter_backends = (
         DjangoFilterBackend,
         filters.SearchFilter,

--- a/trustpoint/management/views/user_management.py
+++ b/trustpoint/management/views/user_management.py
@@ -25,7 +25,7 @@ from management.serializer.user import UserSerializer
 from trustpoint.logger import LoggerMixin
 from trustpoint.views.base import ContextDataMixin, SortableTableMixin, SuperuserRequiredMixin
 from users.form import TrustpointUserCreationForm, TrustpointUserRoleForm
-from users.models import Role, TrustpointUser
+from users.models import BuiltinRole, TrustpointUser
 from users.permissions import AppPermissions
 
 
@@ -42,8 +42,8 @@ def _is_last_admin(user: TrustpointUser) -> bool:
         True when the user has the ADMIN role and no other admin exists.
     """
     return (
-        user.role.name == Role.ADMIN
-        and get_user_model().objects.filter(role__name=Role.ADMIN).count() == 1
+        user.role.name == BuiltinRole.ADMIN
+        and get_user_model().objects.filter(role__name=BuiltinRole.ADMIN).count() == 1
     )
 
 
@@ -187,7 +187,7 @@ class UserChangeRoleView(
         user: TrustpointUser = self.get_object()
         new_role = form.cleaned_data['role']
 
-        if _is_last_admin(user) and new_role.name != Role.ADMIN:
+        if _is_last_admin(user) and new_role.name != BuiltinRole.ADMIN:
             messages.error(
                 self.request,
                 _('Cannot change role of "%(username)s": at least one admin must remain.')

--- a/trustpoint/management/views/user_management.py
+++ b/trustpoint/management/views/user_management.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from django.contrib import messages
 from django.contrib.auth import get_user_model
+from django.core.exceptions import PermissionDenied
 from django.db.models import QuerySet
 from django.forms import BaseModelForm
 from django.http import HttpResponse, HttpResponseRedirect
@@ -25,6 +26,7 @@ from trustpoint.logger import LoggerMixin
 from trustpoint.views.base import ContextDataMixin, SortableTableMixin, SuperuserRequiredMixin
 from users.form import TrustpointUserCreationForm, TrustpointUserRoleForm
 from users.models import Role, TrustpointUser
+from users.permissions import AppPermissions
 
 
 def _is_last_admin(user: TrustpointUser) -> bool:
@@ -93,6 +95,8 @@ class UserCreateView(
         Returns:
             Redirect to the user management list.
         """
+        if not self.request.user.has_perm(AppPermissions.MANAGE_USERS):
+            raise PermissionDenied
         response = super().form_valid(form)
         username = self.object.username if self.object else ''
         messages.success(
@@ -130,6 +134,9 @@ class UserDeleteView(
             Redirect to the user management list on success, or back to the
             list with an error message if the last admin would be removed.
         """
+        if not self.request.user.has_perm(AppPermissions.MANAGE_USERS):
+            raise PermissionDenied
+
         self.object = self.get_object()
 
         if _is_last_admin(self.object):
@@ -165,6 +172,9 @@ class UserChangeRoleView(
     def form_valid(self, form: BaseModelForm[TrustpointUser]) -> HttpResponse:
         """Save the role change unless it would remove the last admin.
 
+        Raises:
+            PermissionDenied: If the current user does not have permission to manage users.
+
         Args:
             form: The validated role form.
 
@@ -172,6 +182,8 @@ class UserChangeRoleView(
             Redirect to the user management list on success, or re-render the
             form with an error message if the last admin would be downgraded.
         """
+        if not self.request.user.has_perm(AppPermissions.MANAGE_ROLES):
+            raise PermissionDenied
         user: TrustpointUser = self.get_object()
         new_role = form.cleaned_data['role']
 
@@ -198,7 +210,13 @@ class UserViewSet(viewsets.ModelViewSet[TrustpointUser]):
     permission_classes = (IsSuperUser,)
 
     def destroy(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        """Delete the user unless they are the last remaining admin."""
+        """Delete the user unless they are the last remaining admin.
+
+        Raises:
+            PermissionDenied: If the current user does not have permission to manage users.
+        """
+        if not request.user.has_perm(AppPermissions.MANAGE_USERS):
+            raise PermissionDenied
         instance = self.get_object()
         if _is_last_admin(instance):
             return Response(
@@ -208,7 +226,13 @@ class UserViewSet(viewsets.ModelViewSet[TrustpointUser]):
         return super().destroy(request, *args, **kwargs)
 
     def update(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        """Update the user, refusing to change the role of the last remaining admin."""
+        """Update the user, refusing to change the role of the last remaining admin.
+
+        Raises:
+            PermissionDenied: If the current user does not have permission to manage users.
+        """
+        if not request.user.has_perm(AppPermissions.MANAGE_USERS):
+            raise PermissionDenied
         instance = self.get_object()
         new_role = request.data.get('role') if isinstance(request.data, dict) else None
         if _is_last_admin(instance) and new_role is not None and str(new_role) != str(instance.role_id):

--- a/trustpoint/pki/management/commands/reset_db.py
+++ b/trustpoint/pki/management/commands/reset_db.py
@@ -85,7 +85,7 @@ class Command(BaseCommand):
             _add_copyright_headers(migration_name, base_path)
         self.stdout.write('Running migrate...')
         call_command('migrate')
-        call_command('create_admin_group')
+        call_command('create_builtin_groups')
 
         # Add default models for development server
         if engine == ENGINE_SQLITE:

--- a/trustpoint/pki/tests/test_crl.py
+++ b/trustpoint/pki/tests/test_crl.py
@@ -44,7 +44,8 @@ def api_client(issuing_ca_instance: dict[str, Any]) -> tuple[APIClient, Any]:
         content_type__model='apppermission',
         codename='use_rest_api',
     )
-    user.role.permissions.add(permission)
+    manage_cas_permission = Permission.objects.get(codename='manage_cas')
+    user.role.permissions.add(permission, manage_cas_permission)
     
     # Get JWT token
     response = client.post(

--- a/trustpoint/pki/tests/test_crl_cycle_views.py
+++ b/trustpoint/pki/tests/test_crl_cycle_views.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import pytest
 from django.contrib.auth.models import User
+from django.contrib.auth.models import Permission
 from django.test import Client
 from django.urls import reverse
 
@@ -24,6 +25,8 @@ def admin_user() -> User:
         email='admin@test.com',
         password='testpass123'
     )
+    permission = Permission.objects.get(codename='manage_cas')
+    user.role.permissions.add(permission)
     return user
 
 

--- a/trustpoint/pki/tests/test_issuing_ca_mixins.py
+++ b/trustpoint/pki/tests/test_issuing_ca_mixins.py
@@ -90,6 +90,7 @@ def test_request_cert_views_redirect_when_content_is_missing() -> None:
         (IssuingCaRequestCertCmpView, 'pki:issuing_cas-define-cert-content-cmp'),
     ]:
         request = RequestFactory().post('/')
+        request.user = Mock(has_perm=Mock(return_value=True))
         request.session = {}
         view = view_class()
         view.get_object = Mock(return_value=ca)

--- a/trustpoint/pki/tests/test_views_ca_rollover.py
+++ b/trustpoint/pki/tests/test_views_ca_rollover.py
@@ -28,7 +28,7 @@ def request(method: str = 'post', **data: str) -> object:
     """Build a request with an authenticated operator."""
     factory = RequestFactory()
     test_request = getattr(factory, method)('/ca/rollover/', data=data)
-    test_request.user = SimpleNamespace(is_authenticated=True)
+    test_request.user = SimpleNamespace(is_authenticated=True, has_perm=lambda _permission: True)
     return test_request
 
 

--- a/trustpoint/pki/tests/test_views_domains.py
+++ b/trustpoint/pki/tests/test_views_domains.py
@@ -5,6 +5,7 @@
 
 
 import pytest
+from django.contrib.auth.models import Permission
 from django.contrib.messages import get_messages
 from django.urls import reverse
 from django.test import RequestFactory
@@ -26,6 +27,13 @@ from pki.views.domains import (
     IssuedCertificatesView,
     OnboardingMethodSelectIdevidHelpView,
 )
+
+
+@pytest.fixture(autouse=True)
+def grant_domain_management_permission(admin_user) -> None:
+    """Grant the shared domain-test user access to protected domain operations."""
+    permission = Permission.objects.get(codename='manage_domains')
+    admin_user.role.permissions.add(permission)
 
 
 @pytest.mark.django_db

--- a/trustpoint/pki/tests/test_views_truststores.py
+++ b/trustpoint/pki/tests/test_views_truststores.py
@@ -229,6 +229,7 @@ class TestTruststoreCreateViewFormValid:
     def view(self):
         view = TruststoreCreateView()
         view.request = RequestFactory().get('/')
+        view.request.user = Mock(has_perm=Mock(return_value=True))
         return view
 
     @pytest.fixture

--- a/trustpoint/pki/tests/test_views_truststores_extended.py
+++ b/trustpoint/pki/tests/test_views_truststores_extended.py
@@ -11,6 +11,7 @@ import pytest
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.test import Client
 from django.urls import reverse
 
@@ -27,7 +28,10 @@ User = get_user_model()
 def authenticated_client() -> Client:
     """Return a logged-in client."""
     client = Client()
-    client.force_login(User.objects.create_user(username='ts-user', password='ts-pass-123'))  # noqa: S106
+    user = User.objects.create_user(username='ts-user', password='ts-pass-123')  # noqa: S106
+    permission = Permission.objects.get(codename='manage_truststores')
+    user.role.permissions.add(permission)
+    client.force_login(user)
     return client
 
 

--- a/trustpoint/pki/views/ca.py
+++ b/trustpoint/pki/views/ca.py
@@ -7,7 +7,7 @@ import logging
 from typing import Any, cast
 
 from django.contrib import messages
-from django.core.exceptions import ValidationError
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.db.models import ProtectedError, QuerySet
 from django.forms import Form
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
@@ -21,6 +21,7 @@ from pki.filters import CaFilter
 from pki.models import CaModel
 from shared.exports import ExportColumn, ExportConfig, ExportMixin
 from trustpoint.views.base import BulkDeleteView, ContextDataMixin
+from users.permissions import AppPermissions
 
 logger = logging.getLogger(__name__)
 
@@ -175,6 +176,8 @@ class CaBulkDeleteConfirmView(BulkDeleteView):
 
     def form_valid(self, form: Form) -> HttpResponse:  # noqa: ARG002
         """Delete the selected CAs on valid form, handling hierarchical dependencies."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         queryset = self.get_queryset()
         deleted_count = queryset.count() if queryset else 0
 

--- a/trustpoint/pki/views/ca_rollover.py
+++ b/trustpoint/pki/views/ca_rollover.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import gettext as _
 from django.views import View
@@ -19,6 +20,7 @@ from pki.models import CaModel
 from pki.models.ca_rollover import CaRolloverModel, CaRolloverStrategyType
 from pki.rollover.registry import rollover_registry
 from pki.services.ca_rollover import CaRolloverError, CaRolloverService
+from users.permissions import AppPermissions
 
 if TYPE_CHECKING:
     from django.http import HttpRequest, HttpResponse
@@ -36,6 +38,8 @@ class PlanRolloverView(LoginRequiredMixin, View):
 
     def post(self, request: HttpRequest, pk: int) -> HttpResponse:
         """Plan a new rollover for the given Issuing CA."""
+        if not request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         _ensure_strategies_loaded()
         issuing_ca = get_object_or_404(CaModel, pk=pk)
 
@@ -100,6 +104,8 @@ class StartRolloverView(LoginRequiredMixin, View):
 
     def post(self, request: HttpRequest, pk: int, rollover_pk: int) -> HttpResponse:
         """Start the specified rollover."""
+        if not request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         _ensure_strategies_loaded()
         rollover = get_object_or_404(CaRolloverModel, pk=rollover_pk, old_issuing_ca_id=pk)
 
@@ -137,6 +143,8 @@ class TransitionRolloverView(LoginRequiredMixin, View):
 
     def post(self, request: HttpRequest, pk: int, rollover_pk: int) -> HttpResponse:
         """Transition the specified rollover from PREPARATION to TRANSITION."""
+        if not request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         _ensure_strategies_loaded()
         rollover = get_object_or_404(CaRolloverModel, pk=rollover_pk, old_issuing_ca_id=pk)
 
@@ -174,6 +182,8 @@ class CompleteRolloverView(LoginRequiredMixin, View):
 
     def post(self, request: HttpRequest, pk: int, rollover_pk: int) -> HttpResponse:
         """Complete the specified rollover."""
+        if not request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         _ensure_strategies_loaded()
         rollover = get_object_or_404(CaRolloverModel, pk=rollover_pk, old_issuing_ca_id=pk)
 
@@ -208,6 +218,8 @@ class CancelRolloverView(LoginRequiredMixin, View):
 
     def post(self, request: HttpRequest, pk: int, rollover_pk: int) -> HttpResponse:
         """Cancel the specified rollover."""
+        if not request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         _ensure_strategies_loaded()
         rollover = get_object_or_404(CaRolloverModel, pk=rollover_pk, old_issuing_ca_id=pk)
 

--- a/trustpoint/pki/views/cert_profiles.py
+++ b/trustpoint/pki/views/cert_profiles.py
@@ -10,6 +10,7 @@ import json
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from django.contrib import messages
+from django.core.exceptions import PermissionDenied
 from django.db.models import ProtectedError, QuerySet
 from django.forms import ValidationError
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
@@ -21,7 +22,8 @@ from django.views.generic.list import ListView
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import OpenApiExample, extend_schema, extend_schema_view
 from rest_framework import filters, viewsets
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import BasePermission
+from rest_framework.request import Request
 
 from pki.forms import CertificateIssuanceForm, CertProfileConfigForm
 from pki.models import CertificateProfileModel
@@ -33,6 +35,7 @@ from trustpoint.views.base import (
     ContextDataMixin,
     SortableTableMixin,
 )
+from users.permissions import AppPermissions
 
 if TYPE_CHECKING:
     from django.forms import Form
@@ -125,6 +128,8 @@ class CertProfileConfigView(LoggerMixin, CertProfileContextMixin,
 
     def form_valid(self, form: CertProfileConfigForm) -> HttpResponse:
         """Handle the case where the form is valid."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_CERTIFICATE_PROFILES):
+            raise PermissionDenied
         cert_profile = form.save()
         messages.success(
             self.request,
@@ -202,6 +207,8 @@ class CertProfileBulkDeleteConfirmView(CertProfileContextMixin, BulkDeleteView):
 
     def form_valid(self, form: Form) -> HttpResponse:
         """Delete the selected credentials on valid form."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_CERTIFICATE_PROFILES):
+            raise PermissionDenied
         queryset = self.get_queryset()
         deleted_count = queryset.count() if queryset else 0
 
@@ -221,6 +228,17 @@ class CertProfileBulkDeleteConfirmView(CertProfileContextMixin, BulkDeleteView):
                 .format(count=deleted_count))
 
         return response
+
+class CanManageCertificateProfiles(BasePermission):
+    """Allow only users permitted to manage certificate profiles."""
+
+    def has_permission(self, request: Request, view: Any) -> bool:
+        """Check if the user has permission to manage certificate profiles."""
+        return bool(
+            request.user
+            and request.user.is_authenticated
+            and request.user.has_perm(AppPermissions.MANAGE_CERTIFICATE_PROFILES)
+        )
 
 @extend_schema(tags=['Certificate Profile'])
 @extend_schema_view(
@@ -283,7 +301,7 @@ class CertProfileViewSet(viewsets.ModelViewSet[CertificateProfileModel]):
     """
     queryset = CertificateProfileModel.objects.all().order_by('-created_at')
     serializer_class = CertProfileSerializer
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (CanManageCertificateProfiles,)
     filter_backends = (
         DjangoFilterBackend,
         filters.SearchFilter,
@@ -298,5 +316,3 @@ class CertProfileViewSet(viewsets.ModelViewSet[CertificateProfileModel]):
         if self.action == 'retrieve':
             return CertProfileDetailSerializer
         return CertProfileSerializer
-
-

--- a/trustpoint/pki/views/cert_profiles.py
+++ b/trustpoint/pki/views/cert_profiles.py
@@ -23,7 +23,6 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import OpenApiExample, extend_schema, extend_schema_view
 from rest_framework import filters, viewsets
 from rest_framework.permissions import BasePermission
-from rest_framework.request import Request
 
 from pki.forms import CertificateIssuanceForm, CertProfileConfigForm
 from pki.models import CertificateProfileModel
@@ -39,6 +38,7 @@ from users.permissions import AppPermissions
 
 if TYPE_CHECKING:
     from django.forms import Form
+    from rest_framework.request import Request
 
 
 class CertProfileContextMixin(ContextDataMixin):
@@ -232,7 +232,7 @@ class CertProfileBulkDeleteConfirmView(CertProfileContextMixin, BulkDeleteView):
 class CanManageCertificateProfiles(BasePermission):
     """Allow only users permitted to manage certificate profiles."""
 
-    def has_permission(self, request: Request, view: Any) -> bool:
+    def has_permission(self, request: Request, _view: Any) -> bool:
         """Check if the user has permission to manage certificate profiles."""
         return bool(
             request.user

--- a/trustpoint/pki/views/domains.py
+++ b/trustpoint/pki/views/domains.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 from django.contrib import messages
-from django.core.exceptions import ValidationError
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.db.models import ProtectedError
 from django.forms import BaseModelForm
 from django.http import Http404, HttpResponse, HttpResponseRedirect
@@ -22,7 +22,7 @@ from django.views.generic.list import ListView
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import filters, status, viewsets
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import BasePermission
 from rest_framework.response import Response
 from trustpoint_core.oid import AlgorithmIdentifier
 
@@ -47,6 +47,7 @@ from trustpoint.views.base import (
     ListInDetailView,
     SortableTableMixin,
 )
+from users.permissions import AppPermissions
 
 if TYPE_CHECKING:
     from typing import ClassVar
@@ -172,6 +173,8 @@ class DomainCreateView(DomainContextMixin, CreateView[DomainModel, BaseModelForm
 
     def form_valid(self, form: BaseModelForm[DomainModel]) -> HttpResponse:
         """Handle the case where the form is valid."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DOMAINS):
+            raise PermissionDenied
         domain = form.save()
         messages.success(
             self.request,
@@ -251,6 +254,8 @@ class DomainConfigView(DomainContextMixin, DomainDevIdRegistrationTableMixin, Li
 
     def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         """Handle config form submission."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DOMAINS):
+            raise PermissionDenied
         del args
         del kwargs
 
@@ -320,6 +325,8 @@ class DomainCaBulkDeleteConfirmView(DomainContextMixin, BulkDeleteView):
 
     def form_valid(self, form: Form) -> HttpResponse:
         """Attempt to delete domains if the form is valid."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DOMAINS):
+            raise PermissionDenied
         queryset = self.get_queryset()
         deleted_count = queryset.count()
         domains_to_delete = list(queryset)
@@ -425,6 +432,8 @@ class DevIdRegistrationCreateView(DomainContextMixin, FormView[DevIdRegistration
 
     def form_valid(self, form: DevIdRegistrationForm) -> HttpResponse:
         """Handle the case where the form is valid."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DOMAINS):
+            raise PermissionDenied
         dev_id_registration = form.save()
         self.object = dev_id_registration
         messages.success(
@@ -450,6 +459,8 @@ class DevIdRegistrationDeleteView(DomainContextMixin, DeleteView[DevIdRegistrati
 
     def delete(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         """Override delete method to add a success message."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DOMAINS):
+            raise PermissionDenied
         response = super().delete(request, *args, **kwargs)
         messages.success(request, _('DevID Registration Pattern deleted successfully.'))
         return response
@@ -474,6 +485,8 @@ class DevIdMethodSelectView(DomainContextMixin, FormView[DevIdAddMethodSelectFor
 
     def form_valid(self, form: DevIdAddMethodSelectForm) -> HttpResponseRedirect:
         """Redirect to the view for the selected method."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_DOMAINS):
+            raise PermissionDenied
         method_select = form.cleaned_data.get('method_select')
         domain_pk = self.kwargs.get('pk')  # Get domain ID
 
@@ -536,6 +549,17 @@ class OnboardingMethodSelectIdevidHelpView(DomainContextMixin, DetailView[DevIdR
 
         return context
 
+class CanManageDomains(BasePermission):
+    """Allow only users permitted to manage domains."""
+
+    def has_permission(self, request: Request, view: Any) -> bool:
+        """Check if the user has permission to manage domains."""
+        return bool(
+            request.user
+            and request.user.is_authenticated
+            and request.user.has_perm(AppPermissions.MANAGE_DOMAINS)
+        )
+
 @extend_schema(tags=['Domain'])
 @extend_schema_view(
     list=extend_schema(description='Retrieve a list of all domains.'),
@@ -554,13 +578,13 @@ class DomainViewSet(viewsets.ModelViewSet[DomainModel]):
 
     queryset = DomainModel.objects.all()
     serializer_class = DomainSerializer
+    permission_classes = (CanManageDomains,)
 
     def get_serializer_class(self) -> type[DomainDetailSerializer | DomainSerializer]:
         """Return the detail serializer for retrieve, and the list serializer for all other actions."""
         if self.action == 'retrieve':
             return DomainDetailSerializer
         return DomainSerializer
-
 
 @extend_schema(tags=['DevID Registration'])
 @extend_schema_view(
@@ -580,7 +604,7 @@ class DevIdRegistrationViewSet(viewsets.ModelViewSet[DevIdRegistration]):
 
     queryset = DevIdRegistration.objects.all()
     serializer_class = DevIdRegistrationSerializer
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (CanManageDomains,)
     filter_backends = (DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter)
     filterset_fields: ClassVar = ['domain', 'truststore']
     search_fields: ClassVar = ['unique_name', 'serial_number_pattern']

--- a/trustpoint/pki/views/domains.py
+++ b/trustpoint/pki/views/domains.py
@@ -552,7 +552,7 @@ class OnboardingMethodSelectIdevidHelpView(DomainContextMixin, DetailView[DevIdR
 class CanManageDomains(BasePermission):
     """Allow only users permitted to manage domains."""
 
-    def has_permission(self, request: Request, view: Any) -> bool:
+    def has_permission(self, request: Request, _view: Any) -> bool:
         """Check if the user has permission to manage domains."""
         return bool(
             request.user

--- a/trustpoint/pki/views/issuing_cas.py
+++ b/trustpoint/pki/views/issuing_cas.py
@@ -1707,7 +1707,7 @@ class CrlDownloadView(IssuingCaContextMixin, DetailView[CaModel]):
 class CanManageIssuingCas(BasePermission):
     """Allow only users permitted to manage issuing CAs."""
 
-    def has_permission(self, request: Request, view: Any) -> bool:
+    def has_permission(self, request: Request, _view: Any) -> bool:
         """Check if the user has permission to manage issuing CAs."""
         return bool(
             request.user

--- a/trustpoint/pki/views/issuing_cas.py
+++ b/trustpoint/pki/views/issuing_cas.py
@@ -14,7 +14,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa  # noqa: TC002
 from django.contrib import messages
-from django.core.exceptions import ValidationError
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.db.models import ProtectedError
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
@@ -34,7 +34,7 @@ from drf_spectacular.utils import (
 )
 from rest_framework import filters, status, viewsets
 from rest_framework.decorators import action
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import BasePermission, IsAuthenticated
 from rest_framework.response import Response
 
 from management.models.audit_log import AuditLog
@@ -73,6 +73,7 @@ from trustpoint.views.base import (
     ContextDataMixin,
     SortableTableMixin,
 )
+from users.permissions import AppPermissions
 
 if TYPE_CHECKING:
     from django.db.models import QuerySet
@@ -167,6 +168,8 @@ class IssuingCaAddFileImportPkcs12View(IssuingCaContextMixin, FormView[IssuingCa
 
     def form_valid(self, form: IssuingCaAddFileImportPkcs12Form) -> HttpResponse:
         """Handle the case where the form is valid."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         messages.success(
             self.request,
             _('Successfully added Issuing CA {name}.').format(name=form.cleaned_data['unique_name']),
@@ -192,6 +195,8 @@ class IssuingCaAddFileImportSeparateFilesView(IssuingCaContextMixin, FormView[Is
 
     def form_valid(self, form: IssuingCaAddFileImportSeparateFilesForm) -> HttpResponse:
         """Handle the case where the form is valid."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         messages.success(
             self.request,
             _('Successfully added Issuing CA {name}.').format(name=form.cleaned_data['unique_name']),
@@ -216,6 +221,8 @@ class IssuingCaAddRequestEstView(IssuingCaContextMixin, FormView[IssuingCaAddReq
 
     def form_valid(self, form: IssuingCaAddRequestEstForm) -> HttpResponse:
         """Handle successful form submission."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         ca = form.save()
         messages.success(
             self.request,
@@ -267,6 +274,8 @@ class IssuingCaTruststoreAssociationView(IssuingCaContextMixin, FormView[Issuing
 
     def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         """Handle both association and import form submissions."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         if 'trust_store_file' in request.FILES:
             return self._handle_import(request)
         return super().post(request, *args, **kwargs)
@@ -405,6 +414,8 @@ class IssuingCaTruststoreAssociationView(IssuingCaContextMixin, FormView[Issuing
 
     def form_valid(self, form: IssuingCaTruststoreAssociationForm) -> HttpResponse:
         """Handle successful form submission."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         form.save()
         ca = self.get_ca()
 
@@ -434,6 +445,7 @@ class IssuingCaTruststoreAssociationView(IssuingCaContextMixin, FormView[Issuing
 class IssuingCaDefineCertContentMixin(LoggerMixin, IssuingCaContextMixin):
     """Mixin for defining certificate content using a certificate profile."""
 
+    request: HttpRequest
     ca_type_filter: CaModel.CaTypeChoice
     redirect_url_name: str
     available_profiles: list[CertificateProfileModel]
@@ -466,6 +478,8 @@ class IssuingCaDefineCertContentMixin(LoggerMixin, IssuingCaContextMixin):
 
     def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         """Dispatch the request, ensuring the CA and profile exist."""
+        if not request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         self.ca = get_object_or_404(
             CaModel.objects.filter(ca_type=self.ca_type_filter),
             pk=kwargs['pk']
@@ -500,16 +514,18 @@ class IssuingCaDefineCertContentMixin(LoggerMixin, IssuingCaContextMixin):
         """Handle the case where the form is invalid."""
         for field, errors in form.errors.items():
             for error in errors:
-                messages.error(self.request, f'{field}: {error}')  # type: ignore[attr-defined]
+                messages.error(self.request, f'{field}: {error}')
         return super().form_invalid(form)  # type: ignore[misc,no-any-return]
 
     def form_valid(self, form: CertificateIssuanceForm) -> HttpResponse:
         """Handle the case where the form is valid."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         self.logger.info('Form cleaned_data: %s', form.cleaned_data)
-        self.request.session[f'cert_content_data_{self.ca.pk}'] = form.cleaned_data # type: ignore[attr-defined]
-        self.request.session[f'cert_profile_pk_{self.ca.pk}'] = self.cert_profile.pk  # type: ignore[attr-defined]
+        self.request.session[f'cert_content_data_{self.ca.pk}'] = form.cleaned_data
+        self.request.session[f'cert_profile_pk_{self.ca.pk}'] = self.cert_profile.pk
         messages.success(
-            self.request, # type: ignore[attr-defined]
+            self.request,
             self.get_success_message()
         )
         return redirect(self.redirect_url_name, pk=self.ca.pk)
@@ -536,14 +552,18 @@ class IssuingCaDefineCertContentEstView(IssuingCaDefineCertContentMixin, FormVie
 class RemoteRaAddRequestCmpMixin(IssuingCaContextMixin):
     """Mixin for CMP RA configuration views."""
 
+    request: HttpRequest
+
     def form_valid(self, form: IssuingCaAddRequestCmpForm) -> HttpResponse:
         """Handle successful CMP RA configuration submission."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_RAS):
+            raise PermissionDenied
         ca = form.save(is_ra_mode=True)
         messages.success(
-            self.request,  # type: ignore[attr-defined]
+            self.request,
             _('Successfully configured CMP RA {name}. Please associate a trust store.').format(name=ca.unique_name)
         )
-        actor = self.request.user if self.request.user.is_authenticated else None  # type: ignore[attr-defined]
+        actor = self.request.user if self.request.user.is_authenticated else None
         AuditLog.create_entry(
             operation_type=AuditLog.OperationType.CA_CREATED,
             target=ca,
@@ -561,6 +581,8 @@ class IssuingCaAddRequestCmpView(IssuingCaContextMixin, FormView[IssuingCaAddReq
 
     def form_valid(self, form: IssuingCaAddRequestCmpForm) -> HttpResponse:
         """Handle successful form submission."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         ca = form.save()
         messages.success(
             self.request,
@@ -588,16 +610,20 @@ class RemoteRaAddRequestCmpView(RemoteRaAddRequestCmpMixin, FormView[IssuingCaAd
 class RemoteRaAddRequestEstMixin(IssuingCaContextMixin):
     """Mixin for EST RA configuration views."""
 
+    request: HttpRequest
+
     def form_valid(self, form: IssuingCaAddRequestEstForm) -> HttpResponse:
         """Handle successful EST RA configuration submission."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_RAS):
+            raise PermissionDenied
         ca = form.save(is_ra_mode=True)
         messages.success(
-            self.request,  # type: ignore[attr-defined]
+            self.request,
             _('Successfully configured EST RA {name}. Please associate the CA chain trust store.').format(
                 name=ca.unique_name
             )
         )
-        actor = self.request.user if self.request.user.is_authenticated else None  # type: ignore[attr-defined]
+        actor = self.request.user if self.request.user.is_authenticated else None
         AuditLog.create_entry(
             operation_type=AuditLog.OperationType.CA_CREATED,
             target=ca,
@@ -706,6 +732,8 @@ class IssuingCaConfigView(LoggerMixin, IssuingCaContextMixin, DetailView[CaModel
 
     def post(self, request: HttpRequest, *_args: Any, **_kwargs: Any) -> HttpResponse:
         """Handle POST request to update CRL cycle settings."""
+        if not request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         issuing_ca = self.get_object()
         self.object = issuing_ca
 
@@ -992,6 +1020,8 @@ class IssuingCaRequestCertEstView(IssuingCaRequestCertMixin, DetailView[CaModel]
 
     def post(self, request: HttpRequest, *_args: Any, **_kwargs: Any) -> HttpResponse:
         """Handle POST request to request certificate via EST."""
+        if not request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         ca = self.get_object()
 
         cert_content_key = f'cert_content_data_{ca.pk}'
@@ -1186,6 +1216,8 @@ class IssuingCaRequestCertCmpView(IssuingCaRequestCertMixin, DetailView[CaModel]
 
     def post(self, request: HttpRequest, *_args: Any, **_kwargs: Any) -> HttpResponse:
         """Handle POST request to request certificate via CMP."""
+        if not request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         ca = self.get_object()
 
         cert_content_key = f'cert_content_data_{ca.pk}'
@@ -1561,6 +1593,8 @@ class IssuingCaBulkDeleteConfirmView(IssuingCaContextMixin, BulkDeleteView):
 
     def form_valid(self, form: Form) -> HttpResponse:
         """Delete the selected Issuing CAs on valid form."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         queryset = self.get_queryset()
         deleted_count = queryset.count() if queryset else 0
 
@@ -1670,6 +1704,17 @@ class CrlDownloadView(IssuingCaContextMixin, DetailView[CaModel]):
             response['Content-Disposition'] = f'attachment; filename="{ca.unique_name}.crl"'
         return response
 
+class CanManageIssuingCas(BasePermission):
+    """Allow only users permitted to manage issuing CAs."""
+
+    def has_permission(self, request: Request, view: Any) -> bool:
+        """Check if the user has permission to manage issuing CAs."""
+        return bool(
+            request.user
+            and request.user.is_authenticated
+            and request.user.has_perm(AppPermissions.MANAGE_CAS)
+        )
+
 @extend_schema(tags=['Issuing-CA'])
 class IssuingCaViewSet(LoggerMixin, viewsets.ModelViewSet[CaModel]):
     """ViewSet for managing Issuing CA instances via REST API."""
@@ -1678,7 +1723,7 @@ class IssuingCaViewSet(LoggerMixin, viewsets.ModelViewSet[CaModel]):
         ca_type__in=[CaModel.CaTypeChoice.KEYLESS, CaModel.CaTypeChoice.AUTOGEN_ROOT]
     ).order_by('-created_at')
     serializer_class = IssuingCaSerializer
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (CanManageIssuingCas,)
     filter_backends = (
         DjangoFilterBackend,
         filters.SearchFilter,
@@ -1884,6 +1929,8 @@ class IssuingCaViewSet(LoggerMixin, viewsets.ModelViewSet[CaModel]):
     )
     def generate_crl(self, _request: Request, pk: int | None = None, **_kwargs: Any) -> Response:
         """Generate a new CRL for this Issuing CA."""
+        if not _request.user.has_perm(AppPermissions.MANAGE_CAS):
+            raise PermissionDenied
         del pk # not needed, but passed by DRF
         ca = self.get_object()
 

--- a/trustpoint/pki/views/truststores.py
+++ b/trustpoint/pki/views/truststores.py
@@ -6,7 +6,7 @@
 from typing import Any, ClassVar, cast
 
 from django.contrib import messages
-from django.core.exceptions import ValidationError
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.db.models import ProtectedError, QuerySet
 from django.forms import Form
 from django.http import Http404, HttpRequest, HttpResponse, HttpResponseRedirect
@@ -21,7 +21,7 @@ from django.views.generic.list import ListView
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import filters, status, viewsets
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 from rest_framework.response import Response
 from trustpoint_core.archiver import ArchiveFormat, Archiver
@@ -42,6 +42,7 @@ from trustpoint.views.base import (
     PrimaryKeyListFromPrimaryKeyString,
     SortableTableMixin,
 )
+from users.permissions import AppPermissions
 
 # Import DeviceModel for runtime use
 try:
@@ -148,6 +149,8 @@ class TruststoreCreateView(TruststoresContextMixin, FormView[TruststoreAddForm])
 
     def form_valid(self, form: TruststoreAddForm) -> HttpResponseRedirect:
         """If the form is valid, redirect to Truststore overview."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_TRUSTSTORES):
+            raise PermissionDenied
         truststore = form.cleaned_data['truststore']
         domain_id = self.kwargs.get('pk')
 
@@ -420,6 +423,8 @@ class TruststoreBulkDeleteConfirmView(TruststoresContextMixin, BulkDeleteView):
 
     def form_valid(self, form: Form) -> HttpResponse:
         """Attempts to delete the selected truststores on valid form."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_TRUSTSTORES):
+            raise PermissionDenied
         queryset = self.get_queryset()
         deleted_count = queryset.count()
 
@@ -440,6 +445,17 @@ class TruststoreBulkDeleteConfirmView(TruststoresContextMixin, BulkDeleteView):
 
         return response
 
+class CanManageTruststores(BasePermission):
+    """Allow only users permitted to manage truststores."""
+
+    def has_permission(self, request: Request, view: Any) -> bool:
+        """Check if the user has permission to manage truststores."""
+        return bool(
+            request.user
+            and request.user.is_authenticated
+            and request.user.has_perm(AppPermissions.MANAGE_TRUSTSTORES)
+        )
+
 @extend_schema(tags=['Truststore'])
 @extend_schema_view(
     retrieve=extend_schema(description='Retrieve a single Truststore by id.'),
@@ -456,7 +472,7 @@ class TruststoreViewSet(viewsets.ModelViewSet[TruststoreModel]):
 
     queryset = TruststoreModel.objects.all().order_by('-created_at')
     serializer_class = TruststoreSerializer
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (CanManageTruststores,)
     filter_backends = (DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter)
     filterset_fields: ClassVar = ['intended_usage']
     search_fields: ClassVar = ['unique_name']

--- a/trustpoint/pki/views/truststores.py
+++ b/trustpoint/pki/views/truststores.py
@@ -448,7 +448,7 @@ class TruststoreBulkDeleteConfirmView(TruststoresContextMixin, BulkDeleteView):
 class CanManageTruststores(BasePermission):
     """Allow only users permitted to manage truststores."""
 
-    def has_permission(self, request: Request, view: Any) -> bool:
+    def has_permission(self, request: Request, _view: Any) -> bool:
         """Check if the user has permission to manage truststores."""
         return bool(
             request.user

--- a/trustpoint/signer/api_views.py
+++ b/trustpoint/signer/api_views.py
@@ -11,7 +11,6 @@ from typing import Any, ClassVar
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
 from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
-from django.http import HttpRequest
 from drf_spectacular.utils import (
     OpenApiResponse,
     extend_schema,
@@ -36,7 +35,7 @@ from users.permissions import AppPermissions
 class CanManageTruststores(BasePermission):
     """Allow only users permitted to manage signer settings."""
 
-    def has_permission(self, request: Request, view: Any) -> bool:
+    def has_permission(self, request: Request, _view: Any) -> bool:
         """Check if the user has permission to manage signer settings."""
         return bool(
             request.user

--- a/trustpoint/signer/api_views.py
+++ b/trustpoint/signer/api_views.py
@@ -11,13 +11,14 @@ from typing import Any, ClassVar
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
 from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
+from django.http import HttpRequest
 from drf_spectacular.utils import (
     OpenApiResponse,
     extend_schema,
 )
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import BasePermission, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -29,7 +30,19 @@ from signer.serializers import (
     SignHashRequestSerializer,
 )
 from trustpoint.logger import LoggerMixin
+from users.permissions import AppPermissions
 
+
+class CanManageTruststores(BasePermission):
+    """Allow only users permitted to manage signer settings."""
+
+    def has_permission(self, request: Request, view: Any) -> bool:
+        """Check if the user has permission to manage signer settings."""
+        return bool(
+            request.user
+            and request.user.is_authenticated
+            and request.user.has_perm(AppPermissions.MANAGE_SIGNER)
+        )
 
 @extend_schema(tags=['Signer'])
 class SignerViewSet(LoggerMixin, viewsets.ReadOnlyModelViewSet[SignerModel]):
@@ -37,7 +50,7 @@ class SignerViewSet(LoggerMixin, viewsets.ReadOnlyModelViewSet[SignerModel]):
 
     queryset = SignerModel.objects.all()
     serializer_class = SignerSerializer
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (CanManageTruststores,)
 
     @extend_schema(
         methods=['post'],

--- a/trustpoint/signer/tests/test_api_views.py
+++ b/trustpoint/signer/tests/test_api_views.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock, patch
 from cryptography import x509
 from cryptography.hazmat.primitives.asymmetric import rsa, ec
 from cryptography.x509.oid import NameOID
+from django.contrib.auth.models import Permission
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -30,6 +31,8 @@ def authenticated_client(api_client):
     from django.contrib.auth import get_user_model
     User = get_user_model()
     user = User.objects.create_user(username='testuser', password='testpass123')
+    manage_signer_perm = Permission.objects.get(codename='manage_signer')
+    user.role.permissions.add(manage_signer_perm)
     api_client.force_authenticate(user=user)
     return api_client
 

--- a/trustpoint/signer/tests/test_views.py
+++ b/trustpoint/signer/tests/test_views.py
@@ -143,6 +143,7 @@ class TestSignerAddMethodSelectView:
         from signer.forms import SignerAddMethodSelectForm
 
         request = request_factory.post(reverse('signer:signer-add-method_select'))
+        request.user = Mock(has_perm=Mock(return_value=True))
         view = SignerAddMethodSelectView()
         view.request = request
 
@@ -166,6 +167,7 @@ class TestSignerAddFileImportFileTypeSelectView:
         from signer.forms import SignerAddFileTypeSelectForm
         
         request = request_factory.post(reverse('signer:signer-add-file_import-file_type_select'))
+        request.user = Mock(has_perm=Mock(return_value=True))
         view = SignerAddFileImportFileTypeSelectView()
         view.request = request
         
@@ -181,6 +183,7 @@ class TestSignerAddFileImportFileTypeSelectView:
         from signer.forms import SignerAddFileTypeSelectForm
 
         request = request_factory.post(reverse('signer:signer-add-file_import-file_type_select'))
+        request.user = Mock(has_perm=Mock(return_value=True))
         view = SignerAddFileImportFileTypeSelectView()
         view.request = request
 

--- a/trustpoint/signer/views.py
+++ b/trustpoint/signer/views.py
@@ -9,7 +9,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
 from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
 from django.contrib import messages
-from django.core.exceptions import ValidationError
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.db.models import ProtectedError, QuerySet
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
@@ -32,6 +32,7 @@ from signer.models import SignedMessageModel, SignerModel
 from trustpoint.logger import LoggerMixin
 from trustpoint.settings import UIConfig
 from trustpoint.views.base import BulkDeleteView, ContextDataMixin, SortableTableMixin
+from users.permissions import AppPermissions
 
 
 class SignerContextMixin(ContextDataMixin):
@@ -57,6 +58,8 @@ class SignerAddMethodSelectView(SignerContextMixin, FormView[SignerAddMethodSele
 
     def form_valid(self, form: SignerAddMethodSelectForm) -> HttpResponseRedirect:
         """Redirect to the next step based on the selected method."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_SIGNER):
+            raise PermissionDenied
         method_select = form.cleaned_data.get('method_select')
         if not method_select:
             return HttpResponseRedirect(reverse_lazy('signer:signer-add-method_select'))
@@ -78,6 +81,8 @@ class SignerGenerateView(SignerContextMixin, FormView[SignerGenerateForm]):
 
     def form_valid(self, form: SignerGenerateForm) -> HttpResponse:
         """Generate the signer and create an audit-log entry."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_SIGNER):
+            raise PermissionDenied
         signer = form.save()
         user = getattr(self.request, 'user', None)
         actor = user if user is not None and user.is_authenticated else None
@@ -103,6 +108,8 @@ class SignerAddFileImportFileTypeSelectView(SignerContextMixin, FormView[SignerA
 
     def form_valid(self, form: SignerAddFileTypeSelectForm) -> HttpResponseRedirect:
         """Redirect to the next step based on the selected file type."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_SIGNER):
+            raise PermissionDenied
         method_select = form.cleaned_data.get('method_select')
         if not method_select:
             return HttpResponseRedirect(reverse_lazy('signer:signer-add-file_import-file_type_select'))
@@ -124,6 +131,8 @@ class SignerAddFileImportPkcs12View(SignerContextMixin, FormView[SignerAddFileIm
 
     def form_valid(self, form: SignerAddFileImportPkcs12Form) -> HttpResponse:
         """Handle the case where the form is valid."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_SIGNER):
+            raise PermissionDenied
         signer = form.created_signer
         user = getattr(self.request, 'user', None)
         actor = user if user is not None and user.is_authenticated else None
@@ -150,6 +159,8 @@ class SignerAddFileImportSeparateFilesView(SignerContextMixin, FormView[SignerAd
 
     def form_valid(self, form: SignerAddFileImportSeparateFilesForm) -> HttpResponse:
         """Handle the case where the form is valid."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_SIGNER):
+            raise PermissionDenied
         signer = form.created_signer
         user = getattr(self.request, 'user', None)
         actor = user if user is not None and user.is_authenticated else None
@@ -239,6 +250,8 @@ class SignerBulkDeleteConfirmView(SignerContextMixin, BulkDeleteView):
 
     def form_valid(self, form: Any) -> HttpResponse:
         """Delete the selected Signers on valid form."""
+        if not self.request.user.has_perm(AppPermissions.MANAGE_SIGNER):
+            raise PermissionDenied
         queryset = self.get_queryset()
         signers_to_delete = list(queryset)
         deleted_count = len(signers_to_delete)

--- a/trustpoint/templates/management/role_edit.html
+++ b/trustpoint/templates/management/role_edit.html
@@ -26,7 +26,7 @@
                     {# --- Name field (read-only for protected roles) --- #}
                     <div class="mb-3">
                         <label for="{{ form.name.id_for_label }}" class="form-label">{{ form.name.label }}</label>
-                        {% if is_protected %}
+                            {% if is_modification_protected %}
                             <input type="text" class="form-control" value="{{ object.name }}" readonly>
                             <input type="hidden" name="name" value="{{ object.name }}">
                         {% else %}
@@ -43,7 +43,7 @@
 
                     {# --- Staff / Superuser checkboxes --- #}
                     <div class="mb-3 form-check">
-                        {% if is_protected %}
+                            {% if is_modification_protected %}
                             <input type="checkbox" class="form-check-input" {% if form.grants_staff.value %}checked{% endif %} disabled>
                             <input type="hidden" name="grants_staff" value="{{ form.grants_staff.value|yesno:'on,' }}">
                         {% else %}
@@ -55,7 +55,7 @@
                         {% endif %}
                     </div>
                     <div class="mb-3 form-check">
-                        {% if is_protected %}
+                            {% if is_modification_protected %}
                             <input type="checkbox" class="form-check-input" id="superuser-check" {% if form.grants_superuser.value %}checked{% endif %} disabled>
                             <input type="hidden" name="grants_superuser" value="{{ form.grants_superuser.value|yesno:'on,' }}">
                         {% else %}
@@ -68,9 +68,9 @@
                     </div>
 
                     {# --- Permissions dual-listbox (hidden when superuser is checked) --- #}
-                    {% if is_protected %}
-                        <div class="mb-3">
-                            <label class="form-label">{% trans 'Permissions' %}</label>
+                    {% if is_modification_protected %}
+                            <div class="mb-3">
+                                <label class="form-label">{% trans 'Permissions' %}</label>
                             <ul class="list-group">
                                 {% for permission in fixed_permissions %}
                                     <li class="list-group-item">{{ permission.name }}</li>
@@ -85,12 +85,12 @@
 
                     <div class="d-flex justify-content-end gap-2 mt-4">
                         <a href="{% url 'management:role_management' %}" class="btn btn-secondary">{% trans "Cancel" %}</a>
-                        {% if not is_protected %}
+                            {% if not is_modification_protected %}
                             <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
                         {% endif %}
                     </div>
                 </form>
-                {% if not is_protected %}
+                {% if not is_modification_protected %}
                     <script>
                     (function () {
                         const cb = document.getElementById('superuser-check') || document.getElementById('{{ form.grants_superuser.id_for_label }}');

--- a/trustpoint/users/form.py
+++ b/trustpoint/users/form.py
@@ -12,7 +12,7 @@ from django.utils.translation import gettext_lazy as _
 
 from management.models.organization import OrganizationModel
 
-from .models import GroupProfile, Role, TrustpointUser
+from .models import BuiltinRole, GroupProfile, TrustpointUser
 
 
 class TrustpointSuperUserCreationForm(UserCreationForm[TrustpointUser]):
@@ -57,7 +57,7 @@ class TrustpointUserCreationForm(UserCreationForm[TrustpointUser]):
         self.fields['email'].required = False
         self.fields['email'].label = _('Email (optional)')
         role_field = cast('forms.ModelChoiceField[Group]', self.fields['role'])
-        role_field.queryset = Group.objects.exclude(name=Role.SERVICE.value)
+        role_field.queryset = Group.objects.exclude(name=BuiltinRole.SERVICE.value)
         organization_field = cast('forms.ModelChoiceField[OrganizationModel]', self.fields['organization'])
         organization_field.required = False
         organization_field.queryset = OrganizationModel.objects.all()

--- a/trustpoint/users/management/commands/create_admin_group.py
+++ b/trustpoint/users/management/commands/create_admin_group.py
@@ -6,7 +6,7 @@
 from django.contrib.auth.models import Group
 from django.core.management import BaseCommand
 
-from users.models import GroupProfile, Role
+from users.models import BuiltinRole, GroupProfile
 
 
 class Command(BaseCommand):
@@ -16,12 +16,12 @@ class Command(BaseCommand):
 
     def handle(self, *_args: object, **_options: object) -> None:
         """Execute the command."""
-        group, created = Group.objects.get_or_create(name=Role.ADMIN.value)
+        group, created = Group.objects.get_or_create(name=BuiltinRole.ADMIN.value)
         GroupProfile.objects.get_or_create(
             group=group,
             defaults={'grants_staff': True, 'grants_superuser': True},
         )
-        service_group = Role.get_service_group()
+        service_group = BuiltinRole.get_service_group()
         service_created = service_group._state.adding
         GroupProfile.objects.get_or_create(
             group=service_group,

--- a/trustpoint/users/management/commands/create_builtin_groups.py
+++ b/trustpoint/users/management/commands/create_builtin_groups.py
@@ -76,7 +76,8 @@ class Command(BaseCommand):
                     'grants_staff': role is BuiltinRole.ADMIN,
                     'grants_superuser': role is BuiltinRole.ADMIN,
                     'is_builtin': True,
-                    'is_protected': role is BuiltinRole.ADMIN,
+                    'is_modification_protected': role is BuiltinRole.ADMIN,
+                    'is_deletion_protected': role in (BuiltinRole.ADMIN, BuiltinRole.SERVICE),
                 },
             )
             group.permissions.set(self._get_permissions(available_permissions, codenames))

--- a/trustpoint/users/management/commands/create_builtin_groups.py
+++ b/trustpoint/users/management/commands/create_builtin_groups.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026 The Trustpoint Project Authors
+# SPDX-License-Identifier: MIT
+
+"""Create Trustpoint's built-in groups with their predefined permissions."""
+
+from collections.abc import Iterable
+
+from django.contrib.auth.models import Group, Permission
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import BaseCommand
+from django.db import transaction
+
+from users.models import AppPermission, BuiltinRole, GroupProfile
+
+
+ROLE_PERMISSION_CODENAMES: dict[BuiltinRole, frozenset[str] | None] = {
+    BuiltinRole.ADMIN: None,
+    BuiltinRole.SERVICE: frozenset({
+        'manage_cas',
+        'manage_ras',
+        'manage_domains',
+        'manage_truststores',
+        'manage_certificate_profiles',
+        'manage_devices',
+    }),
+    BuiltinRole.PKI_ADMIN: frozenset({
+        'manage_crypto_backends',
+        'issue_certificates',
+        'revoke_certificates',
+        'download_credentials',
+        'view_help_pages',
+    }),
+    BuiltinRole.DEVICE_OPERATOR: frozenset({
+        'manage_devices',
+        'download_credentials',
+        'view_help_pages',
+    }),
+    BuiltinRole.SYSTEM_ADMIN: frozenset({
+        'manage_users',
+        'manage_roles',
+        'manage_organizations',
+        'manage_service_accounts',
+        'manage_system_configuration',
+        'manage_security_configuration',
+        'manage_backups',
+        'manage_notifications',
+        'manage_tls_webserver_configuration',
+        'view_metrics',
+    }),
+    BuiltinRole.WORKFLOW_ADMIN: frozenset({'manage_workflows'}),
+    BuiltinRole.WORKFLOW_APPROVER: frozenset({'approve_workflows'}),
+    BuiltinRole.SECURITY_AUDITOR: frozenset({
+        'view_audit_log',
+        'view_system_logs',
+        'view_metrics',
+    }),
+}
+
+
+class Command(BaseCommand):
+    """Create all built-in groups, profiles, and predefined permissions."""
+
+    help = 'Creates all built-in role groups with their predefined permissions.'
+
+    @transaction.atomic
+    def handle(self, *_args: object, **_options: object) -> None:
+        """Create or update every built-in role."""
+        permission_content_type = ContentType.objects.get_for_model(AppPermission)
+        available_permissions = Permission.objects.filter(content_type=permission_content_type)
+
+        for role, codenames in ROLE_PERMISSION_CODENAMES.items():
+            group, created = Group.objects.get_or_create(name=role.value)
+            GroupProfile.objects.update_or_create(
+                group=group,
+                defaults={
+                    'grants_staff': role is BuiltinRole.ADMIN,
+                    'grants_superuser': role is BuiltinRole.ADMIN,
+                    'is_builtin': True,
+                    'is_protected': role is BuiltinRole.ADMIN,
+                },
+            )
+            group.permissions.set(self._get_permissions(available_permissions, codenames))
+            action = 'Created' if created else 'Updated'
+            self.stdout.write(f'{action} {role.value} role.')
+
+    @staticmethod
+    def _get_permissions(
+        available_permissions: Iterable[Permission],
+        codenames: frozenset[str] | None,
+    ) -> Iterable[Permission]:
+        """Return all permissions for Admin or the configured subset for a role."""
+        if codenames is None:
+            return available_permissions
+        return (permission for permission in available_permissions if permission.codename in codenames)

--- a/trustpoint/users/management/commands/create_service_account.py
+++ b/trustpoint/users/management/commands/create_service_account.py
@@ -11,7 +11,7 @@ from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import Group
 from django.core.management.base import BaseCommand
 
-from users.models import Role, ServiceAccountCredential, TrustpointUser
+from users.models import BuiltinRole, ServiceAccountCredential, TrustpointUser
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser
@@ -32,8 +32,8 @@ class Command(BaseCommand):
         parser.add_argument(
             '--role',
             type=str,
-            default=Role.SERVICE.value,
-            help=f'Role/group name for the service account (default: {Role.SERVICE.value})',
+            default=BuiltinRole.SERVICE.value,
+            help=f'Role/group name for the service account (default: {BuiltinRole.SERVICE.value})',
         )
         parser.add_argument(
             '--description',

--- a/trustpoint/users/middleware.py
+++ b/trustpoint/users/middleware.py
@@ -65,10 +65,4 @@ class ServiceAccountMiddleware:
         Returns:
             True if it's an API path.
         """
-        api_prefixes = [
-            '/api/',
-            '/rest/',
-            '/.well-known/',
-            '/aoki/',
-        ]
-        return any(path.startswith(prefix) for prefix in api_prefixes)
+        return path.startswith('/api/')

--- a/trustpoint/users/migrations/0003_tp_v1_0_dev0.py
+++ b/trustpoint/users/migrations/0003_tp_v1_0_dev0.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 The Trustpoint Project Authors
+# SPDX-License-Identifier: MIT
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0002_tp_v1_0_dev0'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='apppermission',
+            options={'default_permissions': (), 'managed': False, 'permissions': [('manage_users', 'Can manage users'), ('manage_roles', 'Can manage roles'), ('manage_organizations', 'Can manage organizations'), ('manage_service_accounts', 'Can manage service accounts'), ('use_rest_api', 'Can use the REST API'), ('manage_cas', 'Can manage certificate authorities'), ('manage_ras', 'Can manage registration authorities'), ('manage_domains', 'Can manage domains'), ('manage_truststores', 'Can manage trust stores'), ('manage_certificate_profiles', 'Can manage certificate profiles'), ('manage_crypto_backends', 'Can manage cryptographic backends'), ('issue_certificates', 'Can issue certificates'), ('revoke_certificates', 'Can revoke certificates'), ('download_credentials', 'Can download private credentials'), ('view_help_pages', 'Can view help pages'), ('manage_devices', 'Can manage devices'), ('manage_certificate_discovery', 'Can manage certificate discovery'), ('manage_signer', 'Can manage signer'), ('manage_workflows', 'Can manage workflows'), ('approve_workflows', 'Can approve workflows'), ('manage_system_configuration', 'Can manage system configuration'), ('manage_security_configuration', 'Can manage security configuration'), ('manage_backups', 'Can manage backups'), ('manage_notifications', 'Can manage notification settings'), ('manage_tls_webserver_configuration', 'Can manage TLS webserver configuration'), ('view_audit_log', 'Can view the audit log'), ('view_system_logs', 'Can view system logs'), ('view_metrics', 'Can view system metrics')]},
+        ),
+        migrations.AddField(
+            model_name='groupprofile',
+            name='is_builtin',
+            field=models.BooleanField(default=False, help_text='Identifies a role provided by Trustpoint.', verbose_name='built-in role'),
+        ),
+        migrations.AddField(
+            model_name='groupprofile',
+            name='is_protected',
+            field=models.BooleanField(default=False, help_text='Prevents the role from being modified or deleted.', verbose_name='protected role'),
+        ),
+    ]

--- a/trustpoint/users/migrations/0004_tp_v1_0_dev0.py
+++ b/trustpoint/users/migrations/0004_tp_v1_0_dev0.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 The Trustpoint Project Authors
+# SPDX-License-Identifier: MIT
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0003_tp_v1_0_dev0'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='groupprofile',
+            name='is_protected',
+        ),
+        migrations.AddField(
+            model_name='groupprofile',
+            name='is_deletion_protected',
+            field=models.BooleanField(default=False, help_text='Prevents the role from being deleted.', verbose_name='deletion-protected role'),
+        ),
+        migrations.AddField(
+            model_name='groupprofile',
+            name='is_modification_protected',
+            field=models.BooleanField(default=False, help_text='Prevents the role from being modified.', verbose_name='modification-protected role'),
+        ),
+    ]

--- a/trustpoint/users/models.py
+++ b/trustpoint/users/models.py
@@ -83,10 +83,15 @@ class GroupProfile(models.Model):
         verbose_name=_('built-in role'),
         help_text=_('Identifies a role provided by Trustpoint.'),
     )
-    is_protected = models.BooleanField(
+    is_modification_protected = models.BooleanField(
         default=False,
-        verbose_name=_('protected role'),
-        help_text=_('Prevents the role from being modified or deleted.'),
+        verbose_name=_('modification-protected role'),
+        help_text=_('Prevents the role from being modified.'),
+    )
+    is_deletion_protected = models.BooleanField(
+        default=False,
+        verbose_name=_('deletion-protected role'),
+        help_text=_('Prevents the role from being deleted.'),
     )
 
     class Meta:

--- a/trustpoint/users/models.py
+++ b/trustpoint/users/models.py
@@ -11,7 +11,7 @@ is a foreign key to ``django.contrib.auth.models.Group``.
 from __future__ import annotations
 
 import secrets
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from django.apps import apps
 from django.contrib.auth.models import AbstractUser, Group, Permission, UserManager
@@ -237,22 +237,122 @@ class TrustpointUser(AbstractUser):
         self.groups.set([self.role])
 
 class AppPermission(models.Model):
-    """Dummy model used only to host app-level permissions.
+    """Host model for Trustpoint-wide application permissions.
 
-    No database usage beyond auth_permission table.
+    This model is not intended to store database records.
+    Django creates the permissions declared in ``Meta.permissions``
+    in ``auth_permission`` during migrations.
     """
 
     class Meta:
-        """Define permissions."""
+        """Configure the unmanaged application-permission model."""
 
-        default_permissions = ()  # disables add/change/delete/view
-        permissions = (
-            ('manage_workflow', 'Can manage workflow'),
-            ('onboard_device', 'Can onboard device'),
-            ('manage_ca', 'Can manage CA'),
-            ('manage_role', 'Can manage role'),
-            ('use_rest_api', 'Can use REST API'),
-        )
+        managed = False
+        default_permissions = ()
+
+        permissions: ClassVar[list[tuple[str, Any]]] = [
+            # -----------------------------------------------------------------
+            # User and access management
+            # -----------------------------------------------------------------
+            ('manage_users', _('Can manage users')),
+            ('manage_roles', _('Can manage roles')),
+            ('manage_organizations', _('Can manage organizations')),
+            (
+                'manage_service_accounts',
+                _('Can manage service accounts'),
+            ),
+
+            # -----------------------------------------------------------------
+            # PKI configuration
+            # -----------------------------------------------------------------
+            ('manage_cas', _('Can manage certificate authorities')),
+            ('manage_ras', _('Can manage registration authorities')),
+            ('manage_domains', _('Can manage domains')),
+            ('manage_truststores', _('Can manage trust stores')),
+            (
+                'manage_certificate_profiles',
+                _('Can manage certificate profiles'),
+            ),
+            (
+                'manage_crypto_backends',
+                _('Can manage cryptographic backends'),
+            ),
+
+            # -----------------------------------------------------------------
+            # Certificate lifecycle
+            # -----------------------------------------------------------------
+            (
+                'issue_certificates',
+                _('Can issue certificates'),
+            ),
+            (
+                'revoke_certificates',
+                _('Can revoke certificates'),
+            ),
+            (
+                'download_credentials',
+                _('Can download private credentials'),
+            ),
+            (
+                'view_help_pages',
+                _('Can view help pages'),
+            ),
+
+            # -----------------------------------------------------------------
+            # Device lifecycle
+            # -----------------------------------------------------------------
+            ('manage_devices', _('Can manage devices')),
+
+            # -----------------------------------------------------------------
+            # Automation and integration
+            # -----------------------------------------------------------------
+
+            (
+                'manage_certificate_discovery',
+                _('Can manage certificate discovery'),
+            ),
+            (
+                'manage_signer',
+                _('Can manage signer'),
+            ),
+
+            # -----------------------------------------------------------------
+            # Workflow engine
+            # -----------------------------------------------------------------
+            ('manage_workflows', _('Can manage workflows')),
+            (
+                'approve_workflows',
+                _('Can approve workflows'),
+            ),
+
+            # -----------------------------------------------------------------
+            # System administration
+            # -----------------------------------------------------------------
+            (
+                'manage_system_configuration',
+                _('Can manage system configuration'),
+            ),
+            (
+                'manage_security_configuration',
+                _('Can manage security configuration'),
+            ),
+            ('manage_backups', _('Can manage backups')),
+            (
+                'manage_notifications',
+                _('Can manage notification settings'),
+            ),
+            (
+                'manage_tls_webserver_configuration',
+                _('Can manage TLS webserver configuration'),
+            ),
+
+            # -----------------------------------------------------------------
+            # Monitoring and audit
+            # -----------------------------------------------------------------
+            ('view_audit_log', _('Can view the audit log')),
+            ('view_system_logs', _('Can view system logs')),
+            ('view_metrics', _('Can view system metrics')),
+        ]
 
     def __str__(self) -> str:
         """Return a string representation for the AppPermission."""

--- a/trustpoint/users/models.py
+++ b/trustpoint/users/models.py
@@ -3,7 +3,7 @@
 
 """Custom user model with role-based access control.
 
-Defines a ``Role`` enum whose values are human-readable group names
+Defines a ``BuiltinRole`` enum whose values are human-readable group names
 (e.g. ``'Admin'``) and a ``TrustpointUser`` model whose ``role`` field
 is a foreign key to ``django.contrib.auth.models.Group``.
 """
@@ -24,16 +24,18 @@ if TYPE_CHECKING:
     from management.models.organization import OrganizationModel
 
 
-class Role(models.TextChoices):
-    """Predefined roles that map to Django groups.
-
-    The *value* is the canonical Group name stored in the database.
-    Admin is the only protected group and cannot be deleted via the UI.
-    """
+class BuiltinRole(models.TextChoices):
+    """Canonical names of built-in Trustpoint roles."""
 
     ADMIN = 'Admin', _('Admin')
-    DEFAULT = 'Default', _('Default')
     SERVICE = 'Service Account', _('Service Account')
+
+    PKI_ADMIN = 'PKI Administrator', _('PKI Administrator')
+    DEVICE_OPERATOR = 'Device Operator', _('Device Operator')
+    SYSTEM_ADMIN = 'System Administrator', _('System Administrator')
+    WORKFLOW_ADMIN = 'Workflow Administrator', _('Workflow Administrator')
+    WORKFLOW_APPROVER = 'Workflow Approver', _('Workflow Approver')
+    SECURITY_AUDITOR = 'Security Auditor', _('Security Auditor')
 
     @classmethod
     def get_service_group(cls) -> Group:
@@ -76,6 +78,16 @@ class GroupProfile(models.Model):
         verbose_name=_('superuser status'),
         help_text=_('Users with this role have all permissions without explicitly assigning them.'),
     )
+    is_builtin = models.BooleanField(
+        default=False,
+        verbose_name=_('built-in role'),
+        help_text=_('Identifies a role provided by Trustpoint.'),
+    )
+    is_protected = models.BooleanField(
+        default=False,
+        verbose_name=_('protected role'),
+        help_text=_('Prevents the role from being modified or deleted.'),
+    )
 
     class Meta:
         """Metaclass for GroupProfile."""
@@ -116,7 +128,7 @@ class TrustpointUserManager(UserManager['TrustpointUser']):
             The newly created superuser instance.
         """
         if 'role' not in extra_fields and 'role_id' not in extra_fields:
-            admin_group, _ = Group.objects.get_or_create(name=Role.ADMIN.value)
+            admin_group, _ = Group.objects.get_or_create(name=BuiltinRole.ADMIN.value)
             extra_fields['role'] = admin_group
         if 'organization' not in extra_fields:
             extra_fields['organization'] = self._get_default_org()
@@ -142,9 +154,9 @@ class TrustpointUserManager(UserManager['TrustpointUser']):
         """
         if 'role' not in extra_fields and 'role_id' not in extra_fields:
             if extra_fields.get('account_type') == TrustpointUser.AccountType.SERVICE:
-                extra_fields['role'] = Role.get_service_group()
+                extra_fields['role'] = BuiltinRole.get_service_group()
             else:
-                default_group, _ = Group.objects.get_or_create(name=Role.DEFAULT.value)
+                default_group, _ = Group.objects.get_or_create(name=BuiltinRole.DEVICE_OPERATOR.value)
                 extra_fields['role'] = default_group
         if 'organization' not in extra_fields:
             extra_fields['organization'] = self._get_default_org()
@@ -261,6 +273,7 @@ class AppPermission(models.Model):
                 'manage_service_accounts',
                 _('Can manage service accounts'),
             ),
+                ('use_rest_api', _('Can use the REST API')),
 
             # -----------------------------------------------------------------
             # PKI configuration

--- a/trustpoint/users/permissions.py
+++ b/trustpoint/users/permissions.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 The Trustpoint Project Authors
+# SPDX-License-Identifier: MIT
+"""Application-wide permission constants for Trustpoint."""
+
+APP_LABEL = 'users'
+
+
+class AppPermissions:
+    """Canonical Django permission identifiers used throughout Trustpoint."""
+
+    # -------------------------------------------------------------------------
+    # User and access management
+    # -------------------------------------------------------------------------
+    MANAGE_USERS = f'{APP_LABEL}.manage_users' #ok
+    MANAGE_ROLES = f'{APP_LABEL}.manage_roles'#ok
+    MANAGE_ORGANIZATIONS = f'{APP_LABEL}.manage_organizations' #ok
+    MANAGE_SERVICE_ACCOUNTS = f'{APP_LABEL}.manage_service_accounts' #ok
+
+    # -------------------------------------------------------------------------
+    # PKI configuration
+    # -------------------------------------------------------------------------
+    MANAGE_CAS = f'{APP_LABEL}.manage_cas'
+    MANAGE_RAS = f'{APP_LABEL}.manage_ras'
+    MANAGE_DOMAINS = f'{APP_LABEL}.manage_domains'
+    MANAGE_TRUSTSTORES = f'{APP_LABEL}.manage_truststores'
+    MANAGE_CERTIFICATE_PROFILES = f'{APP_LABEL}.manage_certificate_profiles'
+    MANAGE_CRYPTO_BACKENDS = f'{APP_LABEL}.manage_crypto_backends'
+
+    # -------------------------------------------------------------------------
+    # Certificate lifecycle
+    # -------------------------------------------------------------------------
+    ISSUE_CERTIFICATES = f'{APP_LABEL}.issue_certificates'
+    REVOKE_CERTIFICATES = f'{APP_LABEL}.revoke_certificates'
+    DOWNLOAD_CREDENTIALS = f'{APP_LABEL}.download_credentials'
+    VIEW_HELP_PAGES = f'{APP_LABEL}.view_help_pages'
+
+    # -------------------------------------------------------------------------
+    # Device lifecycle
+    # -------------------------------------------------------------------------
+    MANAGE_DEVICES = f'{APP_LABEL}.manage_devices'
+
+    # -------------------------------------------------------------------------
+    # Automation and integration
+    # -------------------------------------------------------------------------
+    MANAGE_CERTIFICATE_DISCOVERY = (
+        f'{APP_LABEL}.manage_certificate_discovery'
+    )
+    MANAGE_SIGNER = f'{APP_LABEL}.manage_signer'
+
+    # -------------------------------------------------------------------------
+    # Workflow engine
+    # -------------------------------------------------------------------------
+    MANAGE_WORKFLOWS = f'{APP_LABEL}.manage_workflows' # OK
+    APPROVE_WORKFLOWS = f'{APP_LABEL}.approve_workflows' # OK
+
+    # -------------------------------------------------------------------------
+    # System administration
+    # -------------------------------------------------------------------------
+    MANAGE_SYSTEM_CONFIGURATION = (
+        f'{APP_LABEL}.manage_system_configuration'
+    )
+    MANAGE_SECURITY_CONFIGURATION = (
+        f'{APP_LABEL}.manage_security_configuration'
+    ) #ok
+    MANAGE_TLS_WEBSERVER_CONFIGURATION = (
+        f'{APP_LABEL}.manage_tls_webserver_configuration'
+    ) #ok
+    MANAGE_BACKUPS = f'{APP_LABEL}.manage_backups' #ok
+    MANAGE_NOTIFICATIONS = f'{APP_LABEL}.manage_notifications' #ok
+
+    # -------------------------------------------------------------------------
+    # Monitoring and audit
+    # -------------------------------------------------------------------------
+    VIEW_AUDIT_LOG = f'{APP_LABEL}.view_audit_log'#ok
+    VIEW_SYSTEM_LOGS = f'{APP_LABEL}.view_system_logs' #ok
+    VIEW_METRICS = f'{APP_LABEL}.view_metrics' #ok

--- a/trustpoint/users/tests/test_management_commands.py
+++ b/trustpoint/users/tests/test_management_commands.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026 The Trustpoint Project Authors
+# SPDX-License-Identifier: MIT
+
+"""Tests for user management commands."""
+
+from io import StringIO
+
+import pytest
+from django.contrib.auth.models import Group, Permission
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import call_command
+
+from users.management.commands.create_builtin_groups import ROLE_PERMISSION_CODENAMES
+from users.models import AppPermission, BuiltinRole, GroupProfile
+
+
+@pytest.mark.django_db
+class TestCreateBuiltinGroupsCommand:
+    """Tests for provisioning built-in groups."""
+
+    def test_creates_builtin_groups_with_predefined_permissions(self) -> None:
+        """Every built-in role has profile metadata and its configured permissions."""
+        content_type = ContentType.objects.get_for_model(AppPermission)
+        for codename in set().union(*(codenames or set() for codenames in ROLE_PERMISSION_CODENAMES.values())):
+            Permission.objects.get_or_create(
+                content_type=content_type,
+                codename=codename,
+                defaults={'name': codename},
+            )
+
+        output = StringIO()
+        call_command('create_builtin_groups', stdout=output)
+
+        assert Group.objects.filter(name__in=BuiltinRole.values).count() == len(BuiltinRole)
+        for role, codenames in ROLE_PERMISSION_CODENAMES.items():
+            group = Group.objects.get(name=role.value)
+            profile = GroupProfile.objects.get(group=group)
+
+            assert profile.is_builtin
+            assert profile.is_protected is (role is BuiltinRole.ADMIN)
+            assert profile.grants_staff is (role is BuiltinRole.ADMIN)
+            assert profile.grants_superuser is (role is BuiltinRole.ADMIN)
+            if codenames is not None:
+                assert set(group.permissions.values_list('codename', flat=True)) == codenames
+
+        call_command('create_builtin_groups', stdout=output)
+        assert Group.objects.filter(name__in=BuiltinRole.values).count() == len(BuiltinRole)

--- a/trustpoint/users/tests/test_management_commands.py
+++ b/trustpoint/users/tests/test_management_commands.py
@@ -37,7 +37,8 @@ class TestCreateBuiltinGroupsCommand:
             profile = GroupProfile.objects.get(group=group)
 
             assert profile.is_builtin
-            assert profile.is_protected is (role is BuiltinRole.ADMIN)
+            assert profile.is_modification_protected is (role is BuiltinRole.ADMIN)
+            assert profile.is_deletion_protected is (role in (BuiltinRole.ADMIN, BuiltinRole.SERVICE))
             assert profile.grants_staff is (role is BuiltinRole.ADMIN)
             assert profile.grants_superuser is (role is BuiltinRole.ADMIN)
             if codenames is not None:

--- a/trustpoint/users/tests/test_service_accounts.py
+++ b/trustpoint/users/tests/test_service_accounts.py
@@ -19,7 +19,8 @@ from rest_framework.test import APIClient
 from rest_framework_simplejwt.tokens import AccessToken
 
 from users.authentication import ServiceAccountBackend
-from users.models import Role, ServiceAccountCredential, TrustpointUser
+from users.middleware import ServiceAccountMiddleware
+from users.models import BuiltinRole, ServiceAccountCredential, TrustpointUser
 
 if TYPE_CHECKING:
     from management.models.organization import OrganizationModel
@@ -35,7 +36,7 @@ def organization(db: object) -> OrganizationModel:
 @pytest.fixture
 def service_role(db: object) -> Group:
     """Create a role for service accounts."""
-    return Role.get_service_group()
+    return BuiltinRole.get_service_group()
 
 
 @pytest.fixture
@@ -96,8 +97,8 @@ class TestTrustpointUser:
             organization=organization,
         )
 
-        assert account.role.name == Role.SERVICE.value
-        assert account.role.name == Role.get_service_group().name
+        assert account.role.name == BuiltinRole.SERVICE.value
+        assert account.role.name == BuiltinRole.get_service_group().name
         assert account.has_perm('users.use_rest_api')
 
     def test_service_account_cannot_be_staff(self, service_account: TrustpointUser) -> None:
@@ -387,6 +388,20 @@ class TestServiceAccountBackend:
 @pytest.mark.django_db
 class TestServiceAccountConfiguration:
     """Tests for service account configuration wiring."""
+
+    @pytest.mark.parametrize(
+        ('path', 'is_api_path'),
+        [
+            ('/api/pki/cert-profiles/', True),
+            ('/rest/', False),
+            ('/.well-known/cmp/', False),
+            ('/aoki/', False),
+            ('/management/', False),
+        ],
+    )
+    def test_service_account_api_path_is_limited_to_viewset_api(self, path: str, *, is_api_path: bool) -> None:
+        """Only the REST ViewSet namespace may be used by service-account sessions."""
+        assert ServiceAccountMiddleware._is_api_path(path) is is_api_path
 
     def test_service_account_middleware_is_enabled(self) -> None:
         """Service accounts should be blocked from the Web UI when enabled in settings."""

--- a/trustpoint/workflows2/api_views.py
+++ b/trustpoint/workflows2/api_views.py
@@ -19,7 +19,6 @@ from workflows2.serializers import Workflow2DefinitionSerializer
 from workflows2.services.definitions import WorkflowDefinitionService
 
 if TYPE_CHECKING:
-    from django.http import HttpRequest
     from rest_framework.request import Request
 
 
@@ -54,7 +53,7 @@ YAML_REQUEST_EXAMPLE = OpenApiExample(
 class CanManageWorkflows(BasePermission):
     """Allow only users permitted to manage workflows."""
 
-    def has_permission(self, request: Request, view: Any) -> bool:
+    def has_permission(self, request: Request, _view: Any) -> bool:
         """Check if the user has permission to manage workflows."""
         return bool(
             request.user

--- a/trustpoint/workflows2/api_views.py
+++ b/trustpoint/workflows2/api_views.py
@@ -5,18 +5,21 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiExample, extend_schema
 from rest_framework import status, viewsets
+from rest_framework.permissions import BasePermission
 from rest_framework.response import Response
 
+from users.permissions import AppPermissions
 from workflows2.models import Workflow2Definition
 from workflows2.serializers import Workflow2DefinitionSerializer
 from workflows2.services.definitions import WorkflowDefinitionService
 
 if TYPE_CHECKING:
+    from django.http import HttpRequest
     from rest_framework.request import Request
 
 
@@ -48,6 +51,17 @@ YAML_REQUEST_EXAMPLE = OpenApiExample(
         media_type='application/yaml',
 )
 
+class CanManageWorkflows(BasePermission):
+    """Allow only users permitted to manage workflows."""
+
+    def has_permission(self, request: Request, view: Any) -> bool:
+        """Check if the user has permission to manage workflows."""
+        return bool(
+            request.user
+            and request.user.is_authenticated
+            and request.user.has_perm(AppPermissions.MANAGE_WORKFLOWS)
+        )
+
 
 @extend_schema(tags=['Workflows2'])
 class Workflow2DefinitionViewSet(viewsets.ModelViewSet[Workflow2Definition]):
@@ -58,7 +72,7 @@ class Workflow2DefinitionViewSet(viewsets.ModelViewSet[Workflow2Definition]):
 
     queryset = Workflow2Definition.objects.order_by('-created_at')
     serializer_class = Workflow2DefinitionSerializer
-
+    permission_classes = (CanManageWorkflows,)
     @staticmethod
     def _request_yaml_text(request: Request) -> str:
         """Return UTF-8 YAML text from the raw request body."""

--- a/trustpoint/workflows2/tests/test_api_views.py
+++ b/trustpoint/workflows2/tests/test_api_views.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework.test import APIClient
@@ -66,6 +67,8 @@ class Workflow2DefinitionApiViewSetTests(TestCase):
             username='workflow2-api-tester',
             password='testpass123',
         )
+        manage_workflows_perm = Permission.objects.get(codename='manage_workflows')
+        self.user.role.permissions.add(manage_workflows_perm)
         self.authenticated_client = APIClient()
         self.authenticated_client.force_authenticate(user=self.user)
 

--- a/trustpoint/workflows2/tests/test_views_http.py
+++ b/trustpoint/workflows2/tests/test_views_http.py
@@ -102,8 +102,9 @@ workflow:
 class Workflow2HttpViewTests(TestCase):
     def setUp(self) -> None:
         wf2_test_role, _created = Group.objects.get_or_create(name='wf2_test_role')
-        manage_workflow_perm = Permission.objects.get(codename='manage_workflow')
-        wf2_test_role.permissions.add(manage_workflow_perm)
+        manage_workflows_perm = Permission.objects.get(codename='manage_workflows')
+        approve_workflows_perm = Permission.objects.get(codename='approve_workflows')
+        wf2_test_role.permissions.add(manage_workflows_perm, approve_workflows_perm)
         self.user = get_user_model().objects.create_user(
             username="workflow2-tester",
             password="testpass123",

--- a/trustpoint/workflows2/views/approvals.py
+++ b/trustpoint/workflows2/views/approvals.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator
 from django.db import transaction
 from django.shortcuts import get_object_or_404, redirect, render
@@ -17,6 +18,7 @@ from django.utils.translation import gettext as _
 from django.views import View
 
 from trustpoint.page_context import PageContextMixin
+from users.permissions import AppPermissions
 from workflows2.engine.executor import WorkflowExecutor
 from workflows2.models import Workflow2Approval, Workflow2Instance
 from workflows2.services.dispatch import WorkflowDispatchService
@@ -316,8 +318,10 @@ class Workflow2ApprovalDetailView(PageContextMixin, LoginRequiredMixin, View):
 class Workflow2ApprovalResolveView(LoginRequiredMixin, View):
     """Approve/Reject and continue with the normal dispatch execution policy."""
 
-    def post(self, request: HttpRequest, approval_id: UUID) -> HttpResponse:
+    def post(self, request: HttpRequest, approval_id: UUID) -> HttpResponse: #noqa: C901
         """Resolve an approval and continue execution if the workflow can proceed."""
+        if not request.user.has_perm(AppPermissions.APPROVE_WORKFLOWS):
+            raise PermissionDenied
         decision = (request.POST.get('decision') or '').strip().lower()
         comment = (request.POST.get('comment') or '').strip()
         if decision not in {'approved', 'rejected'}:

--- a/trustpoint/workflows2/views/definitions.py
+++ b/trustpoint/workflows2/views/definitions.py
@@ -16,6 +16,7 @@ from django.views.generic import ListView
 
 from trustpoint.page_context import PageContextMixin
 from trustpoint.views.base import UserPermissionRequiredMixin
+from users.permissions import AppPermissions
 from workflows2.forms import Workflow2DefinitionForm
 from workflows2.models import Workflow2Definition
 from workflows2.services.definitions import WorkflowDefinitionService
@@ -30,7 +31,7 @@ if TYPE_CHECKING:
 class WF2DefPermReqMixin(UserPermissionRequiredMixin):
     """Mixin requiring the user to have the 'users.manage_workflow' permission."""
 
-    permission_required = 'users.manage_workflow'
+    permission_required = AppPermissions.MANAGE_WORKFLOWS
     raise_exception = True
 
 


### PR DESCRIPTION
- Introduced AppPermissions class to define application-level permissions for managing users, PKI configuration, certificate lifecycle, device lifecycle, automation, workflows, system administration, and monitoring.


**Legal** <!-- please check by replacing the space in the brackets with an 'x'! (CLA in AUTHORS.md) -->
- [ ] I certify that I have all necessary rights to publish this contribution under the MIT license. I agree to the Trustpoint CLA and have added my name to the AUTHORS.md file.